### PR TITLE
Refatora fluxo de candidatura do LinkedIn e endurece contratos

### DIFF
--- a/docs/plans/POS_MVP_ESTRUTURA_E_REFATORACAO_CHECKLIST.md
+++ b/docs/plans/POS_MVP_ESTRUTURA_E_REFATORACAO_CHECKLIST.md
@@ -17,22 +17,26 @@ Fechar o produto operacionalmente antes de expandir escopo.
 
 Regra da fase atual:
 
-- [ ] Nao adicionar novos portais antes de estabilizar o LinkedIn
-- [ ] Nao adicionar novas features de produto antes de endurecer operacao, estados e observabilidade
-- [ ] Tratar a fase atual como estabilizacao e padronizacao
+- [x] Nao adicionar novos portais antes de estabilizar o LinkedIn
+- [x] Nao adicionar novas features de produto antes de endurecer operacao, estados e observabilidade
+- [x] Tratar a fase atual como estabilizacao e padronizacao
 
 ## P0: Estabilizacao Operacional
 
 ### Fluxo real
 
-- [ ] Repetir validacao real em mais amostras de vagas Easy Apply
-- [ ] Catalogar variacoes reais do LinkedIn que ainda aparecem:
+- [x] Repetir validacao real em mais amostras de vagas Easy Apply
+  - [x] amostras reais validadas: `application_id=2`, `5`, `7`, `8`, `10` em `submitted`
+  - [x] bloqueios reais classificados: `application_id=1` (`vaga_expirada`), `3` (`similar_jobs`), `4`, `6`, `9` (`candidatura_externa`)
+- [x] Catalogar variacoes reais do LinkedIn que ainda aparecem:
   - [x] redirecionamento para `similar jobs`
   - [x] perguntas adicionais obrigatorias
-  - [ ] checkboxes opcionais
-  - [ ] vagas com curriculo reaproveitado
-  - [ ] vagas com etapa final sem modal classico
-- [ ] Criar criterios objetivos para classificar:
+  - [x] checkboxes opcionais
+  - [x] vagas com curriculo reaproveitado
+    - [x] nao observadas nas amostras reais atuais; nenhum tratamento especifico adicional necessario ate aqui
+  - [x] vagas com etapa final sem modal classico
+    - [x] nao observadas nas amostras reais atuais; monitoradas via artefatos e classificacao operacional
+- [x] Criar criterios objetivos para classificar:
   - [x] `ready`
   - [x] `manual_review`
   - [x] `blocked`
@@ -46,29 +50,30 @@ Regra da fase atual:
   - [x] ultimo erro
   - [x] historico resumido de transicoes
 - [x] Garantir que toda transicao relevante tenha timestamp e motivo explicito
-- [ ] Revisar se `support_level` e `support_rationale` devem ser atualizados por ciclo ou preservados como snapshot inicial
+- [x] Revisar se `support_level` e `support_rationale` devem ser atualizados por ciclo ou preservados como snapshot inicial
+  - [x] decisao: preservar como snapshot inicial do rascunho; preflight e submit nao recalculam suporte por ciclo
 
 ### Observabilidade
 
-- [ ] Criar uma visao clara de fila operacional por status
-- [ ] Expor rapidamente:
-  - [ ] quantas vagas estao `approved`
-  - [ ] quantas candidaturas estao `draft`
-  - [ ] quantas estao `confirmed`
-  - [ ] quantas estao `authorized_submit`
-  - [ ] quantas estao `submitted`
-  - [ ] quantas estao `error_submit`
+- [x] Criar uma visao clara de fila operacional por status
+- [x] Expor rapidamente:
+  - [x] quantas vagas estao `approved`
+  - [x] quantas candidaturas estao `draft`
+  - [x] quantas estao `confirmed`
+  - [x] quantas estao `authorized_submit`
+  - [x] quantas estao `submitted`
+  - [x] quantas estao `error_submit`
 - [x] Padronizar nomes e estrutura dos artefatos de falha
-- [ ] Adicionar um resumo final por execucao com:
-  - [ ] preflights concluidos
-  - [ ] submits concluidos
-  - [ ] bloqueios por tipo
+- [x] Adicionar um resumo final por execucao com:
+  - [x] preflights concluidos
+  - [x] submits concluidos
+  - [x] bloqueios por tipo
 
 ## P0: UX Operacional
 
 - [x] Eliminar operacao por `python -c` para tarefas frequentes
 - [x] Fechar cobertura operacional completa por CLI para que o fluxo nao dependa do Telegram como unico caminho de execucao
-- [ ] Criar comandos claros para:
+- [x] Criar comandos claros para:
   - [x] listar vagas pendentes de revisao
   - [x] aprovar vaga
   - [x] rejeitar vaga
@@ -82,9 +87,9 @@ Regra da fase atual:
   - [x] executar submit
   - [x] ver artefatos da ultima falha
 - [x] Explicitar na UX que CLI e Telegram cobrem o fluxo operacional principal, com Telegram opcional para revisao assincrona
-- [ ] Definir uma interface principal:
-  - [ ] Telegram como interface de operacao principal
-  - [ ] CLI como fallback tecnico
+- [x] Definir uma interface principal:
+  - [x] CLI como interface operacional principal
+  - [x] Telegram como interface de revisao assincrona opcional
 - [x] Tornar o fluxo humano rastreavel sem editar estado manualmente no banco
 
 ## P1: Melhorias Estruturais

--- a/docs/plans/POS_MVP_ESTRUTURA_E_REFATORACAO_CHECKLIST.md
+++ b/docs/plans/POS_MVP_ESTRUTURA_E_REFATORACAO_CHECKLIST.md
@@ -58,7 +58,7 @@ Regra da fase atual:
   - [ ] quantas estao `authorized_submit`
   - [ ] quantas estao `submitted`
   - [ ] quantas estao `error_submit`
-- [ ] Padronizar nomes e estrutura dos artefatos de falha
+- [x] Padronizar nomes e estrutura dos artefatos de falha
 - [ ] Adicionar um resumo final por execucao com:
   - [ ] preflights concluidos
   - [ ] submits concluidos
@@ -229,6 +229,7 @@ Descricao:
 As possibilidades abaixo parecem potencialmente beneficas para o produto, mas ainda precisam de analise de viabilidade antes de entrarem no backlog priorizado. A avaliacao deve considerar aderencia ao escopo local-first, impacto no loop principal, complexidade de manutencao, risco de ampliar demais o produto e custo operacional no uso diario.
 
 - [ ] Avaliar calibracao do scoring com base no historico local de vagas `approved` e `rejected`
+- [ ] Avaliar um modo de coleta continua priorizada para revisao em lote, ordenando vagas relevantes por aderencia, recencia e sinal de `Easy Apply`
 - [ ] Avaliar registrar motivo curto e padronizado para descarte por regra ou por score
 - [ ] Avaliar criar um feedback loop local de revisao humana para refinar criterios de triagem
 - [ ] Avaliar um modo formal de `dry-run` para preflight e submit, com relatorio e artefatos

--- a/docs/plans/POS_MVP_ESTRUTURA_E_REFATORACAO_CHECKLIST.md
+++ b/docs/plans/POS_MVP_ESTRUTURA_E_REFATORACAO_CHECKLIST.md
@@ -44,7 +44,7 @@ Regra da fase atual:
 ### Higiene de estado
 
 - [x] Parar de acumular todo o historico operacional em `notes`
-- [ ] Separar no armazenamento:
+- [x] Separar no armazenamento:
   - [x] ultimo preflight
   - [x] ultimo submit
   - [x] ultimo erro

--- a/docs/plans/POS_MVP_ESTRUTURA_E_REFATORACAO_CHECKLIST.md
+++ b/docs/plans/POS_MVP_ESTRUTURA_E_REFATORACAO_CHECKLIST.md
@@ -112,11 +112,11 @@ Regra da fase atual:
 #### Single Responsibility Principle
 
 - [ ] Quebrar `linkedin_application.py` em componentes menores:
-  - [ ] leitura do estado da pagina
-  - [ ] localizacao e abertura do fluxo apply
-  - [ ] preenchimento de campos
-  - [ ] decisao de submit
-  - [ ] captura de artefatos
+  - [x] leitura do estado da pagina
+  - [x] localizacao e abertura do fluxo apply
+  - [x] preenchimento de campos
+  - [x] decisao de submit
+  - [x] captura de artefatos
 - [x] Reduzir o papel de `applicant.py` para servicos de caso de uso e transicao
 - [ ] Manter logs e persistencia fora de helpers de DOM quando possivel
 
@@ -125,16 +125,16 @@ Regra da fase atual:
 - [ ] Definir pontos de extensao para novos tipos de fluxo do LinkedIn sem branching espalhado
 - [ ] Isolar estrategias de deteccao do fluxo:
   - [ ] modal classico
-  - [ ] `apply` por URL
+  - [x] `apply` por URL
   - [ ] review final
-  - [ ] bloqueios conhecidos
+  - [x] bloqueios conhecidos
 - [ ] Tornar a classificacao de preflight extensivel por estrategia
 
 #### Liskov Substitution Principle
 
-- [ ] Revisar protocolos de `ApplicationFlowInspector` e `JobApplicant`
-- [ ] Garantir que dublês de teste preservem o contrato real
-- [ ] Evitar caminhos especiais de producao que nao aparecem nos testes
+- [x] Revisar protocolos de `ApplicationFlowInspector` e `JobApplicant`
+- [x] Garantir que dublês de teste preservem o contrato real
+- [x] Evitar caminhos especiais de producao que nao aparecem nos testes
 
 #### Interface Segregation Principle
 
@@ -162,7 +162,7 @@ Regra da fase atual:
 ### Tamanho e legibilidade
 
 - [ ] Reduzir funcoes longas com muitos caminhos de erro
-- [ ] Extrair blocos de fallback do LinkedIn para helpers nomeados
+- [x] Extrair blocos de fallback do LinkedIn para helpers nomeados
 - [ ] Consolidar trechos repetidos de clique, espera e recuperacao
 
 ### Dados e modelos
@@ -234,7 +234,7 @@ Descricao:
 As possibilidades abaixo parecem potencialmente beneficas para o produto, mas ainda precisam de analise de viabilidade antes de entrarem no backlog priorizado. A avaliacao deve considerar aderencia ao escopo local-first, impacto no loop principal, complexidade de manutencao, risco de ampliar demais o produto e custo operacional no uso diario.
 
 - [ ] Avaliar calibracao do scoring com base no historico local de vagas `approved` e `rejected`
-- [ ] Avaliar um modo de coleta continua priorizada para revisao em lote, ordenando vagas relevantes por aderencia, recencia e sinal de `Easy Apply`
+- [ ] Avaliar e implementar busca dirigida por empresas prioritarias, usando grupos de prioridade de empresas, familias de cargo, senioridade alvo e janela temporal para gerar uma fila priorizada de revisao em lote
 - [ ] Avaliar registrar motivo curto e padronizado para descarte por regra ou por score
 - [ ] Avaliar criar um feedback loop local de revisao humana para refinar criterios de triagem
 - [ ] Avaliar um modo formal de `dry-run` para preflight e submit, com relatorio e artefatos

--- a/docs/plans/POS_MVP_ESTRUTURA_E_REFATORACAO_CHECKLIST.md
+++ b/docs/plans/POS_MVP_ESTRUTURA_E_REFATORACAO_CHECKLIST.md
@@ -27,15 +27,15 @@ Regra da fase atual:
 
 - [ ] Repetir validacao real em mais amostras de vagas Easy Apply
 - [ ] Catalogar variacoes reais do LinkedIn que ainda aparecem:
-  - [ ] redirecionamento para `similar jobs`
-  - [ ] perguntas adicionais obrigatorias
+  - [x] redirecionamento para `similar jobs`
+  - [x] perguntas adicionais obrigatorias
   - [ ] checkboxes opcionais
   - [ ] vagas com curriculo reaproveitado
   - [ ] vagas com etapa final sem modal classico
 - [ ] Criar criterios objetivos para classificar:
-  - [ ] `ready`
-  - [ ] `manual_review`
-  - [ ] `blocked`
+  - [x] `ready`
+  - [x] `manual_review`
+  - [x] `blocked`
 
 ### Higiene de estado
 
@@ -467,8 +467,8 @@ Existe uma hipotese de evolucao em que o OpenClaw opere a aplicacao como camada 
 
 - [ ] Tornar o Telegram suficiente para operar o fluxo completo com seguranca
 - [ ] Exibir melhor o motivo de `manual_review`
-- [ ] Exibir quando a vaga parece cair em `similar jobs`
-- [ ] Exibir quando a vaga exige perguntas adicionais
+- [x] Exibir quando a vaga parece cair em `similar jobs`
+- [x] Exibir quando a vaga exige perguntas adicionais
 
 ### Priorizacao
 
@@ -530,7 +530,7 @@ Existe uma hipotese de evolucao em que o OpenClaw opere a aplicacao como camada 
 
 - [x] Fluxo de candidatura assistida opera sem `python -c`
 - [x] Historico operacional deixa de depender de texto livre acumulado
-- [ ] Casos `similar jobs` e `perguntas adicionais` ficam claramente classificados
+- [x] Casos `similar jobs` e `perguntas adicionais` ficam claramente classificados
 - [x] Regressao operacional principal permanece verde
 - [x] Estrutura do codigo fica mais modular no fluxo LinkedIn
 - [x] Telegram ou CLI passam a ser suficientes para operar o produto com seguranca

--- a/job_hunter_agent/application/app.py
+++ b/job_hunter_agent/application/app.py
@@ -6,6 +6,7 @@ import logging
 from datetime import datetime, timedelta
 from pathlib import Path
 
+from job_hunter_agent.core.application_insights import classify_application_operational_insight
 from job_hunter_agent.core.domain import VALID_APPLICATION_STATUSES, VALID_STATUSES
 from job_hunter_agent.collectors.collector import JobCollectionService
 from job_hunter_agent.application.composition import (
@@ -150,7 +151,8 @@ class JobHunterApplication:
                     else f"job_id={application.job_id}"
                 )
                 lines.append(
-                    f"{application.id}: {application.status} | {job_label} | suporte={application.support_level}"
+                    f"{application.id}: {application.status} | {job_label} | suporte={application.support_level} "
+                    f"| op={classify_application_operational_insight(application).reason_code}"
                 )
                 total += 1
         if not lines:
@@ -214,6 +216,8 @@ class JobHunterApplication:
     def show_status_overview(self) -> str:
         job_summary = self.repository.summary()
         application_summary = self.repository.application_summary()
+        tracked_applications = self._list_tracked_applications()
+        operational_counts = self._summarize_operational_counts(tracked_applications)
         lines = [
             "Resumo operacional:",
             "vagas:",
@@ -232,6 +236,20 @@ class JobHunterApplication:
             f"- error_submit={application_summary['error_submit']}",
             f"- cancelled={application_summary['cancelled']}",
         ]
+        if operational_counts:
+            lines.append("operacao:")
+            for key in (
+                "pronto_para_envio",
+                "perguntas_adicionais",
+                "similar_jobs",
+                "candidatura_externa",
+                "vaga_expirada",
+                "no_apply_cta",
+                "fluxo_inconclusivo",
+                "bloqueio_funcional",
+            ):
+                if key in operational_counts:
+                    lines.append(f"- {key}={operational_counts[key]}")
         return "\n".join(lines)
 
     def review_job(self, job_id: int, action: str) -> str:
@@ -297,6 +315,9 @@ class JobHunterApplication:
             f"vaga={job_title}",
             f"empresa={job_company}",
             f"suporte={application.support_level}",
+            "classificacao_operacional="
+            f"{classify_application_operational_insight(application).classification}"
+            f" | motivo={classify_application_operational_insight(application).reason_code}",
             f"url={job_url}",
             f"last_preflight_detail={application.last_preflight_detail or '-'}",
             f"last_submit_detail={application.last_submit_detail or '-'}",
@@ -375,6 +396,22 @@ class JobHunterApplication:
             return False
         await self.notifier.notify_jobs_for_review(jobs)
         return True
+
+    def _list_tracked_applications(self) -> list:
+        tracked_statuses = ("draft", "ready_for_review", "confirmed", "authorized_submit", "error_submit", "submitted")
+        applications: list = []
+        for status in tracked_statuses:
+            applications.extend(self.repository.list_applications_by_status(status))
+        return applications
+
+    def _summarize_operational_counts(self, applications: list) -> dict[str, int]:
+        counts: dict[str, int] = {}
+        for application in applications:
+            reason_code = classify_application_operational_insight(application).reason_code
+            if reason_code in {"sem_detalhe_operacional", "nao_classificado"}:
+                continue
+            counts[reason_code] = counts.get(reason_code, 0) + 1
+        return counts
 
     async def wait_for_review_window(self) -> None:
         if not self.enable_telegram:

--- a/job_hunter_agent/application/app.py
+++ b/job_hunter_agent/application/app.py
@@ -6,7 +6,10 @@ import logging
 from datetime import datetime, timedelta
 from pathlib import Path
 
-from job_hunter_agent.core.application_insights import classify_application_operational_insight
+from job_hunter_agent.core.application_insights import (
+    classify_application_operational_insight,
+    classify_operational_detail,
+)
 from job_hunter_agent.core.domain import VALID_APPLICATION_STATUSES, VALID_STATUSES
 from job_hunter_agent.collectors.collector import JobCollectionService
 from job_hunter_agent.application.composition import (
@@ -448,6 +451,7 @@ class JobHunterApplication:
                 await asyncio.sleep(interval_seconds)
 
     async def run(self, run_once: bool, fixed_cycles: int | None = None, cycle_interval_seconds: int = 0) -> None:
+        execution_started_at = datetime.now().isoformat(timespec="seconds")
         terminated_processes = self.runtime_guard.prepare_for_startup()
         interrupted_runs = self.repository.interrupt_running_collection_runs()
         if terminated_processes:
@@ -466,8 +470,39 @@ class JobHunterApplication:
                 return
             await self.run_scheduler()
         finally:
+            logger.info("Resumo final da execucao:\n%s", self.build_execution_summary(execution_started_at))
             await self.notifier.stop()
             self.runtime_guard.release()
+
+    def build_execution_summary(self, since: str) -> str:
+        list_events_since = getattr(self.repository, "list_recent_application_events_since", None)
+        if list_events_since is None:
+            return "Execucao operacional:\n- preflights_concluidos=0\n- submits_concluidos=0\n- bloqueios_por_tipo=nenhum"
+        events = list_events_since(since)
+        preflight_count = 0
+        submit_count = 0
+        block_counts: dict[str, int] = {}
+        for event in events:
+            if event.event_type in {"preflight_ready", "preflight_manual_review", "preflight_blocked", "preflight_error"}:
+                preflight_count += 1
+            if event.event_type in {"submit_submitted", "submit_error"}:
+                submit_count += 1
+            if event.event_type in {"preflight_blocked", "submit_error"}:
+                reason_code = classify_operational_detail(event.detail).reason_code
+                if reason_code not in {"sem_detalhe_operacional", "nao_classificado"}:
+                    block_counts[reason_code] = block_counts.get(reason_code, 0) + 1
+        lines = [
+            "Execucao operacional:",
+            f"- preflights_concluidos={preflight_count}",
+            f"- submits_concluidos={submit_count}",
+        ]
+        if block_counts:
+            lines.append("- bloqueios_por_tipo:")
+            for key in sorted(block_counts):
+                lines.append(f"  - {key}={block_counts[key]}")
+        else:
+            lines.append("- bloqueios_por_tipo=nenhum")
+        return "\n".join(lines)
 
 
 def parse_args() -> argparse.Namespace:

--- a/job_hunter_agent/application/applicant.py
+++ b/job_hunter_agent/application/applicant.py
@@ -53,6 +53,12 @@ class ApplicationSubmitResult:
     application_status: str
 
 
+@dataclass(frozen=True)
+class ApplicationFlowInspection:
+    outcome: str
+    detail: str
+
+
 class ApplicationSupportAssessor(Protocol):
     def assess(self, job: JobPosting) -> ApplicationSupportAssessment:
         raise NotImplementedError
@@ -64,7 +70,7 @@ class JobApplicant(Protocol):
 
 
 class ApplicationFlowInspector(Protocol):
-    def inspect(self, job: JobPosting):
+    def inspect(self, job: JobPosting) -> ApplicationFlowInspection:
         raise NotImplementedError
 
 
@@ -166,6 +172,47 @@ class ApplicationPreparationService:
         return format_application_priority_note(assessed)
 
 
+def normalize_application_flow_inspection(result) -> ApplicationFlowInspection:
+    outcome = str(getattr(result, "outcome", "") or "").strip()
+    detail = str(getattr(result, "detail", "") or "").strip()
+    if outcome not in {"ready", "manual_review", "blocked", "ignored", "error"}:
+        return ApplicationFlowInspection(
+            outcome="error",
+            detail="inspecao de fluxo retornou outcome invalido",
+        )
+    if not detail:
+        return ApplicationFlowInspection(
+            outcome="error",
+            detail="inspecao de fluxo retornou detail vazio",
+        )
+    return ApplicationFlowInspection(outcome=outcome, detail=detail)
+
+
+def normalize_application_submission_result(result) -> ApplicationSubmissionResult:
+    status = str(getattr(result, "status", "") or "").strip()
+    detail = str(getattr(result, "detail", "") or "").strip()
+    submitted_at_raw = getattr(result, "submitted_at", None)
+    external_reference_raw = getattr(result, "external_reference", "")
+    if status not in {"submitted", "error_submit", "authorized_submit"}:
+        return ApplicationSubmissionResult(
+            status="error_submit",
+            detail="applicant retornou status invalido",
+        )
+    if not detail:
+        return ApplicationSubmissionResult(
+            status="error_submit",
+            detail="applicant retornou detail vazio",
+        )
+    submitted_at = str(submitted_at_raw).strip() if submitted_at_raw else None
+    external_reference = str(external_reference_raw or "").strip()
+    return ApplicationSubmissionResult(
+        status=status,
+        detail=detail,
+        submitted_at=submitted_at,
+        external_reference=external_reference,
+    )
+
+
 class ApplicationPreflightService:
     def __init__(self, repository: JobRepository, flow_inspector: ApplicationFlowInspector | None = None) -> None:
         self.repository = repository
@@ -213,7 +260,7 @@ class ApplicationPreflightService:
         if capabilities.preflight_supported and job.source_site.lower() == "linkedin" and "linkedin.com/jobs/" in job.url.lower():
             if self.flow_inspector is not None:
                 try:
-                    inspection = self.flow_inspector.inspect(job)
+                    inspection = normalize_application_flow_inspection(self.flow_inspector.inspect(job))
                 except Exception as exc:
                     inspection = None
                     detail = f"preflight real falhou ao inspecionar a pagina: {exc}"
@@ -388,7 +435,7 @@ class ApplicationSubmissionService:
             )
 
         try:
-            result = self.applicant.submit(application, job)
+            result = normalize_application_submission_result(self.applicant.submit(application, job))
         except Exception as exc:
             detail = f"submissao real falhou ao executar o applicant: {exc}"
             application_status = self.flow.record_submit_result(

--- a/job_hunter_agent/application/composition.py
+++ b/job_hunter_agent/application/composition.py
@@ -92,18 +92,9 @@ def create_application_preparation_service(
 def create_application_preflight_service(repository: JobRepository, settings: Settings) -> ApplicationPreflightService:
     return ApplicationPreflightService(
         repository,
-        flow_inspector=LinkedInApplicationFlowInspector(
-            storage_state_path=settings.linkedin_storage_state_path,
-            headless=settings.browser_headless,
-            resume_path=settings.resume_path,
-            contact_email=settings.application_contact_email,
-            phone=settings.application_phone,
-            phone_country_code=settings.application_phone_country_code,
-            candidate_profile=load_candidate_profile(settings.candidate_profile_path),
-            candidate_profile_path=settings.candidate_profile_path,
-            modal_interpretation_formatter=create_linkedin_modal_interpretation_formatter(settings),
-            save_failure_artifacts=settings.save_failure_artifacts,
-            failure_artifacts_dir=settings.failure_artifacts_dir,
+        flow_inspector=create_linkedin_application_flow_inspector(
+            settings,
+            mode="preflight",
         ),
     )
 
@@ -111,18 +102,9 @@ def create_application_preflight_service(repository: JobRepository, settings: Se
 def create_application_submission_service(repository: JobRepository, settings: Settings) -> ApplicationSubmissionService:
     return ApplicationSubmissionService(
         repository,
-        applicant=LinkedInApplicationFlowInspector(
-            storage_state_path=settings.linkedin_storage_state_path,
-            headless=settings.browser_headless,
-            resume_path=settings.resume_path,
-            contact_email=settings.application_contact_email,
-            phone=settings.application_phone,
-            phone_country_code=settings.application_phone_country_code,
-            candidate_profile=load_candidate_profile(settings.candidate_profile_path),
-            candidate_profile_path=settings.candidate_profile_path,
-            modal_interpreter=create_linkedin_modal_interpreter(settings),
-            save_failure_artifacts=settings.save_failure_artifacts,
-            failure_artifacts_dir=settings.failure_artifacts_dir,
+        applicant=create_linkedin_application_flow_inspector(
+            settings,
+            mode="submit",
         ),
         readiness_checker=ApplicationReadinessCheckService(
             linkedin_storage_state_path=settings.linkedin_storage_state_path,
@@ -212,6 +194,36 @@ def create_linkedin_field_repairer(settings: Settings) -> OllamaLinkedInFieldRep
         model_name=settings.ollama_model,
         base_url=settings.ollama_url,
     )
+
+
+def create_linkedin_application_flow_inspector(
+    settings: Settings,
+    *,
+    mode: str,
+) -> LinkedInApplicationFlowInspector:
+    shared_kwargs = {
+        "storage_state_path": settings.linkedin_storage_state_path,
+        "headless": settings.browser_headless,
+        "resume_path": settings.resume_path,
+        "contact_email": settings.application_contact_email,
+        "phone": settings.application_phone,
+        "phone_country_code": settings.application_phone_country_code,
+        "candidate_profile": load_candidate_profile(settings.candidate_profile_path),
+        "candidate_profile_path": settings.candidate_profile_path,
+        "save_failure_artifacts": settings.save_failure_artifacts,
+        "failure_artifacts_dir": settings.failure_artifacts_dir,
+    }
+    if mode == "preflight":
+        return LinkedInApplicationFlowInspector(
+            **shared_kwargs,
+            modal_interpretation_formatter=create_linkedin_modal_interpretation_formatter(settings),
+        )
+    if mode == "submit":
+        return LinkedInApplicationFlowInspector(
+            **shared_kwargs,
+            modal_interpreter=create_linkedin_modal_interpreter(settings),
+        )
+    raise ValueError(f"modo de inspector do LinkedIn nao suportado: {mode}")
 
 
 def create_notifier(

--- a/job_hunter_agent/collectors/linkedin_application.py
+++ b/job_hunter_agent/collectors/linkedin_application.py
@@ -2,18 +2,25 @@ from __future__ import annotations
 
 from datetime import datetime
 from pathlib import Path
-import re
 from typing import Callable, TYPE_CHECKING
-from urllib.parse import parse_qs, urlparse
 
 from job_hunter_agent.application.applicant import ApplicationSubmissionResult
 from job_hunter_agent.collectors.linkedin_application_artifacts import (
-    capture_failure_artifacts,
+    LinkedInFailureArtifactCapture,
     is_closed_target_error,
     is_page_closed,
 )
+from job_hunter_agent.collectors.linkedin_application_entrypoint import (
+    canonical_linkedin_job_url,
+    classify_linkedin_job_page_readiness,
+    extract_linkedin_job_id,
+    needs_canonical_job_navigation,
+    recover_linkedin_direct_apply_url_from_html,
+)
 from job_hunter_agent.collectors.linkedin_application_modal import LinkedInEasyApplyModalDriver
 from job_hunter_agent.collectors.linkedin_application_navigation import LinkedInEasyApplyNavigator
+from job_hunter_agent.collectors.linkedin_application_opening import LinkedInEasyApplyFlowOpener
+from job_hunter_agent.collectors.linkedin_application_reader import LinkedInApplicationPageReader
 from job_hunter_agent.collectors.linkedin_application_state import (
     LinkedInApplicationInspection,
     LinkedInApplicationPageState,
@@ -23,6 +30,9 @@ from job_hunter_agent.collectors.linkedin_application_state import (
     describe_linkedin_easy_apply_entrypoint,
     describe_linkedin_job_page_readiness,
     describe_linkedin_modal_blocker,
+)
+from job_hunter_agent.collectors.linkedin_application_submit import (
+    evaluate_linkedin_submit_readiness,
 )
 from job_hunter_agent.core.browser_support import load_playwright_storage_state, resolve_local_chromium
 from job_hunter_agent.core.candidate_profile import CandidateProfile
@@ -61,7 +71,12 @@ class LinkedInApplicationFlowInspector:
         self.modal_interpreter = modal_interpreter
         self.save_failure_artifacts = save_failure_artifacts
         self.failure_artifacts_dir = Path(failure_artifacts_dir).resolve() if failure_artifacts_dir else None
+        self._artifact_capture = LinkedInFailureArtifactCapture(
+            enabled=self.save_failure_artifacts,
+            artifacts_dir=self.failure_artifacts_dir,
+        )
         self._navigator = LinkedInEasyApplyNavigator()
+        self._page_reader = LinkedInApplicationPageReader()
         self._modal_driver = LinkedInEasyApplyModalDriver(
             resume_path=self.resume_path,
             contact_email=self.contact_email,
@@ -71,6 +86,22 @@ class LinkedInApplicationFlowInspector:
             candidate_profile_path=self.candidate_profile_path,
             modal_interpreter=self.modal_interpreter,
         )
+        self._flow_opener = LinkedInEasyApplyFlowOpener(
+            prepare_job_page_for_apply=self._prepare_job_page_for_apply,
+            read_page_state=self._read_page_state,
+            assess_job_page_readiness=self._assess_job_page_readiness,
+            extract_easy_apply_href=self._extract_easy_apply_href,
+            inspect_easy_apply_modal=self._inspect_easy_apply_modal_via_opener,
+            is_page_closed=self._is_page_closed,
+        )
+
+    def _refresh_flow_opener_callbacks(self) -> None:
+        self._flow_opener._prepare_job_page_for_apply = self._prepare_job_page_for_apply
+        self._flow_opener._read_page_state = self._read_page_state
+        self._flow_opener._assess_job_page_readiness = self._assess_job_page_readiness
+        self._flow_opener._extract_easy_apply_href = self._extract_easy_apply_href
+        self._flow_opener._inspect_easy_apply_modal = self._inspect_easy_apply_modal_via_opener
+        self._flow_opener._is_page_closed = self._is_page_closed
 
     def inspect(self, job: JobPosting) -> LinkedInApplicationInspection:
         if "linkedin.com/jobs/" not in job.url.lower():
@@ -229,11 +260,9 @@ class LinkedInApplicationFlowInspector:
                 if not state.modal_open and state.easy_apply:
                     state = await self._try_open_easy_apply_via_direct_url(page, close_modal=False)
                 if not state.modal_open or not state.modal_submit_visible:
-                    interpretation_detail = self._format_modal_interpretation_for_error(state)
-                    snapshot_detail = (
-                        f" | {build_linkedin_modal_snapshot(state)}"
-                        if state.modal_open
-                        else ""
+                    submit_readiness = evaluate_linkedin_submit_readiness(
+                        state,
+                        interpretation_detail=self._format_modal_interpretation_for_error(state),
                     )
                     artifact_detail = await self._capture_failure_artifacts(
                         page,
@@ -247,15 +276,7 @@ class LinkedInApplicationFlowInspector:
                     )
                     return ApplicationSubmissionResult(
                         status="error_submit",
-                        detail=(
-                            "submissao real bloqueada: fluxo nao chegou ao botao de envio"
-                            f" | bloqueio={describe_linkedin_modal_blocker(state)}"
-                            f" | modal={state.modal_sample or 'nao_informado'}"
-                            f" | {describe_linkedin_easy_apply_entrypoint(state)}"
-                            f"{interpretation_detail}"
-                            f"{snapshot_detail}"
-                            f"{artifact_detail}"
-                        ),
+                        detail=f"{submit_readiness.detail}{artifact_detail}",
                     )
                 submitted = await self._try_submit_application(page)
                 if not submitted:
@@ -285,306 +306,15 @@ class LinkedInApplicationFlowInspector:
                 await browser.close()
 
     async def _read_page_state(self, page) -> LinkedInApplicationPageState:
-        raw_state = await page.evaluate(
-            """
-            () => {
-              const normalize = (value) => (value || "").replace(/\\s+/g, " ").trim().toLowerCase();
-              const isExcludedNode = (node) => !!node?.closest(
-                '[componentkey^="JobDetailsSimilarJobsSlot_"], [data-sdui-component*="similarJobs"]'
-              );
-              const currentUrl = window.location.href || "";
-              const currentPath = `${window.location.origin || ''}${window.location.pathname || ''}`;
-              const hiddenPayload = Array.from(document.querySelectorAll('code, script[type="application/ld+json"]'))
-                .map((node) => normalize(node.textContent || ''))
-                .join(' | ')
-                .slice(0, 4000);
-              const main = document.querySelector('main') || document.body;
-              const detailCandidates = [
-                '.jobs-search__job-details--container .jobs-details-top-card',
-                '.jobs-details-top-card',
-                '.jobs-search__job-details--container',
-                '.jobs-details',
-                'div[role="main"][data-sdui-screen*="JobDetails"]',
-                '#workspace',
-                'main',
-              ];
-              const detailPanel =
-                detailCandidates
-                  .map((selector) => document.querySelector(selector))
-                  .find((node) => !!node)
-                || main;
-              const topCard =
-                detailPanel.querySelector('.jobs-details-top-card') ||
-                detailPanel.querySelector('[data-live-test-job-apply-button]') ||
-                detailPanel;
-              const prioritizedSelectors = [
-                '[data-live-test-job-apply-button]',
-                '[data-control-name="jobdetails_topcard_inapply"]',
-                '[data-control-name="topcard_inapply"]',
-                '[data-control-name="jobs-details-top-card-apply-button"]',
-                '.jobs-apply-button',
-                '.jobs-apply-button--top-card button',
-                '.jobs-s-apply button',
-              ];
-              const prioritizedNodes = prioritizedSelectors.flatMap((selector) =>
-                Array.from(topCard.querySelectorAll(selector)).filter((node) => !isExcludedNode(node))
-              );
-              const globalApplyNodes = Array.from(main.querySelectorAll("button, a"))
-                .filter((node) => !isExcludedNode(node))
-                .filter((node) => {
-                  if (node.closest('header, footer, nav')) return false;
-                  const href = (node.getAttribute('href') || '').toLowerCase();
-                  const text = normalize(node.textContent || node.getAttribute('aria-label') || '');
-                  const control = normalize(node.getAttribute('data-control-name') || '');
-                  return (
-                    text.includes("easy apply")
-                    || text.includes("candidatura simplificada")
-                    || href.includes("/apply/")
-                    || control.includes("inapply")
-                    || control.includes("apply-button")
-                  );
-                });
-              const prioritizedTexts = prioritizedNodes
-                .map((node) => normalize(node.textContent || node.getAttribute('aria-label') || ''))
-                .filter(Boolean);
-              const globalApplyTexts = globalApplyNodes
-                .map((node) => normalize(node.textContent || node.getAttribute('aria-label') || ''))
-                .filter(Boolean);
-              const texts = Array.from(detailPanel.querySelectorAll("button, a"))
-                .filter((node) => !isExcludedNode(node))
-                .map((node) => normalize(node.textContent || node.getAttribute('aria-label') || ''))
-                .filter(Boolean);
-              const applyContext = globalApplyNodes[0]?.closest('section, article, div');
-              const joined = normalize(
-                applyContext?.innerText
-                || detailPanel.innerText
-                || topCard.innerText
-                || main.innerText
-                || ""
-              ).slice(0, 400);
-              const easyApplyTexts = (prioritizedTexts.length ? prioritizedTexts : (globalApplyTexts.length ? globalApplyTexts : texts))
-                .filter((text) => text.includes("easy apply") || text.includes("candidatura simplificada"));
-              const applyHrefVisible = globalApplyNodes.some((node) =>
-                ((node.getAttribute('href') || '').toLowerCase().includes('/apply/'))
-              );
-              const applyFlowActive = currentUrl.includes("/apply/") || currentUrl.includes("openSDUIApplyFlow=true");
-              const hiddenEasyApply = hiddenPayload.includes('onsiteapply')
-                || hiddenPayload.includes('applyctatext')
-                || hiddenPayload.includes('candidatura simplificada');
-              const externalApply = texts.some((text) =>
-                text.includes("candidate-se")
-                || text.includes("candidatar-se")
-                || text.includes("apply on company website")
-                || text.includes("site da empresa")
-              );
-              const submitVisible = texts.some((text) => text.includes("enviar candidatura") || text.includes("submit application"));
+        return await self._page_reader.read(page)
 
-              const confirmationDialog = document.querySelector('[role="alertdialog"]');
-              const confirmationTexts = confirmationDialog
-                ? Array.from(confirmationDialog.querySelectorAll("button, span, div, h1, h2, h3, p"))
-                    .map((node) => normalize(node.textContent))
-                    .filter(Boolean)
-                : [];
-              const confirmationJoined = confirmationTexts.join(" | ");
-              const saveApplicationDialogVisible = confirmationJoined.includes("salvar esta candidatura")
-                || confirmationJoined.includes("save this application");
-
-              const modal = document.querySelector('[role="dialog"]');
-              const modalButtonTexts = modal
-                ? Array.from(modal.querySelectorAll("button"))
-                    .map((node) => normalize(node.textContent))
-                    .filter(Boolean)
-                : [];
-              const modalTexts = modal
-                ? Array.from(modal.querySelectorAll("button, label, span, div, h2, h3, p, legend"))
-                    .map((node) => normalize(node.textContent))
-                    .filter(Boolean)
-                : [];
-              const modalInputNames = modal
-                ? Array.from(modal.querySelectorAll("input, textarea, select"))
-                    .map((node) => normalize(node.getAttribute("name") || node.getAttribute("aria-label") || node.id || ""))
-                    .filter(Boolean)
-                : [];
-              const modalHeadings = modal
-                ? Array.from(modal.querySelectorAll("h1, h2, h3, legend"))
-                    .map((node) => normalize(node.textContent))
-                    .filter(Boolean)
-                : [];
-              const fieldDescriptor = (field) => {
-                if (!field) return "";
-                const parts = [];
-                const fieldId = field.getAttribute("id");
-                if (fieldId) {
-                  const explicitLabel = modal.querySelector(`label[for="${fieldId}"]`);
-                  if (explicitLabel) parts.push(explicitLabel.textContent || "");
-                }
-                const labelledBy = field.getAttribute("aria-labelledby");
-                if (labelledBy) {
-                  labelledBy.split(/\\s+/).forEach((id) => {
-                    const labelNode = document.getElementById(id);
-                    if (labelNode) parts.push(labelNode.textContent || "");
-                  });
-                }
-                const describedBy = field.getAttribute("aria-describedby");
-                if (describedBy) {
-                  describedBy.split(/\\s+/).forEach((id) => {
-                    const describedNode = document.getElementById(id);
-                    if (describedNode) parts.push(describedNode.textContent || "");
-                  });
-                }
-                const closestLabel = field.closest("label");
-                if (closestLabel) parts.push(closestLabel.textContent || "");
-                const formElement = field.closest("[data-test-form-element]") || field.closest(".fb-dash-form-element");
-                if (formElement) {
-                  const legend = formElement.querySelector("legend");
-                  const title = formElement.querySelector("[data-test-text-entity-list-form-title]");
-                  if (legend) parts.push(legend.textContent || "");
-                  if (title) parts.push(title.textContent || "");
-                }
-                parts.push(field.getAttribute("name") || "");
-                parts.push(field.getAttribute("aria-label") || "");
-                return normalize(parts.join(" "));
-              };
-              const hasText = (items, parts) => parts.some((part) => items.some((value) => value.includes(part)));
-              const resumableFields = [];
-              const contactEmailVisible = hasText(modalTexts, ["email", "e-mail"]) || hasText(modalInputNames, ["email"]);
-              const contactPhoneVisible = hasText(modalTexts, ["phone", "telefone", "celular"]) || hasText(modalInputNames, ["phone", "telefone", "celular"]);
-              const countryCodeVisible = hasText(modalTexts, ["country code", "codigo do pais", "código do país"]) || hasText(modalInputNames, ["country code", "codigo", "código"]);
-              const workAuthorizationVisible = hasText(modalTexts, ["work authorization", "work permit", "autoriz", "visa"]) || hasText(modalInputNames, ["authorization", "permit", "visa"]);
-              const yearsOfExperienceVisible = hasText(modalTexts, ["years of work experience", "anos de experiencia"]) || hasText(modalInputNames, ["years", "experience"]);
-              if (contactEmailVisible) resumableFields.push("email");
-              if (contactPhoneVisible) resumableFields.push("telefone");
-              if (countryCodeVisible) resumableFields.push("codigo_pais");
-              if (workAuthorizationVisible) resumableFields.push("autorizacao_trabalho");
-              if (yearsOfExperienceVisible) resumableFields.push("anos_experiencia");
-              const requiredFields = modal
-                ? Array.from(modal.querySelectorAll('input[required], textarea[required], select[required]'))
-                    .map((field) => fieldDescriptor(field))
-                    .filter(Boolean)
-                : [];
-              const modalQuestions = requiredFields.filter((descriptor) => !(
-                descriptor.includes("email")
-                || descriptor.includes("e-mail")
-                || descriptor.includes("phone")
-                || descriptor.includes("telefone")
-                || descriptor.includes("celular")
-                || descriptor.includes("country code")
-                || descriptor.includes("codigo do pais")
-                || descriptor.includes("código do país")
-                || descriptor.includes("cÃ³digo do paÃ­s")
-                || descriptor.includes("resume")
-                || descriptor.includes("curriculo")
-              ));
-                return {
-                current_url: currentUrl,
-                easy_apply: easyApplyTexts.length > 0 || applyHrefVisible || applyFlowActive || hiddenEasyApply,
-                external_apply: externalApply,
-                submit_visible: submitVisible,
-                modal_open: !!modal,
-                modal_submit_visible: modalButtonTexts.some((text) => text.includes("submit application") || text.includes("enviar candidatura")),
-                modal_next_visible: modalButtonTexts.some((text) => text.includes("next") || text.includes("continuar") || text.includes("avancar") || text.includes("avançar")),
-                modal_review_visible: modalButtonTexts.some((text) => text.includes("review") || text.includes("revisar")),
-                modal_file_upload: modal ? modal.querySelectorAll('input[type="file"]').length > 0 : false,
-                modal_questions_visible: modalQuestions.length > 0,
-                save_application_dialog_visible: saveApplicationDialogVisible,
-                cta_text: easyApplyTexts[0] || (hiddenEasyApply ? "candidatura simplificada" : ""),
-                sample: `${currentPath} | ${joined}`.slice(0, 400),
-                modal_sample: (modalTexts.join(" | ") || confirmationJoined).slice(0, 400),
-                contact_email_visible: contactEmailVisible,
-                contact_phone_visible: contactPhoneVisible,
-                country_code_visible: countryCodeVisible,
-                work_authorization_visible: workAuthorizationVisible,
-                years_of_experience_visible: yearsOfExperienceVisible,
-                resumable_fields: resumableFields,
-                filled_fields: [],
-                progressed_to_next_step: false,
-                uploaded_resume: false,
-                reached_review_step: false,
-                ready_to_submit: false,
-                modal_headings: modalHeadings.slice(0, 6),
-                modal_buttons: modalButtonTexts.slice(0, 8),
-                modal_fields: modalInputNames.slice(0, 8),
-                modal_questions: modalQuestions.slice(0, 6),
-              };
-            }
-            """
-        )
-        raw_state["resumable_fields"] = tuple(raw_state.get("resumable_fields", ()))
-        raw_state["filled_fields"] = tuple(raw_state.get("filled_fields", ()))
-        raw_state["modal_headings"] = tuple(raw_state.get("modal_headings", ()))
-        raw_state["modal_buttons"] = tuple(raw_state.get("modal_buttons", ()))
-        raw_state["modal_fields"] = tuple(raw_state.get("modal_fields", ()))
-        raw_state["modal_questions"] = tuple(raw_state.get("modal_questions", ()))
-        return LinkedInApplicationPageState(**raw_state)
 
     def _assess_job_page_readiness(
         self,
         job: JobPosting,
         state: LinkedInApplicationPageState,
     ) -> LinkedInJobPageReadiness:
-        current_url = state.current_url or ""
-        current_job_id = self._extract_linkedin_job_id(current_url)
-        target_job_id = self._extract_linkedin_job_id(job.url)
-        normalized_url = current_url.lower()
-        normalized_sample = state.sample.lower()
-
-        expired_patterns = (
-            r"job (is )?no longer available",
-            r"job.*no longer open",
-            r"this job has expired",
-            r"job posting has expired",
-            r"this (position|role|job) (is )?no longer",
-            r"this job (listing )?is closed",
-            r"job (listing )?not found",
-            r"pagina que voce esta procurando nao existe",
-            r"vaga (nao|não) esta mais disponivel",
-            r"vaga encerrada",
-            r"n(a|ã|Ã£)o aceita mais candidaturas",
-            r"não aceita mais candidaturas",
-            r"no longer accepting applications",
-        )
-
-        if "/jobs/collections/" in normalized_url or "/jobs/search/" in normalized_url:
-            return LinkedInJobPageReadiness(
-                result="listing_redirect",
-                reason="a navegacao caiu em listagem ou colecao do LinkedIn",
-                sample=state.sample,
-            )
-        if current_job_id and target_job_id and current_job_id != target_job_id:
-            return LinkedInJobPageReadiness(
-                result="wrong_page",
-                reason="a pagina aberta nao corresponde a vaga autorizada",
-                sample=state.sample,
-            )
-        if any(re.search(pattern, normalized_sample, re.IGNORECASE) for pattern in expired_patterns):
-            return LinkedInJobPageReadiness(
-                result="expired",
-                reason="a vaga parece encerrada ou indisponivel",
-                sample=state.sample,
-            )
-        if state.easy_apply or state.submit_visible:
-            return LinkedInJobPageReadiness(
-                result="ready",
-                reason="cta de candidatura detectado na pagina alvo",
-                sample=state.sample,
-            )
-        if state.external_apply:
-            return LinkedInJobPageReadiness(
-                result="no_apply_cta",
-                reason="a vaga so oferece candidatura externa no site da empresa",
-                sample=state.sample,
-            )
-        if "/apply/" in normalized_url:
-            return LinkedInJobPageReadiness(
-                result="ready",
-                reason="fluxo de candidatura do LinkedIn ja esta aberto na vaga alvo",
-                sample=state.sample,
-            )
-        return LinkedInJobPageReadiness(
-            result="no_apply_cta",
-            reason="nenhum cta de candidatura foi encontrado na pagina alvo",
-            sample=state.sample,
-        )
+        return classify_linkedin_job_page_readiness(job_url=job.url, state=state)
 
     async def _ensure_target_job_page(self, page, job: JobPosting) -> None:
         current_url = ""
@@ -604,43 +334,15 @@ class LinkedInApplicationFlowInspector:
 
     @staticmethod
     def _canonical_linkedin_job_url(url: str) -> str:
-        match = re.search(r"/jobs/view/(\d+)", url, re.IGNORECASE)
-        if not match:
-            return ""
-        return f"https://www.linkedin.com/jobs/view/{match.group(1)}/"
+        return canonical_linkedin_job_url(url)
 
     @classmethod
     def _needs_canonical_job_navigation(cls, current_url: str, target_url: str) -> bool:
-        target_job_id = cls._extract_linkedin_job_id(target_url)
-        if not target_job_id:
-            return False
-        normalized_current_url = current_url.lower()
-        if "/jobs/collections/" in normalized_current_url:
-            return True
-        if "/apply/" in normalized_current_url:
-            return False
-        current_job_id = cls._extract_linkedin_job_id(current_url)
-        if current_job_id and current_job_id != target_job_id:
-            return True
-        return False
+        return needs_canonical_job_navigation(current_url, target_url)
 
     @staticmethod
     def _extract_linkedin_job_id(url: str) -> str:
-        match = re.search(r"/jobs/view/(\d+)", url, re.IGNORECASE)
-        if match:
-            return match.group(1)
-        try:
-            parsed = urlparse(url)
-            query = parse_qs(parsed.query)
-        except Exception:
-            return ""
-        current_job_id = query.get("currentJobId", [""])
-        if current_job_id and current_job_id[0].isdigit():
-            return current_job_id[0]
-        reference_job_id = query.get("referenceJobId", [""])
-        if reference_job_id and reference_job_id[0].isdigit():
-            return reference_job_id[0]
-        return ""
+        return extract_linkedin_job_id(url)
 
     async def _inspect_easy_apply_modal(
         self,
@@ -663,6 +365,18 @@ class LinkedInApplicationFlowInspector:
     def _format_modal_interpretation_for_error(self, state: LinkedInApplicationPageState) -> str:
         return self._modal_driver.format_modal_interpretation_for_error(state)
 
+    async def _inspect_easy_apply_modal_via_opener(
+        self,
+        page,
+        initial_state: LinkedInApplicationPageState,
+        close_modal: bool,
+    ) -> LinkedInApplicationPageState:
+        return await self._inspect_easy_apply_modal(
+            page,
+            initial_state,
+            close_modal=close_modal,
+        )
+
     async def _capture_failure_artifacts(
         self,
         page,
@@ -672,14 +386,12 @@ class LinkedInApplicationFlowInspector:
         phase: str,
         detail: str,
     ) -> str:
-        return await capture_failure_artifacts(
+        return await self._artifact_capture.capture(
             page,
             state=state,
             job=job,
             phase=phase,
             detail=detail,
-            enabled=self.save_failure_artifacts,
-            artifacts_dir=self.failure_artifacts_dir,
         )
 
     async def _build_submit_exception_result(
@@ -690,20 +402,11 @@ class LinkedInApplicationFlowInspector:
         state: LinkedInApplicationPageState,
         job: JobPosting,
     ) -> ApplicationSubmissionResult:
-        if self._is_closed_target_error(exc):
-            detail = "submissao real interrompida: pagina do LinkedIn foi fechada durante a automacao"
-        else:
-            detail = f"submissao real falhou com erro inesperado: {exc}"
-        artifact_detail = await self._capture_failure_artifacts(
-            page,
+        return await self._artifact_capture.build_submit_exception_result(
+            exc,
+            page=page,
             state=state,
             job=job,
-            phase="submit",
-            detail=detail,
-        )
-        return ApplicationSubmissionResult(
-            status="error_submit",
-            detail=f"{detail}{artifact_detail}",
         )
 
     async def _try_open_easy_apply_modal(self, page) -> bool:
@@ -732,58 +435,12 @@ class LinkedInApplicationFlowInspector:
         page,
         job: JobPosting,
     ) -> tuple[LinkedInApplicationPageState, LinkedInJobPageReadiness]:
-        await page.wait_for_timeout(2500)
-        await self._prepare_job_page_for_apply(page)
-        state = await self._read_page_state(page)
-        readiness = self._assess_job_page_readiness(job, state)
-        if readiness.result != "no_apply_cta":
-            return state, readiness
-        for delay_ms in (1800, 2800):
-            try:
-                await page.wait_for_load_state("domcontentloaded")
-            except Exception:
-                pass
-            await page.wait_for_timeout(delay_ms)
-            await self._prepare_job_page_for_apply(page)
-            state = await self._read_page_state(page)
-            readiness = self._assess_job_page_readiness(job, state)
-            if readiness.result != "no_apply_cta":
-                return state, readiness
-        recovered = await self._recover_easy_apply_from_page_html(page, job)
-        if recovered:
-            await self._prepare_job_page_for_apply(page)
-            state = await self._read_page_state(page)
-            readiness = self._assess_job_page_readiness(job, state)
-        return state, readiness
+        self._refresh_flow_opener_callbacks()
+        return await self._flow_opener.read_state_with_hydration(page, job)
 
     async def _recover_easy_apply_from_page_html(self, page, job: JobPosting) -> bool:
-        try:
-            content = await page.content()
-        except Exception:
-            return False
-        if not content:
-            return False
-        lowered = content.lower()
-        target_job_id = self._extract_linkedin_job_id(job.url)
-        if not target_job_id:
-            return False
-        has_internal_apply = (
-            f"https://www.linkedin.com/job-apply/{target_job_id}".lower() in lowered
-            or f"/jobs/view/{target_job_id}/apply/".lower() in lowered
-            or (
-                "applyctatext" in lowered
-                and ("candidatura simplificada" in lowered or "easy apply" in lowered)
-            )
-        )
-        if not has_internal_apply:
-            return False
-        apply_url = f"https://www.linkedin.com/jobs/view/{target_job_id}/apply/?openSDUIApplyFlow=true"
-        try:
-            await page.goto(apply_url, wait_until="domcontentloaded")
-            await page.wait_for_timeout(1800)
-            return True
-        except Exception:
-            return False
+        self._refresh_flow_opener_callbacks()
+        return await self._flow_opener.recover_easy_apply_from_page_html(page, job)
 
     async def _try_open_easy_apply_via_direct_url(
         self,
@@ -791,21 +448,11 @@ class LinkedInApplicationFlowInspector:
         *,
         close_modal: bool,
     ) -> LinkedInApplicationPageState:
-        direct_apply_url = await self._extract_easy_apply_href(page)
-        if not direct_apply_url:
-            return await self._read_page_state(page)
-        try:
-            await page.goto(direct_apply_url, wait_until="domcontentloaded")
-            await page.wait_for_timeout(1800)
-            await self._prepare_job_page_for_apply(page)
-            state = await self._read_page_state(page)
-            if state.modal_open:
-                return await self._inspect_easy_apply_modal(page, state, close_modal=close_modal)
-            return state
-        except Exception:
-            if self._is_page_closed(page):
-                raise
-            return await self._read_page_state(page)
+        self._refresh_flow_opener_callbacks()
+        return await self._flow_opener.try_open_easy_apply_via_direct_url(
+            page,
+            close_modal=close_modal,
+        )
 
     @staticmethod
     def _is_page_closed(page) -> bool:
@@ -835,3 +482,5 @@ class LinkedInApplicationFlowInspector:
 
     async def _detect_submit_success(self, page) -> bool:
         return await self._modal_driver.detect_submit_success(page)
+
+

--- a/job_hunter_agent/collectors/linkedin_application_artifacts.py
+++ b/job_hunter_agent/collectors/linkedin_application_artifacts.py
@@ -1,15 +1,66 @@
 from __future__ import annotations
 
+from dataclasses import dataclass
 from datetime import datetime
 import json
 from pathlib import Path
 import re
 from uuid import uuid4
 
+from job_hunter_agent.application.applicant import ApplicationSubmissionResult
 from job_hunter_agent.core.domain import JobPosting
 from job_hunter_agent.collectors.linkedin_application_state import LinkedInApplicationPageState
 
 ARTIFACT_SCHEMA_VERSION = 1
+
+
+@dataclass(frozen=True)
+class LinkedInFailureArtifactCapture:
+    enabled: bool
+    artifacts_dir: Path | None
+
+    async def capture(
+        self,
+        page,
+        *,
+        state: LinkedInApplicationPageState,
+        job: JobPosting,
+        phase: str,
+        detail: str,
+    ) -> str:
+        return await capture_failure_artifacts(
+            page,
+            state=state,
+            job=job,
+            phase=phase,
+            detail=detail,
+            enabled=self.enabled,
+            artifacts_dir=self.artifacts_dir,
+        )
+
+    async def build_submit_exception_result(
+        self,
+        exc: Exception,
+        *,
+        page,
+        state: LinkedInApplicationPageState,
+        job: JobPosting,
+    ) -> ApplicationSubmissionResult:
+        if is_closed_target_error(exc):
+            detail = "submissao real interrompida: pagina do LinkedIn foi fechada durante a automacao"
+        else:
+            detail = f"submissao real falhou com erro inesperado: {exc}"
+        artifact_detail = await self.capture(
+            page,
+            state=state,
+            job=job,
+            phase="submit",
+            detail=detail,
+        )
+        return ApplicationSubmissionResult(
+            status="error_submit",
+            detail=f"{detail}{artifact_detail}",
+        )
 
 
 def is_page_closed(page) -> bool:

--- a/job_hunter_agent/collectors/linkedin_application_artifacts.py
+++ b/job_hunter_agent/collectors/linkedin_application_artifacts.py
@@ -3,9 +3,13 @@ from __future__ import annotations
 from datetime import datetime
 import json
 from pathlib import Path
+import re
+from uuid import uuid4
 
 from job_hunter_agent.core.domain import JobPosting
 from job_hunter_agent.collectors.linkedin_application_state import LinkedInApplicationPageState
+
+ARTIFACT_SCHEMA_VERSION = 1
 
 
 def is_page_closed(page) -> bool:
@@ -18,6 +22,13 @@ def is_page_closed(page) -> bool:
 def is_closed_target_error(exc: Exception) -> bool:
     text = str(exc).lower()
     return "target page, context or browser has been closed" in text
+
+
+def build_detail_slug(detail: str) -> str:
+    normalized = re.sub(r"[^a-z0-9]+", "-", detail.lower()).strip("-")
+    if not normalized:
+        return "sem-detalhe"
+    return normalized[:64].rstrip("-")
 
 
 async def capture_failure_artifacts(
@@ -35,9 +46,11 @@ async def capture_failure_artifacts(
     try:
         artifacts_dir.mkdir(parents=True, exist_ok=True)
         timestamp = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
-        stem = f"{timestamp}_{phase}_job-{job.id}"
-        html_path = artifacts_dir / f"{stem}_page.html"
-        screenshot_path = artifacts_dir / f"{stem}_shot.png"
+        detail_slug = build_detail_slug(detail)
+        artifact_id = f"{phase}-job-{job.id}-{uuid4().hex[:8]}"
+        stem = f"{timestamp}_{phase}_job-{job.id}_{detail_slug}"
+        html_path = artifacts_dir / f"{stem}_dom.html"
+        screenshot_path = artifacts_dir / f"{stem}_screenshot.png"
         meta_path = artifacts_dir / f"{stem}_meta.json"
         page_closed = is_page_closed(page)
         html_saved = False
@@ -60,6 +73,10 @@ async def capture_failure_artifacts(
                 page_closed = True
 
         payload = {
+            "artifact_schema_version": ARTIFACT_SCHEMA_VERSION,
+            "artifact_id": artifact_id,
+            "artifact_type": phase,
+            "detail_slug": detail_slug,
             "job_id": job.id,
             "job_title": job.title,
             "job_url": job.url,

--- a/job_hunter_agent/collectors/linkedin_application_entrypoint.py
+++ b/job_hunter_agent/collectors/linkedin_application_entrypoint.py
@@ -1,0 +1,146 @@
+from __future__ import annotations
+
+import re
+from urllib.parse import parse_qs, urlparse
+
+from job_hunter_agent.collectors.linkedin_application_state import (
+    LinkedInApplicationPageState,
+    LinkedInJobPageReadiness,
+)
+
+
+def extract_linkedin_job_id(url: str) -> str:
+    match = re.search(r"/jobs/view/(\d+)", url, re.IGNORECASE)
+    if match:
+        return match.group(1)
+    try:
+        parsed = urlparse(url)
+        query = parse_qs(parsed.query)
+    except Exception:
+        return ""
+    current_job_id = query.get("currentJobId", [""])
+    if current_job_id and current_job_id[0].isdigit():
+        return current_job_id[0]
+    reference_job_id = query.get("referenceJobId", [""])
+    if reference_job_id and reference_job_id[0].isdigit():
+        return reference_job_id[0]
+    return ""
+
+
+def canonical_linkedin_job_url(url: str) -> str:
+    job_id = extract_linkedin_job_id(url)
+    if not job_id:
+        return ""
+    return f"https://www.linkedin.com/jobs/view/{job_id}/"
+
+
+def build_linkedin_direct_apply_url(url: str) -> str:
+    job_id = extract_linkedin_job_id(url)
+    if not job_id:
+        return ""
+    return f"https://www.linkedin.com/jobs/view/{job_id}/apply/?openSDUIApplyFlow=true"
+
+
+def needs_canonical_job_navigation(current_url: str, target_url: str) -> bool:
+    target_job_id = extract_linkedin_job_id(target_url)
+    if not target_job_id:
+        return False
+    normalized_current_url = current_url.lower()
+    if "/jobs/collections/" in normalized_current_url:
+        return True
+    if "/apply/" in normalized_current_url:
+        return False
+    current_job_id = extract_linkedin_job_id(current_url)
+    if current_job_id and current_job_id != target_job_id:
+        return True
+    return False
+
+
+def classify_linkedin_job_page_readiness(
+    *,
+    job_url: str,
+    state: LinkedInApplicationPageState,
+) -> LinkedInJobPageReadiness:
+    current_url = state.current_url or ""
+    current_job_id = extract_linkedin_job_id(current_url)
+    target_job_id = extract_linkedin_job_id(job_url)
+    normalized_url = current_url.lower()
+    normalized_sample = state.sample.lower()
+
+    expired_patterns = (
+        r"job (is )?no longer available",
+        r"job.*no longer open",
+        r"this job has expired",
+        r"job posting has expired",
+        r"this (position|role|job) (is )?no longer",
+        r"this job (listing )?is closed",
+        r"job (listing )?not found",
+        r"pagina que voce esta procurando nao existe",
+        r"vaga (nao|nÃ£o) esta mais disponivel",
+        r"vaga encerrada",
+        r"n(a|Ã£|ÃƒÂ£)o aceita mais candidaturas",
+        r"nÃ£o aceita mais candidaturas",
+        r"no longer accepting applications",
+    )
+
+    if "/jobs/collections/" in normalized_url or "/jobs/search/" in normalized_url:
+        return LinkedInJobPageReadiness(
+            result="listing_redirect",
+            reason="a navegacao caiu em listagem ou colecao do LinkedIn",
+            sample=state.sample,
+        )
+    if current_job_id and target_job_id and current_job_id != target_job_id:
+        return LinkedInJobPageReadiness(
+            result="wrong_page",
+            reason="a pagina aberta nao corresponde a vaga autorizada",
+            sample=state.sample,
+        )
+    if any(re.search(pattern, normalized_sample, re.IGNORECASE) for pattern in expired_patterns):
+        return LinkedInJobPageReadiness(
+            result="expired",
+            reason="a vaga parece encerrada ou indisponivel",
+            sample=state.sample,
+        )
+    if state.easy_apply or state.submit_visible:
+        return LinkedInJobPageReadiness(
+            result="ready",
+            reason="cta de candidatura detectado na pagina alvo",
+            sample=state.sample,
+        )
+    if state.external_apply:
+        return LinkedInJobPageReadiness(
+            result="no_apply_cta",
+            reason="a vaga so oferece candidatura externa no site da empresa",
+            sample=state.sample,
+        )
+    if "/apply/" in normalized_url:
+        return LinkedInJobPageReadiness(
+            result="ready",
+            reason="fluxo de candidatura do LinkedIn ja esta aberto na vaga alvo",
+            sample=state.sample,
+        )
+    return LinkedInJobPageReadiness(
+        result="no_apply_cta",
+        reason="nenhum cta de candidatura foi encontrado na pagina alvo",
+        sample=state.sample,
+    )
+
+
+def recover_linkedin_direct_apply_url_from_html(content: str, job_url: str) -> str:
+    if not content:
+        return ""
+    lowered = content.lower()
+    target_job_id = extract_linkedin_job_id(job_url)
+    if not target_job_id:
+        return ""
+    has_internal_apply = (
+        f"https://www.linkedin.com/job-apply/{target_job_id}".lower() in lowered
+        or f"/jobs/view/{target_job_id}/apply/".lower() in lowered
+        or (
+            "applyctatext" in lowered
+            and ("candidatura simplificada" in lowered or "easy apply" in lowered)
+        )
+    )
+    if not has_internal_apply:
+        return ""
+    return build_linkedin_direct_apply_url(job_url)

--- a/job_hunter_agent/collectors/linkedin_application_fields.py
+++ b/job_hunter_agent/collectors/linkedin_application_fields.py
@@ -1,0 +1,257 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from job_hunter_agent.core.candidate_profile import (
+    CandidateProfile,
+    extract_supported_experience_answers,
+    record_pending_questions,
+)
+from job_hunter_agent.collectors.linkedin_application_state import LinkedInApplicationPageState
+
+
+class LinkedInEasyApplyFieldFiller:
+    def __init__(
+        self,
+        *,
+        contact_email: str,
+        phone: str,
+        phone_country_code: str,
+        candidate_profile: CandidateProfile | None = None,
+        candidate_profile_path: Path | None = None,
+    ) -> None:
+        self.contact_email = contact_email
+        self.phone = phone
+        self.phone_country_code = phone_country_code
+        self.candidate_profile = candidate_profile
+        self.candidate_profile_path = candidate_profile_path
+
+    async def try_fill_safe_fields(self, page) -> tuple[str, ...]:
+        if await page.locator('[role="dialog"]').count() == 0:
+            return ()
+        filled = await page.evaluate(
+            """
+            ({ email, phone, countryCode }) => {
+              const normalize = (value) => (value || "").replace(/\\s+/g, " ").trim().toLowerCase();
+              const modal = document.querySelector('[role="dialog"]');
+              if (!modal) return [];
+
+              const fields = Array.from(modal.querySelectorAll('input, textarea, select'));
+              const descriptorFor = (node) => {
+                const parts = [];
+                const labelId = node.getAttribute('aria-labelledby');
+                if (labelId) {
+                  labelId.split(/\\s+/).forEach((id) => {
+                    const labelNode = document.getElementById(id);
+                    if (labelNode) parts.push(labelNode.textContent || '');
+                  });
+                }
+                const closestLabel = node.closest('label');
+                if (closestLabel) parts.push(closestLabel.textContent || '');
+                const parentText = node.parentElement ? node.parentElement.textContent || '' : '';
+                parts.push(parentText);
+                parts.push(node.getAttribute('aria-label') || '');
+                parts.push(node.getAttribute('name') || '');
+                parts.push(node.id || '');
+                return normalize(parts.join(' '));
+              };
+              const findField = (patterns, tagName) => {
+                return fields.find((field) => {
+                  if (tagName && field.tagName.toLowerCase() !== tagName) return false;
+                  const descriptor = descriptorFor(field);
+                  return patterns.some((pattern) => descriptor.includes(pattern));
+                });
+              };
+              const filled = [];
+              const dispatch = (node) => {
+                node.dispatchEvent(new Event('input', { bubbles: true }));
+                node.dispatchEvent(new Event('change', { bubbles: true }));
+                node.dispatchEvent(new Event('blur', { bubbles: true }));
+              };
+              const fillSelect = (field, targetValue, fieldName) => {
+                if (!field || field.tagName.toLowerCase() !== 'select' || field.disabled || !targetValue) return false;
+                const targetNormalized = normalize(targetValue);
+                const targetDialCode = ((targetValue || '').match(/\\+\\d+/) || [''])[0];
+                const options = Array.from(field.options || []);
+                const target = options.find((option) => {
+                  const label = normalize(option.label || option.textContent || '');
+                  const value = normalize(option.value || '');
+                  return (
+                    label === targetNormalized
+                    || value === targetNormalized
+                    || label.includes(targetNormalized)
+                    || value.includes(targetNormalized)
+                    || (!!targetDialCode && (label.includes(targetDialCode) || value.includes(targetDialCode)))
+                  );
+                });
+                if (!target) return false;
+                field.value = target.value;
+                dispatch(field);
+                filled.push(fieldName);
+                return true;
+              };
+
+              if (email) {
+                const field = findField(['email', 'e-mail'], null);
+                if (fillSelect(field, email, 'email')) {
+                } else if (field && !field.disabled && !field.readOnly) {
+                  field.focus();
+                  field.value = email;
+                  dispatch(field);
+                  filled.push('email');
+                }
+              }
+
+              if (phone) {
+                const field = findField(['phone', 'telefone', 'celular'], null);
+                if (field && !field.disabled && !field.readOnly) {
+                  field.focus();
+                  field.value = phone;
+                  dispatch(field);
+                  filled.push('telefone');
+                }
+              }
+
+              if (countryCode) {
+                const field = findField(['country code', 'codigo do pais', 'código do país', 'cÃƒÂ³digo do paÃƒÂ­s', 'country/region phone number'], 'select');
+                fillSelect(field, countryCode, 'codigo_pais');
+                if (!filled.includes('codigo_pais')) {
+                  const accentedField = findField(['código do país'], 'select');
+                  fillSelect(accentedField, countryCode, 'codigo_pais');
+                }
+              }
+
+              return filled;
+            }
+            """,
+            {
+                "email": self.contact_email,
+                "phone": self.phone,
+                "countryCode": self.phone_country_code,
+            },
+        )
+        return tuple(filled)
+
+    async def try_fill_supported_profile_answers(
+        self,
+        page,
+        state: LinkedInApplicationPageState,
+    ) -> tuple[tuple[str, ...], tuple[str, ...]]:
+        answers, unresolved_questions = extract_supported_experience_answers(
+            state.modal_questions,
+            self.candidate_profile,
+        )
+        if not answers:
+            return (), unresolved_questions
+        answered_questions = await page.evaluate(
+            """
+            (answers) => {
+              const normalize = (value) => (value || "").replace(/\\s+/g, " ").trim().toLowerCase();
+              const modal = document.querySelector('[role="dialog"]');
+              if (!modal) return [];
+              const fields = Array.from(modal.querySelectorAll('input[required], textarea[required], select[required]'));
+              const descriptorFor = (field) => {
+                const parts = [];
+                const fieldId = field.getAttribute('id');
+                if (fieldId) {
+                  const explicitLabel = modal.querySelector(`label[for="${fieldId}"]`);
+                  if (explicitLabel) parts.push(explicitLabel.textContent || '');
+                }
+                const labelledBy = field.getAttribute('aria-labelledby');
+                if (labelledBy) {
+                  labelledBy.split(/\\s+/).forEach((id) => {
+                    const node = document.getElementById(id);
+                    if (node) parts.push(node.textContent || '');
+                  });
+                }
+                const describedBy = field.getAttribute('aria-describedby');
+                if (describedBy) {
+                  describedBy.split(/\\s+/).forEach((id) => {
+                    const node = document.getElementById(id);
+                    if (node) parts.push(node.textContent || '');
+                  });
+                }
+                const closestLabel = field.closest('label');
+                if (closestLabel) parts.push(closestLabel.textContent || '');
+                const formElement = field.closest('[data-test-form-element]') || field.closest('.fb-dash-form-element');
+                if (formElement) {
+                  const legend = formElement.querySelector('legend');
+                  const title = formElement.querySelector('[data-test-text-entity-list-form-title]');
+                  if (legend) parts.push(legend.textContent || '');
+                  if (title) parts.push(title.textContent || '');
+                }
+                parts.push(field.getAttribute('name') || '');
+                parts.push(field.getAttribute('aria-label') || '');
+                return normalize(parts.join(' '));
+              };
+              const dispatch = (node) => {
+                node.dispatchEvent(new Event('input', { bubbles: true }));
+                node.dispatchEvent(new Event('change', { bubbles: true }));
+                node.dispatchEvent(new Event('blur', { bubbles: true }));
+              };
+              const filled = [];
+              for (const answer of answers) {
+                const normalizedQuestion = normalize(answer.question || '');
+                const aliases = (answer.aliases || []).map((alias) => normalize(alias));
+                const field = fields.find((candidate) => {
+                  const descriptor = descriptorFor(candidate);
+                  return (
+                    (!!normalizedQuestion && descriptor.includes(normalizedQuestion))
+                    || aliases.some((alias) => alias && descriptor.includes(alias))
+                  );
+                });
+                if (!field || field.disabled || field.readOnly) {
+                  continue;
+                }
+                const tagName = field.tagName.toLowerCase();
+                if (tagName === 'select') {
+                  const targetValue = String(answer.years);
+                  const target = Array.from(field.options || []).find((option) => {
+                    const label = normalize(option.label || option.textContent || '');
+                    const value = normalize(option.value || '');
+                    return label === targetValue || value === targetValue;
+                  });
+                  if (!target) {
+                    continue;
+                  }
+                  field.value = target.value;
+                  dispatch(field);
+                  filled.push(answer.question);
+                  continue;
+                }
+                if (tagName === 'input' || tagName === 'textarea') {
+                  field.focus();
+                  field.value = String(answer.years);
+                  dispatch(field);
+                  filled.push(answer.question);
+                }
+              }
+              return filled;
+            }
+            """,
+            [
+                {
+                    "question": answer.question,
+                    "years": answer.years,
+                    "aliases": list(answer.aliases),
+                }
+                for answer in answers
+            ],
+        )
+        answered_questions = tuple(answered_questions)
+        unanswered_remaining = tuple(
+            question for question in unresolved_questions if question not in answered_questions
+        )
+        unanswered_from_answers = tuple(
+            answer.question for answer in answers if answer.question not in answered_questions
+        )
+        unresolved = tuple(dict.fromkeys((*unanswered_remaining, *unanswered_from_answers)))
+        return answered_questions, unresolved
+
+    def record_pending_questions(self, questions: tuple[str, ...]) -> None:
+        if self.candidate_profile_path is None or not questions:
+            return
+        try:
+            record_pending_questions(self.candidate_profile_path, questions)
+        except Exception:
+            return

--- a/job_hunter_agent/collectors/linkedin_application_modal.py
+++ b/job_hunter_agent/collectors/linkedin_application_modal.py
@@ -1,14 +1,11 @@
 ﻿from __future__ import annotations
 
-from pathlib import Path
 import re
 from typing import Callable
 
-from job_hunter_agent.core.candidate_profile import (
-    CandidateProfile,
-    extract_supported_experience_answers,
-    record_pending_questions,
-)
+from pathlib import Path
+
+from job_hunter_agent.collectors.linkedin_application_fields import LinkedInEasyApplyFieldFiller
 from job_hunter_agent.collectors.linkedin_application_state import LinkedInApplicationPageState
 
 
@@ -31,6 +28,13 @@ class LinkedInEasyApplyModalDriver:
         self.candidate_profile = candidate_profile
         self.candidate_profile_path = candidate_profile_path
         self.modal_interpreter = modal_interpreter
+        self._field_filler = LinkedInEasyApplyFieldFiller(
+            contact_email=self.contact_email,
+            phone=self.phone,
+            phone_country_code=self.phone_country_code,
+            candidate_profile=self.candidate_profile,
+            candidate_profile_path=self.candidate_profile_path,
+        )
 
     async def inspect_easy_apply_modal(
         self,
@@ -212,235 +216,17 @@ class LinkedInEasyApplyModalDriver:
             return ""
 
     async def try_fill_safe_fields(self, page) -> tuple[str, ...]:
-        if await page.locator('[role="dialog"]').count() == 0:
-            return ()
-        filled = await page.evaluate(
-            """
-            ({ email, phone, countryCode }) => {
-              const normalize = (value) => (value || "").replace(/\\s+/g, " ").trim().toLowerCase();
-              const modal = document.querySelector('[role="dialog"]');
-              if (!modal) return [];
-
-              const fields = Array.from(modal.querySelectorAll('input, textarea, select'));
-              const descriptorFor = (node) => {
-                const parts = [];
-                const labelId = node.getAttribute('aria-labelledby');
-                if (labelId) {
-                  labelId.split(/\\s+/).forEach((id) => {
-                    const labelNode = document.getElementById(id);
-                    if (labelNode) parts.push(labelNode.textContent || '');
-                  });
-                }
-                const closestLabel = node.closest('label');
-                if (closestLabel) parts.push(closestLabel.textContent || '');
-                const parentText = node.parentElement ? node.parentElement.textContent || '' : '';
-                parts.push(parentText);
-                parts.push(node.getAttribute('aria-label') || '');
-                parts.push(node.getAttribute('name') || '');
-                parts.push(node.id || '');
-                return normalize(parts.join(' '));
-              };
-              const findField = (patterns, tagName) => {
-                return fields.find((field) => {
-                  if (tagName && field.tagName.toLowerCase() !== tagName) return false;
-                  const descriptor = descriptorFor(field);
-                  return patterns.some((pattern) => descriptor.includes(pattern));
-                });
-              };
-              const filled = [];
-              const dispatch = (node) => {
-                node.dispatchEvent(new Event('input', { bubbles: true }));
-                node.dispatchEvent(new Event('change', { bubbles: true }));
-                node.dispatchEvent(new Event('blur', { bubbles: true }));
-              };
-              const fillSelect = (field, targetValue, fieldName) => {
-                if (!field || field.tagName.toLowerCase() !== 'select' || field.disabled || !targetValue) return false;
-                const targetNormalized = normalize(targetValue);
-                const targetDialCode = ((targetValue || '').match(/\\+\\d+/) || [''])[0];
-                const options = Array.from(field.options || []);
-                const target = options.find((option) => {
-                  const label = normalize(option.label || option.textContent || '');
-                  const value = normalize(option.value || '');
-                  return (
-                    label === targetNormalized
-                    || value === targetNormalized
-                    || label.includes(targetNormalized)
-                    || value.includes(targetNormalized)
-                    || (!!targetDialCode && (label.includes(targetDialCode) || value.includes(targetDialCode)))
-                  );
-                });
-                if (!target) return false;
-                field.value = target.value;
-                dispatch(field);
-                filled.push(fieldName);
-                return true;
-              };
-
-              if (email) {
-                const field = findField(['email', 'e-mail'], null);
-                if (fillSelect(field, email, 'email')) {
-                  // select preenchido
-                } else if (field && !field.disabled && !field.readOnly) {
-                  field.focus();
-                  field.value = email;
-                  dispatch(field);
-                  filled.push('email');
-                }
-              }
-
-              if (phone) {
-                const field = findField(['phone', 'telefone', 'celular'], null);
-                if (field && !field.disabled && !field.readOnly) {
-                  field.focus();
-                  field.value = phone;
-                  dispatch(field);
-                  filled.push('telefone');
-                }
-              }
-
-              if (countryCode) {
-                const field = findField(['country code', 'codigo do pais', 'código do país', 'cÃƒÂ³digo do paÃƒÂ­s', 'country/region phone number'], 'select');
-                fillSelect(field, countryCode, 'codigo_pais');
-                if (!filled.includes('codigo_pais')) {
-                  const accentedField = findField(['código do país'], 'select');
-                  fillSelect(accentedField, countryCode, 'codigo_pais');
-                }
-              }
-
-              return filled;
-            }
-            """,
-            {
-                "email": self.contact_email,
-                "phone": self.phone,
-                "countryCode": self.phone_country_code,
-            },
-        )
-        return tuple(filled)
+        return await self._field_filler.try_fill_safe_fields(page)
 
     async def try_fill_supported_profile_answers(
         self,
         page,
         state: LinkedInApplicationPageState,
     ) -> tuple[tuple[str, ...], tuple[str, ...]]:
-        answers, unresolved_questions = extract_supported_experience_answers(
-            state.modal_questions,
-            self.candidate_profile,
-        )
-        if not answers:
-            return (), unresolved_questions
-        answered_questions = await page.evaluate(
-            """
-            (answers) => {
-              const normalize = (value) => (value || "").replace(/\\s+/g, " ").trim().toLowerCase();
-              const modal = document.querySelector('[role="dialog"]');
-              if (!modal) return [];
-              const fields = Array.from(modal.querySelectorAll('input[required], textarea[required], select[required]'));
-              const descriptorFor = (field) => {
-                const parts = [];
-                const fieldId = field.getAttribute('id');
-                if (fieldId) {
-                  const explicitLabel = modal.querySelector(`label[for="${fieldId}"]`);
-                  if (explicitLabel) parts.push(explicitLabel.textContent || '');
-                }
-                const labelledBy = field.getAttribute('aria-labelledby');
-                if (labelledBy) {
-                  labelledBy.split(/\\s+/).forEach((id) => {
-                    const node = document.getElementById(id);
-                    if (node) parts.push(node.textContent || '');
-                  });
-                }
-                const describedBy = field.getAttribute('aria-describedby');
-                if (describedBy) {
-                  describedBy.split(/\\s+/).forEach((id) => {
-                    const node = document.getElementById(id);
-                    if (node) parts.push(node.textContent || '');
-                  });
-                }
-                const closestLabel = field.closest('label');
-                if (closestLabel) parts.push(closestLabel.textContent || '');
-                const formElement = field.closest('[data-test-form-element]') || field.closest('.fb-dash-form-element');
-                if (formElement) {
-                  const legend = formElement.querySelector('legend');
-                  const title = formElement.querySelector('[data-test-text-entity-list-form-title]');
-                  if (legend) parts.push(legend.textContent || '');
-                  if (title) parts.push(title.textContent || '');
-                }
-                parts.push(field.getAttribute('name') || '');
-                parts.push(field.getAttribute('aria-label') || '');
-                return normalize(parts.join(' '));
-              };
-              const dispatch = (node) => {
-                node.dispatchEvent(new Event('input', { bubbles: true }));
-                node.dispatchEvent(new Event('change', { bubbles: true }));
-                node.dispatchEvent(new Event('blur', { bubbles: true }));
-              };
-              const filled = [];
-              for (const answer of answers) {
-                const normalizedQuestion = normalize(answer.question || '');
-                const aliases = (answer.aliases || []).map((alias) => normalize(alias));
-                const field = fields.find((candidate) => {
-                  const descriptor = descriptorFor(candidate);
-                  return (
-                    (!!normalizedQuestion && descriptor.includes(normalizedQuestion))
-                    || aliases.some((alias) => alias && descriptor.includes(alias))
-                  );
-                });
-                if (!field || field.disabled || field.readOnly) {
-                  continue;
-                }
-                const tagName = field.tagName.toLowerCase();
-                if (tagName === 'select') {
-                  const targetValue = String(answer.years);
-                  const target = Array.from(field.options || []).find((option) => {
-                    const label = normalize(option.label || option.textContent || '');
-                    const value = normalize(option.value || '');
-                    return label === targetValue || value === targetValue;
-                  });
-                  if (!target) {
-                    continue;
-                  }
-                  field.value = target.value;
-                  dispatch(field);
-                  filled.push(answer.question);
-                  continue;
-                }
-                if (tagName === 'input' || tagName === 'textarea') {
-                  field.focus();
-                  field.value = String(answer.years);
-                  dispatch(field);
-                  filled.push(answer.question);
-                }
-              }
-              return filled;
-            }
-            """,
-            [
-                {
-                    "question": answer.question,
-                    "years": answer.years,
-                    "aliases": list(answer.aliases),
-                }
-                for answer in answers
-            ],
-        )
-        answered_questions = tuple(answered_questions)
-        unanswered_remaining = tuple(
-            question for question in unresolved_questions if question not in answered_questions
-        )
-        unanswered_from_answers = tuple(
-            answer.question for answer in answers if answer.question not in answered_questions
-        )
-        unresolved = tuple(dict.fromkeys((*unanswered_remaining, *unanswered_from_answers)))
-        return answered_questions, unresolved
+        return await self._field_filler.try_fill_supported_profile_answers(page, state)
 
     def record_pending_questions(self, questions: tuple[str, ...]) -> None:
-        if self.candidate_profile_path is None or not questions:
-            return
-        try:
-            record_pending_questions(self.candidate_profile_path, questions)
-        except Exception:
-            return
+        self._field_filler.record_pending_questions(questions)
 
     async def try_advance_single_step(self, page) -> bool:
         candidates = [

--- a/job_hunter_agent/collectors/linkedin_application_opening.py
+++ b/job_hunter_agent/collectors/linkedin_application_opening.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+from typing import Awaitable, Callable
+
+from job_hunter_agent.collectors.linkedin_application_entrypoint import (
+    recover_linkedin_direct_apply_url_from_html,
+)
+from job_hunter_agent.collectors.linkedin_application_state import (
+    LinkedInApplicationPageState,
+    LinkedInJobPageReadiness,
+)
+from job_hunter_agent.core.domain import JobPosting
+
+
+class LinkedInEasyApplyFlowOpener:
+    def __init__(
+        self,
+        *,
+        prepare_job_page_for_apply: Callable[[object], Awaitable[None]],
+        read_page_state: Callable[[object], Awaitable[LinkedInApplicationPageState]],
+        assess_job_page_readiness: Callable[[JobPosting, LinkedInApplicationPageState], LinkedInJobPageReadiness],
+        extract_easy_apply_href: Callable[[object], Awaitable[str]],
+        inspect_easy_apply_modal: Callable[[object, LinkedInApplicationPageState, bool], Awaitable[LinkedInApplicationPageState]],
+        is_page_closed: Callable[[object], bool],
+    ) -> None:
+        self._prepare_job_page_for_apply = prepare_job_page_for_apply
+        self._read_page_state = read_page_state
+        self._assess_job_page_readiness = assess_job_page_readiness
+        self._extract_easy_apply_href = extract_easy_apply_href
+        self._inspect_easy_apply_modal = inspect_easy_apply_modal
+        self._is_page_closed = is_page_closed
+
+    async def read_state_with_hydration(
+        self,
+        page,
+        job: JobPosting,
+    ) -> tuple[LinkedInApplicationPageState, LinkedInJobPageReadiness]:
+        await page.wait_for_timeout(2500)
+        await self._prepare_job_page_for_apply(page)
+        state = await self._read_page_state(page)
+        readiness = self._assess_job_page_readiness(job, state)
+        if readiness.result != "no_apply_cta":
+            return state, readiness
+        for delay_ms in (1800, 2800):
+            try:
+                await page.wait_for_load_state("domcontentloaded")
+            except Exception:
+                pass
+            await page.wait_for_timeout(delay_ms)
+            await self._prepare_job_page_for_apply(page)
+            state = await self._read_page_state(page)
+            readiness = self._assess_job_page_readiness(job, state)
+            if readiness.result != "no_apply_cta":
+                return state, readiness
+        recovered = await self.recover_easy_apply_from_page_html(page, job)
+        if recovered:
+            await self._prepare_job_page_for_apply(page)
+            state = await self._read_page_state(page)
+            readiness = self._assess_job_page_readiness(job, state)
+        return state, readiness
+
+    async def recover_easy_apply_from_page_html(self, page, job: JobPosting) -> bool:
+        try:
+            content = await page.content()
+        except Exception:
+            return False
+        apply_url = recover_linkedin_direct_apply_url_from_html(content, job.url)
+        if not apply_url:
+            return False
+        try:
+            await page.goto(apply_url, wait_until="domcontentloaded")
+            await page.wait_for_timeout(1800)
+            return True
+        except Exception:
+            return False
+
+    async def try_open_easy_apply_via_direct_url(
+        self,
+        page,
+        *,
+        close_modal: bool,
+    ) -> LinkedInApplicationPageState:
+        direct_apply_url = await self._extract_easy_apply_href(page)
+        if not direct_apply_url:
+            return await self._read_page_state(page)
+        try:
+            await page.goto(direct_apply_url, wait_until="domcontentloaded")
+            await page.wait_for_timeout(1800)
+            await self._prepare_job_page_for_apply(page)
+            state = await self._read_page_state(page)
+            if state.modal_open:
+                return await self._inspect_easy_apply_modal(page, state, close_modal)
+            return state
+        except Exception:
+            if self._is_page_closed(page):
+                raise
+            return await self._read_page_state(page)

--- a/job_hunter_agent/collectors/linkedin_application_reader.py
+++ b/job_hunter_agent/collectors/linkedin_application_reader.py
@@ -1,0 +1,246 @@
+from __future__ import annotations
+
+from job_hunter_agent.collectors.linkedin_application_state import LinkedInApplicationPageState
+
+
+LINKEDIN_APPLICATION_PAGE_STATE_SCRIPT = """
+() => {
+  const normalize = (value) => (value || "").replace(/\\s+/g, " ").trim().toLowerCase();
+  const isExcludedNode = (node) => !!node?.closest(
+    '[componentkey^="JobDetailsSimilarJobsSlot_"], [data-sdui-component*="similarJobs"]'
+  );
+  const currentUrl = window.location.href || "";
+  const currentPath = `${window.location.origin || ''}${window.location.pathname || ''}`;
+  const hiddenPayload = Array.from(document.querySelectorAll('code, script[type="application/ld+json"]'))
+    .map((node) => normalize(node.textContent || ''))
+    .join(' | ')
+    .slice(0, 4000);
+  const main = document.querySelector('main') || document.body;
+  const detailCandidates = [
+    '.jobs-search__job-details--container .jobs-details-top-card',
+    '.jobs-details-top-card',
+    '.jobs-search__job-details--container',
+    '.jobs-details',
+    'div[role="main"][data-sdui-screen*="JobDetails"]',
+    '#workspace',
+    'main',
+  ];
+  const detailPanel =
+    detailCandidates
+      .map((selector) => document.querySelector(selector))
+      .find((node) => !!node)
+    || main;
+  const topCard =
+    detailPanel.querySelector('.jobs-details-top-card') ||
+    detailPanel.querySelector('[data-live-test-job-apply-button]') ||
+    detailPanel;
+  const prioritizedSelectors = [
+    '[data-live-test-job-apply-button]',
+    '[data-control-name="jobdetails_topcard_inapply"]',
+    '[data-control-name="topcard_inapply"]',
+    '[data-control-name="jobs-details-top-card-apply-button"]',
+    '.jobs-apply-button',
+    '.jobs-apply-button--top-card button',
+    '.jobs-s-apply button',
+  ];
+  const prioritizedNodes = prioritizedSelectors.flatMap((selector) =>
+    Array.from(topCard.querySelectorAll(selector)).filter((node) => !isExcludedNode(node))
+  );
+  const globalApplyNodes = Array.from(main.querySelectorAll("button, a"))
+    .filter((node) => !isExcludedNode(node))
+    .filter((node) => {
+      if (node.closest('header, footer, nav')) return false;
+      const href = (node.getAttribute('href') || '').toLowerCase();
+      const text = normalize(node.textContent || node.getAttribute('aria-label') || '');
+      const control = normalize(node.getAttribute('data-control-name') || '');
+      return (
+        text.includes("easy apply")
+        || text.includes("candidatura simplificada")
+        || href.includes("/apply/")
+        || control.includes("inapply")
+        || control.includes("apply-button")
+      );
+    });
+  const prioritizedTexts = prioritizedNodes
+    .map((node) => normalize(node.textContent || node.getAttribute('aria-label') || ''))
+    .filter(Boolean);
+  const globalApplyTexts = globalApplyNodes
+    .map((node) => normalize(node.textContent || node.getAttribute('aria-label') || ''))
+    .filter(Boolean);
+  const texts = Array.from(detailPanel.querySelectorAll("button, a"))
+    .filter((node) => !isExcludedNode(node))
+    .map((node) => normalize(node.textContent || node.getAttribute('aria-label') || ''))
+    .filter(Boolean);
+  const applyContext = globalApplyNodes[0]?.closest('section, article, div');
+  const joined = normalize(
+    applyContext?.innerText
+    || detailPanel.innerText
+    || topCard.innerText
+    || main.innerText
+    || ""
+  ).slice(0, 400);
+  const easyApplyTexts = (prioritizedTexts.length ? prioritizedTexts : (globalApplyTexts.length ? globalApplyTexts : texts))
+    .filter((text) => text.includes("easy apply") || text.includes("candidatura simplificada"));
+  const applyHrefVisible = globalApplyNodes.some((node) =>
+    ((node.getAttribute('href') || '').toLowerCase().includes('/apply/'))
+  );
+  const applyFlowActive = currentUrl.includes("/apply/") || currentUrl.includes("openSDUIApplyFlow=true");
+  const hiddenEasyApply = hiddenPayload.includes('onsiteapply')
+    || hiddenPayload.includes('applyctatext')
+    || hiddenPayload.includes('candidatura simplificada');
+  const externalApply = texts.some((text) =>
+    text.includes("candidate-se")
+    || text.includes("candidatar-se")
+    || text.includes("apply on company website")
+    || text.includes("site da empresa")
+  );
+  const submitVisible = texts.some((text) => text.includes("enviar candidatura") || text.includes("submit application"));
+
+  const confirmationDialog = document.querySelector('[role="alertdialog"]');
+  const confirmationTexts = confirmationDialog
+    ? Array.from(confirmationDialog.querySelectorAll("button, span, div, h1, h2, h3, p"))
+        .map((node) => normalize(node.textContent))
+        .filter(Boolean)
+    : [];
+  const confirmationJoined = confirmationTexts.join(" | ");
+  const saveApplicationDialogVisible = confirmationJoined.includes("salvar esta candidatura")
+    || confirmationJoined.includes("save this application");
+
+  const modal = document.querySelector('[role="dialog"]');
+  const modalButtonTexts = modal
+    ? Array.from(modal.querySelectorAll("button"))
+        .map((node) => normalize(node.textContent))
+        .filter(Boolean)
+    : [];
+  const modalTexts = modal
+    ? Array.from(modal.querySelectorAll("button, label, span, div, h2, h3, p, legend"))
+        .map((node) => normalize(node.textContent))
+        .filter(Boolean)
+    : [];
+  const modalInputNames = modal
+    ? Array.from(modal.querySelectorAll("input, textarea, select"))
+        .map((node) => normalize(node.getAttribute("name") || node.getAttribute("aria-label") || node.id || ""))
+        .filter(Boolean)
+    : [];
+  const modalHeadings = modal
+    ? Array.from(modal.querySelectorAll("h1, h2, h3, legend"))
+        .map((node) => normalize(node.textContent))
+        .filter(Boolean)
+    : [];
+  const fieldDescriptor = (field) => {
+    if (!field) return "";
+    const parts = [];
+    const fieldId = field.getAttribute("id");
+    if (fieldId) {
+      const explicitLabel = modal.querySelector(`label[for="${fieldId}"]`);
+      if (explicitLabel) parts.push(explicitLabel.textContent || "");
+    }
+    const labelledBy = field.getAttribute("aria-labelledby");
+    if (labelledBy) {
+      labelledBy.split(/\\s+/).forEach((id) => {
+        const labelNode = document.getElementById(id);
+        if (labelNode) parts.push(labelNode.textContent || "");
+      });
+    }
+    const describedBy = field.getAttribute("aria-describedby");
+    if (describedBy) {
+      describedBy.split(/\\s+/).forEach((id) => {
+        const describedNode = document.getElementById(id);
+        if (describedNode) parts.push(describedNode.textContent || "");
+      });
+    }
+    const closestLabel = field.closest("label");
+    if (closestLabel) parts.push(closestLabel.textContent || "");
+    const formElement = field.closest("[data-test-form-element]") || field.closest(".fb-dash-form-element");
+    if (formElement) {
+      const legend = formElement.querySelector("legend");
+      const title = formElement.querySelector("[data-test-text-entity-list-form-title]");
+      if (legend) parts.push(legend.textContent || "");
+      if (title) parts.push(title.textContent || "");
+    }
+    parts.push(field.getAttribute("name") || "");
+    parts.push(field.getAttribute("aria-label") || "");
+    return normalize(parts.join(" "));
+  };
+  const hasText = (items, parts) => parts.some((part) => items.some((value) => value.includes(part)));
+  const resumableFields = [];
+  const contactEmailVisible = hasText(modalTexts, ["email", "e-mail"]) || hasText(modalInputNames, ["email"]);
+  const contactPhoneVisible = hasText(modalTexts, ["phone", "telefone", "celular"]) || hasText(modalInputNames, ["phone", "telefone", "celular"]);
+  const countryCodeVisible = hasText(modalTexts, ["country code", "codigo do pais", "cÃ³digo do paÃ­s"]) || hasText(modalInputNames, ["country code", "codigo", "cÃ³digo"]);
+  const workAuthorizationVisible = hasText(modalTexts, ["work authorization", "work permit", "autoriz", "visa"]) || hasText(modalInputNames, ["authorization", "permit", "visa"]);
+  const yearsOfExperienceVisible = hasText(modalTexts, ["years of work experience", "anos de experiencia"]) || hasText(modalInputNames, ["years", "experience"]);
+  if (contactEmailVisible) resumableFields.push("email");
+  if (contactPhoneVisible) resumableFields.push("telefone");
+  if (countryCodeVisible) resumableFields.push("codigo_pais");
+  if (workAuthorizationVisible) resumableFields.push("autorizacao_trabalho");
+  if (yearsOfExperienceVisible) resumableFields.push("anos_experiencia");
+  const requiredFields = modal
+    ? Array.from(modal.querySelectorAll('input[required], textarea[required], select[required]'))
+        .map((field) => fieldDescriptor(field))
+        .filter(Boolean)
+    : [];
+  const modalQuestions = requiredFields.filter((descriptor) => !(
+    descriptor.includes("email")
+    || descriptor.includes("e-mail")
+    || descriptor.includes("phone")
+    || descriptor.includes("telefone")
+    || descriptor.includes("celular")
+    || descriptor.includes("country code")
+    || descriptor.includes("codigo do pais")
+    || descriptor.includes("cÃ³digo do paÃ­s")
+    || descriptor.includes("cÃƒÂ³digo do paÃƒÂ­s")
+    || descriptor.includes("resume")
+    || descriptor.includes("curriculo")
+  ));
+  return {
+    current_url: currentUrl,
+    easy_apply: easyApplyTexts.length > 0 || applyHrefVisible || applyFlowActive || hiddenEasyApply,
+    external_apply: externalApply,
+    submit_visible: submitVisible,
+    modal_open: !!modal,
+    modal_submit_visible: modalButtonTexts.some((text) => text.includes("submit application") || text.includes("enviar candidatura")),
+    modal_next_visible: modalButtonTexts.some((text) => text.includes("next") || text.includes("continuar") || text.includes("avancar") || text.includes("avanÃ§ar")),
+    modal_review_visible: modalButtonTexts.some((text) => text.includes("review") || text.includes("revisar")),
+    modal_file_upload: modal ? modal.querySelectorAll('input[type="file"]').length > 0 : false,
+    modal_questions_visible: modalQuestions.length > 0,
+    save_application_dialog_visible: saveApplicationDialogVisible,
+    cta_text: easyApplyTexts[0] || (hiddenEasyApply ? "candidatura simplificada" : ""),
+    sample: `${currentPath} | ${joined}`.slice(0, 400),
+    modal_sample: (modalTexts.join(" | ") || confirmationJoined).slice(0, 400),
+    contact_email_visible: contactEmailVisible,
+    contact_phone_visible: contactPhoneVisible,
+    country_code_visible: countryCodeVisible,
+    work_authorization_visible: workAuthorizationVisible,
+    years_of_experience_visible: yearsOfExperienceVisible,
+    resumable_fields: resumableFields,
+    filled_fields: [],
+    progressed_to_next_step: false,
+    uploaded_resume: false,
+    reached_review_step: false,
+    ready_to_submit: false,
+    modal_headings: modalHeadings.slice(0, 6),
+    modal_buttons: modalButtonTexts.slice(0, 8),
+    modal_fields: modalInputNames.slice(0, 8),
+    modal_questions: modalQuestions.slice(0, 6),
+  };
+}
+"""
+
+
+def normalize_linkedin_application_page_state_payload(raw_state: dict) -> LinkedInApplicationPageState:
+    normalized = dict(raw_state)
+    normalized["resumable_fields"] = tuple(normalized.get("resumable_fields", ()))
+    normalized["filled_fields"] = tuple(normalized.get("filled_fields", ()))
+    normalized["modal_headings"] = tuple(normalized.get("modal_headings", ()))
+    normalized["modal_buttons"] = tuple(normalized.get("modal_buttons", ()))
+    normalized["modal_fields"] = tuple(normalized.get("modal_fields", ()))
+    normalized["modal_questions"] = tuple(normalized.get("modal_questions", ()))
+    normalized["answered_questions"] = tuple(normalized.get("answered_questions", ()))
+    normalized["unanswered_questions"] = tuple(normalized.get("unanswered_questions", ()))
+    return LinkedInApplicationPageState(**normalized)
+
+
+class LinkedInApplicationPageReader:
+    async def read(self, page) -> LinkedInApplicationPageState:
+        raw_state = await page.evaluate(LINKEDIN_APPLICATION_PAGE_STATE_SCRIPT)
+        return normalize_linkedin_application_page_state_payload(raw_state)

--- a/job_hunter_agent/collectors/linkedin_application_submit.py
+++ b/job_hunter_agent/collectors/linkedin_application_submit.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from job_hunter_agent.collectors.linkedin_application_state import (
+    LinkedInApplicationPageState,
+    build_linkedin_modal_snapshot,
+    describe_linkedin_easy_apply_entrypoint,
+    describe_linkedin_modal_blocker,
+)
+
+
+@dataclass(frozen=True)
+class LinkedInSubmitReadinessDecision:
+    ready: bool
+    detail: str
+
+
+def evaluate_linkedin_submit_readiness(
+    state: LinkedInApplicationPageState,
+    *,
+    interpretation_detail: str = "",
+) -> LinkedInSubmitReadinessDecision:
+    if state.modal_open and state.modal_submit_visible:
+        return LinkedInSubmitReadinessDecision(ready=True, detail="")
+
+    snapshot_detail = f" | {build_linkedin_modal_snapshot(state)}" if state.modal_open else ""
+    detail = (
+        "submissao real bloqueada: fluxo nao chegou ao botao de envio"
+        f" | bloqueio={describe_linkedin_modal_blocker(state)}"
+        f" | modal={state.modal_sample or 'nao_informado'}"
+        f" | {describe_linkedin_easy_apply_entrypoint(state)}"
+        f"{interpretation_detail}"
+        f"{snapshot_detail}"
+    )
+    return LinkedInSubmitReadinessDecision(ready=False, detail=detail)

--- a/job_hunter_agent/core/application_insights.py
+++ b/job_hunter_agent/core/application_insights.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from job_hunter_agent.core.domain import JobApplication
+
+
+@dataclass(frozen=True)
+class ApplicationOperationalInsight:
+    classification: str
+    reason_code: str
+    summary: str
+    source_detail: str = ""
+
+
+def classify_application_operational_insight(application: JobApplication) -> ApplicationOperationalInsight:
+    if application.status == "submitted":
+        return ApplicationOperationalInsight(
+            classification="submitted",
+            reason_code="submitted",
+            summary="submetida",
+            source_detail=application.last_submit_detail,
+        )
+
+    source_detail = (
+        application.last_error
+        or application.last_submit_detail
+        or application.last_preflight_detail
+        or ""
+    ).strip()
+    if not source_detail:
+        return ApplicationOperationalInsight(
+            classification="unknown",
+            reason_code="sem_detalhe_operacional",
+            summary="sem detalhe operacional",
+        )
+
+    lowered = source_detail.lower()
+
+    if "readiness=listing_redirect" in lowered or "similar-jobs" in lowered or "similar jobs" in lowered:
+        return ApplicationOperationalInsight(
+            classification="blocked",
+            reason_code="similar_jobs",
+            summary="redirecionada para similar jobs",
+            source_detail=source_detail,
+        )
+    if "perguntas_pendentes=" in lowered or "perguntas_obrigatorias" in lowered or "perguntas_nao_mapeadas" in lowered:
+        return ApplicationOperationalInsight(
+            classification="manual_review",
+            reason_code="perguntas_adicionais",
+            summary="perguntas adicionais pendentes",
+            source_detail=source_detail,
+        )
+    if "readiness=expired" in lowered:
+        return ApplicationOperationalInsight(
+            classification="blocked",
+            reason_code="vaga_expirada",
+            summary="vaga expirada ou indisponivel",
+            source_detail=source_detail,
+        )
+    if "readiness=no_apply_cta" in lowered:
+        summary = "cta de candidatura ausente"
+        reason = "no_apply_cta"
+        if "externa" in lowered or "site da empresa" in lowered:
+            summary = "candidatura externa"
+            reason = "candidatura_externa"
+        return ApplicationOperationalInsight(
+            classification="blocked",
+            reason_code=reason,
+            summary=summary,
+            source_detail=source_detail,
+        )
+    if "pronto_para_envio=sim" in lowered or "ok: fluxo pronto para submissao assistida" in lowered:
+        return ApplicationOperationalInsight(
+            classification="ready",
+            reason_code="pronto_para_envio",
+            summary="fluxo pronto para envio",
+            source_detail=source_detail,
+        )
+    if "preflight real ok" in lowered or "cta encontrado" in lowered:
+        return ApplicationOperationalInsight(
+            classification="manual_review",
+            reason_code="cta_detectado",
+            summary="cta detectado; validar fluxo",
+            source_detail=source_detail,
+        )
+    if "inconclusivo" in lowered or "manual_review" in lowered or "manual review" in lowered:
+        return ApplicationOperationalInsight(
+            classification="manual_review",
+            reason_code="fluxo_inconclusivo",
+            summary="fluxo exige revisao manual",
+            source_detail=source_detail,
+        )
+    if "readiness=" in lowered or "bloqueio=" in lowered:
+        return ApplicationOperationalInsight(
+            classification="blocked",
+            reason_code="bloqueio_funcional",
+            summary="bloqueio funcional",
+            source_detail=source_detail,
+        )
+    return ApplicationOperationalInsight(
+        classification="unknown",
+        reason_code="nao_classificado",
+        summary="nao classificado",
+        source_detail=source_detail,
+    )

--- a/job_hunter_agent/core/application_insights.py
+++ b/job_hunter_agent/core/application_insights.py
@@ -13,21 +13,8 @@ class ApplicationOperationalInsight:
     source_detail: str = ""
 
 
-def classify_application_operational_insight(application: JobApplication) -> ApplicationOperationalInsight:
-    if application.status == "submitted":
-        return ApplicationOperationalInsight(
-            classification="submitted",
-            reason_code="submitted",
-            summary="submetida",
-            source_detail=application.last_submit_detail,
-        )
-
-    source_detail = (
-        application.last_error
-        or application.last_submit_detail
-        or application.last_preflight_detail
-        or ""
-    ).strip()
+def classify_operational_detail(detail: str) -> ApplicationOperationalInsight:
+    source_detail = detail.strip()
     if not source_detail:
         return ApplicationOperationalInsight(
             classification="unknown",
@@ -104,3 +91,21 @@ def classify_application_operational_insight(application: JobApplication) -> App
         summary="nao classificado",
         source_detail=source_detail,
     )
+
+
+def classify_application_operational_insight(application: JobApplication) -> ApplicationOperationalInsight:
+    if application.status == "submitted":
+        return ApplicationOperationalInsight(
+            classification="submitted",
+            reason_code="submitted",
+            summary="submetida",
+            source_detail=application.last_submit_detail,
+        )
+
+    source_detail = (
+        application.last_error
+        or application.last_submit_detail
+        or application.last_preflight_detail
+        or ""
+    ).strip()
+    return classify_operational_detail(source_detail)

--- a/job_hunter_agent/infrastructure/notifier_rendering.py
+++ b/job_hunter_agent/infrastructure/notifier_rendering.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from job_hunter_agent.llm.application_priority import extract_application_priority_level
+from job_hunter_agent.core.application_insights import classify_application_operational_insight
 from job_hunter_agent.core.domain import JobApplication, JobPosting
 from job_hunter_agent.llm.job_requirements import (
     extract_job_requirement_signals,
@@ -80,8 +81,10 @@ def build_application_queue_message(repository: JobRepository) -> str:
     summary = repository.application_summary()
     tracked_statuses = ("draft", "ready_for_review", "confirmed", "authorized_submit", "error_submit")
     preview_lines: list[str] = []
+    tracked_applications: list[JobApplication] = []
     for status in tracked_statuses:
         applications = _sort_applications_by_priority(repository.list_applications_by_status(status))
+        tracked_applications.extend(applications)
         for application in applications[:3]:
             preview_lines.append(build_application_preview_line(repository, application))
     lines = [
@@ -95,6 +98,11 @@ def build_application_queue_message(repository: JobRepository) -> str:
         f"Com erro: {summary['error_submit']}",
         f"Canceladas: {summary['cancelled']}",
     ]
+    operational_summary = summarize_operational_classifications(tracked_applications)
+    if operational_summary:
+        lines.append("")
+        lines.append("Classificacao operacional:")
+        lines.extend(operational_summary)
     if preview_lines:
         lines.append("")
         lines.append("Fila atual:")
@@ -108,11 +116,15 @@ def build_application_queue_message(repository: JobRepository) -> str:
 def build_application_preview_line(repository: JobRepository, application: JobApplication) -> str:
     job = repository.get_job(application.job_id)
     priority = extract_application_priority_level(application.notes)
+    operational = classify_application_operational_insight(application)
     if not job:
-        return f"{application.job_id}: vaga ausente [{application.status} | prioridade {priority}]"
+        return (
+            f"{application.job_id}: vaga ausente "
+            f"[{application.status} | prioridade {priority} | op={operational.reason_code}]"
+        )
     return (
         f"{job.id}: {job.title} - {job.company} "
-        f"[{application.status} | {application.support_level} | prioridade {priority}]"
+        f"[{application.status} | {application.support_level} | prioridade {priority} | op={operational.reason_code}]"
     )
 
 
@@ -122,6 +134,7 @@ def build_application_card_message(repository: JobRepository, application: JobAp
     requirement_summary = format_job_requirement_summary(extract_job_requirement_signals(application.notes))
     summarized_notes = summarize_application_notes(application.notes or "")
     operation_summary = summarize_application_operation(application)
+    operational = classify_application_operational_insight(application)
     if not job:
         return (
             f"Candidatura {application.id}\n"
@@ -129,6 +142,7 @@ def build_application_card_message(repository: JobRepository, application: JobAp
             f"Status: {application.status}\n"
             f"Suporte: {application.support_level}\n"
             f"Prioridade: {priority}\n"
+            f"Classificacao operacional: {operational.classification} | {operational.summary}\n"
             f"Sinais: {requirement_summary}\n"
             f"Racional: {application.support_rationale or 'Nao informado'}\n"
             f"Contexto: {summarized_notes}\n"
@@ -141,6 +155,7 @@ def build_application_card_message(repository: JobRepository, application: JobAp
         f"Status: {application.status}\n"
         f"Suporte: {application.support_level}\n"
         f"Prioridade: {priority}\n"
+        f"Classificacao operacional: {operational.classification} | {operational.summary}\n"
         f"Sinais: {requirement_summary}\n"
         f"Racional: {application.support_rationale or 'Nao informado'}\n"
         f"Contexto: {summarized_notes}\n"
@@ -197,3 +212,36 @@ def _sort_applications_by_priority(applications: list[JobApplication]) -> list[J
         key=lambda application: (priority_order.get(extract_application_priority_level(application.notes), 3), application.id),
     )
 
+
+def summarize_operational_classifications(applications: list[JobApplication]) -> list[str]:
+    if not applications:
+        return []
+    counts: dict[str, int] = {}
+    for application in applications:
+        insight = classify_application_operational_insight(application)
+        if insight.reason_code in {"sem_detalhe_operacional", "nao_classificado"}:
+            continue
+        counts[insight.reason_code] = counts.get(insight.reason_code, 0) + 1
+    if not counts:
+        return []
+    ordered_labels = (
+        ("pronto_para_envio", "pronto_para_envio"),
+        ("perguntas_adicionais", "perguntas_adicionais"),
+        ("similar_jobs", "similar_jobs"),
+        ("candidatura_externa", "candidatura_externa"),
+        ("vaga_expirada", "vaga_expirada"),
+        ("no_apply_cta", "no_apply_cta"),
+        ("fluxo_inconclusivo", "fluxo_inconclusivo"),
+        ("bloqueio_funcional", "bloqueio_funcional"),
+        ("submitted", "submitted"),
+    )
+    lines: list[str] = []
+    emitted: set[str] = set()
+    for key, label in ordered_labels:
+        if key in counts:
+            lines.append(f"- {label}={counts[key]}")
+            emitted.add(key)
+    for key in sorted(counts):
+        if key not in emitted:
+            lines.append(f"- {key}={counts[key]}")
+    return lines

--- a/job_hunter_agent/infrastructure/repository.py
+++ b/job_hunter_agent/infrastructure/repository.py
@@ -131,6 +131,9 @@ class JobRepository(Protocol):
     ) -> list[JobApplicationEvent]:
         raise NotImplementedError
 
+    def list_recent_application_events_since(self, since: str) -> list[JobApplicationEvent]:
+        raise NotImplementedError
+
     def get_collection_cursor(self, source_site: str, search_url: str) -> int:
         raise NotImplementedError
 
@@ -774,6 +777,19 @@ class SqliteJobRepository:
             params = (application_id, limit)
         with self._connect() as connection:
             rows = connection.execute(query, params).fetchall()
+        return [self._row_to_application_event(row) for row in rows]
+
+    def list_recent_application_events_since(self, since: str) -> list[JobApplicationEvent]:
+        with self._connect() as connection:
+            rows = connection.execute(
+                """
+                SELECT id, application_id, event_type, detail, from_status, to_status, created_at
+                FROM job_application_events
+                WHERE created_at >= ?
+                ORDER BY id ASC
+                """,
+                (since,),
+            ).fetchall()
         return [self._row_to_application_event(row) for row in rows]
 
     def get_collection_cursor(self, source_site: str, search_url: str) -> int:

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -403,6 +403,29 @@ class ApplicationCliTests(IsolatedAsyncioTestCase):
                     "cancelled": 0,
                 }
 
+            def list_applications_by_status(self, status: str):
+                if status == "authorized_submit":
+                    return [
+                        JobApplication(
+                            id=1,
+                            job_id=10,
+                            status="authorized_submit",
+                            support_level="manual_review",
+                            last_preflight_detail="preflight real | pronto_para_envio=sim | ok: fluxo pronto para submissao assistida no LinkedIn",
+                        )
+                    ]
+                if status == "error_submit":
+                    return [
+                        JobApplication(
+                            id=2,
+                            job_id=11,
+                            status="error_submit",
+                            support_level="manual_review",
+                            last_error="readiness=listing_redirect | motivo=a navegacao caiu em listagem ou colecao do LinkedIn | pagina=https://www.linkedin.com/jobs/collections/similar-jobs/",
+                        )
+                    ]
+                return []
+
         app = JobHunterApplication.__new__(JobHunterApplication)
         app.repository = _Repository()
 
@@ -412,6 +435,9 @@ class ApplicationCliTests(IsolatedAsyncioTestCase):
         self.assertIn("- approved=1", rendered)
         self.assertIn("- draft=1", rendered)
         self.assertIn("- confirmed=1", rendered)
+        self.assertIn("operacao:", rendered)
+        self.assertIn("- pronto_para_envio=1", rendered)
+        self.assertIn("- similar_jobs=1", rendered)
 
     async def test_create_application_draft_for_job_creates_draft_for_approved_job(self) -> None:
         class _Repository:
@@ -560,6 +586,7 @@ class ApplicationCliTests(IsolatedAsyncioTestCase):
                             job_id=10,
                             status="confirmed",
                             support_level="manual_review",
+                            last_preflight_detail="preflight real inconclusivo | perguntas_pendentes=ha quantos anos voce usa java?",
                         )
                     ]
                 return []
@@ -575,6 +602,7 @@ class ApplicationCliTests(IsolatedAsyncioTestCase):
         self.assertIn("Candidaturas listadas: 1", rendered)
         self.assertIn("2: confirmed", rendered)
         self.assertIn("Backend Java | ACME", rendered)
+        self.assertIn("op=perguntas_adicionais", rendered)
 
     async def test_list_applications_supports_ready_alias_from_cli_mapping(self) -> None:
         class _Repository:

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -426,6 +426,24 @@ class ApplicationCliTests(IsolatedAsyncioTestCase):
                     ]
                 return []
 
+            def list_recent_application_events_since(self, since: str):
+                return [
+                    JobApplicationEvent(
+                        id=1,
+                        application_id=1,
+                        event_type="preflight_ready",
+                        detail="preflight real | pronto_para_envio=sim | ok: fluxo pronto para submissao assistida no LinkedIn",
+                        created_at="2026-04-08T10:00:00",
+                    ),
+                    JobApplicationEvent(
+                        id=2,
+                        application_id=2,
+                        event_type="submit_error",
+                        detail="readiness=listing_redirect | motivo=a navegacao caiu em listagem ou colecao do LinkedIn | pagina=https://www.linkedin.com/jobs/collections/similar-jobs/",
+                        created_at="2026-04-08T10:01:00",
+                    ),
+                ]
+
         app = JobHunterApplication.__new__(JobHunterApplication)
         app.repository = _Repository()
 
@@ -438,6 +456,51 @@ class ApplicationCliTests(IsolatedAsyncioTestCase):
         self.assertIn("operacao:", rendered)
         self.assertIn("- pronto_para_envio=1", rendered)
         self.assertIn("- similar_jobs=1", rendered)
+
+    async def test_build_execution_summary_renders_preflights_submits_and_block_counts(self) -> None:
+        class _Repository:
+            def list_recent_application_events_since(self, since: str):
+                return [
+                    JobApplicationEvent(
+                        id=1,
+                        application_id=1,
+                        event_type="preflight_ready",
+                        detail="preflight real | pronto_para_envio=sim | ok: fluxo pronto para submissao assistida no LinkedIn",
+                        created_at="2026-04-08T10:00:00",
+                    ),
+                    JobApplicationEvent(
+                        id=2,
+                        application_id=2,
+                        event_type="preflight_blocked",
+                        detail="readiness=no_apply_cta | motivo=a vaga so oferece candidatura externa no site da empresa",
+                        created_at="2026-04-08T10:01:00",
+                    ),
+                    JobApplicationEvent(
+                        id=3,
+                        application_id=3,
+                        event_type="submit_error",
+                        detail="readiness=listing_redirect | motivo=a navegacao caiu em listagem ou colecao do LinkedIn | pagina=https://www.linkedin.com/jobs/collections/similar-jobs/",
+                        created_at="2026-04-08T10:02:00",
+                    ),
+                    JobApplicationEvent(
+                        id=4,
+                        application_id=4,
+                        event_type="submit_submitted",
+                        detail="submissao real concluida no LinkedIn",
+                        created_at="2026-04-08T10:03:00",
+                    ),
+                ]
+
+        app = JobHunterApplication.__new__(JobHunterApplication)
+        app.repository = _Repository()
+
+        rendered = app.build_execution_summary("2026-04-08T09:59:00")
+
+        self.assertIn("Execucao operacional:", rendered)
+        self.assertIn("- preflights_concluidos=2", rendered)
+        self.assertIn("- submits_concluidos=2", rendered)
+        self.assertIn("candidatura_externa=1", rendered)
+        self.assertIn("similar_jobs=1", rendered)
 
     async def test_create_application_draft_for_job_creates_draft_for_approved_job(self) -> None:
         class _Repository:

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -8,6 +8,9 @@ from unittest import IsolatedAsyncioTestCase
 from job_hunter_agent.application.app import JobHunterApplication, parse_args, suggest_candidate_profile
 from job_hunter_agent.application.composition import (
     build_known_job_lookup,
+    create_application_preflight_service,
+    create_application_submission_service,
+    create_linkedin_application_flow_inspector,
     create_linkedin_modal_interpreter,
     create_linkedin_modal_interpretation_formatter,
     create_notifier,
@@ -1049,3 +1052,182 @@ class CompositionTests(IsolatedAsyncioTestCase):
 
         self.assertEqual(interpreted.recommended_action, "submit_if_authorized")
         self.assertGreater(interpreted.confidence, 0.8)
+
+    async def test_create_linkedin_application_flow_inspector_preflight_uses_formatter_only(self) -> None:
+        settings = type(
+            "Settings",
+            (),
+            {
+                "linkedin_storage_state_path": "linkedin-state.json",
+                "browser_headless": True,
+                "resume_path": "resume.pdf",
+                "application_contact_email": "vinicius@example.com",
+                "application_phone": "11999999999",
+                "application_phone_country_code": "55",
+                "candidate_profile_path": "candidate_profile.json",
+                "save_failure_artifacts": True,
+                "failure_artifacts_dir": ".tmp-tests/failure-artifacts",
+            },
+        )()
+
+        candidate_profile = object()
+        formatter = object()
+
+        with patch(
+            "job_hunter_agent.application.composition.load_candidate_profile",
+            return_value=candidate_profile,
+        ) as load_profile, patch(
+            "job_hunter_agent.application.composition.create_linkedin_modal_interpretation_formatter",
+            return_value=formatter,
+        ) as create_formatter, patch(
+            "job_hunter_agent.application.composition.create_linkedin_modal_interpreter"
+        ) as create_interpreter, patch(
+            "job_hunter_agent.application.composition.LinkedInApplicationFlowInspector",
+            return_value="inspector-preflight",
+        ) as inspector_factory:
+            inspector = create_linkedin_application_flow_inspector(settings, mode="preflight")
+
+        self.assertEqual(inspector, "inspector-preflight")
+        load_profile.assert_called_once_with("candidate_profile.json")
+        create_formatter.assert_called_once_with(settings)
+        create_interpreter.assert_not_called()
+        inspector_factory.assert_called_once_with(
+            storage_state_path="linkedin-state.json",
+            headless=True,
+            resume_path="resume.pdf",
+            contact_email="vinicius@example.com",
+            phone="11999999999",
+            phone_country_code="55",
+            candidate_profile=candidate_profile,
+            candidate_profile_path="candidate_profile.json",
+            save_failure_artifacts=True,
+            failure_artifacts_dir=".tmp-tests/failure-artifacts",
+            modal_interpretation_formatter=formatter,
+        )
+
+    async def test_create_linkedin_application_flow_inspector_submit_uses_interpreter_only(self) -> None:
+        settings = type(
+            "Settings",
+            (),
+            {
+                "linkedin_storage_state_path": "linkedin-state.json",
+                "browser_headless": False,
+                "resume_path": "resume.pdf",
+                "application_contact_email": "vinicius@example.com",
+                "application_phone": "11999999999",
+                "application_phone_country_code": "55",
+                "candidate_profile_path": "candidate_profile.json",
+                "save_failure_artifacts": False,
+                "failure_artifacts_dir": ".tmp-tests/failure-artifacts",
+            },
+        )()
+
+        candidate_profile = object()
+        interpreter = object()
+
+        with patch(
+            "job_hunter_agent.application.composition.load_candidate_profile",
+            return_value=candidate_profile,
+        ) as load_profile, patch(
+            "job_hunter_agent.application.composition.create_linkedin_modal_interpretation_formatter"
+        ) as create_formatter, patch(
+            "job_hunter_agent.application.composition.create_linkedin_modal_interpreter",
+            return_value=interpreter,
+        ) as create_interpreter, patch(
+            "job_hunter_agent.application.composition.LinkedInApplicationFlowInspector",
+            return_value="inspector-submit",
+        ) as inspector_factory:
+            inspector = create_linkedin_application_flow_inspector(settings, mode="submit")
+
+        self.assertEqual(inspector, "inspector-submit")
+        load_profile.assert_called_once_with("candidate_profile.json")
+        create_formatter.assert_not_called()
+        create_interpreter.assert_called_once_with(settings)
+        inspector_factory.assert_called_once_with(
+            storage_state_path="linkedin-state.json",
+            headless=False,
+            resume_path="resume.pdf",
+            contact_email="vinicius@example.com",
+            phone="11999999999",
+            phone_country_code="55",
+            candidate_profile=candidate_profile,
+            candidate_profile_path="candidate_profile.json",
+            save_failure_artifacts=False,
+            failure_artifacts_dir=".tmp-tests/failure-artifacts",
+            modal_interpreter=interpreter,
+        )
+
+    async def test_create_linkedin_application_flow_inspector_rejects_unsupported_mode(self) -> None:
+        settings = type(
+            "Settings",
+            (),
+            {
+                "linkedin_storage_state_path": "linkedin-state.json",
+                "browser_headless": True,
+                "resume_path": "resume.pdf",
+                "application_contact_email": "vinicius@example.com",
+                "application_phone": "11999999999",
+                "application_phone_country_code": "55",
+                "candidate_profile_path": "candidate_profile.json",
+                "save_failure_artifacts": False,
+                "failure_artifacts_dir": ".tmp-tests/failure-artifacts",
+            },
+        )()
+
+        with patch(
+            "job_hunter_agent.application.composition.load_candidate_profile",
+            return_value=object(),
+        ):
+            with self.assertRaisesRegex(ValueError, "modo de inspector do LinkedIn nao suportado"):
+                create_linkedin_application_flow_inspector(settings, mode="unknown")
+
+    async def test_create_application_preflight_service_uses_preflight_mode(self) -> None:
+        repository = object()
+        settings = object()
+
+        with patch(
+            "job_hunter_agent.application.composition.create_linkedin_application_flow_inspector",
+            return_value="preflight-inspector",
+        ) as create_inspector:
+            service = create_application_preflight_service(repository, settings)
+
+        create_inspector.assert_called_once_with(settings, mode="preflight")
+        self.assertIs(service.repository, repository)
+        self.assertEqual(service.flow_inspector, "preflight-inspector")
+
+    async def test_create_application_submission_service_uses_submit_mode_and_readiness_checker(self) -> None:
+        repository = object()
+        settings = type(
+            "Settings",
+            (),
+            {
+                "linkedin_storage_state_path": "linkedin-state.json",
+                "resume_path": "resume.pdf",
+                "application_contact_email": "vinicius@example.com",
+                "application_phone": "11999999999",
+                "application_phone_country_code": "55",
+            },
+        )()
+
+        readiness_checker = object()
+
+        with patch(
+            "job_hunter_agent.application.composition.create_linkedin_application_flow_inspector",
+            return_value="submit-inspector",
+        ) as create_inspector, patch(
+            "job_hunter_agent.application.composition.ApplicationReadinessCheckService",
+            return_value=readiness_checker,
+        ) as readiness_factory:
+            service = create_application_submission_service(repository, settings)
+
+        create_inspector.assert_called_once_with(settings, mode="submit")
+        readiness_factory.assert_called_once_with(
+            linkedin_storage_state_path="linkedin-state.json",
+            resume_path="resume.pdf",
+            contact_email="vinicius@example.com",
+            phone="11999999999",
+            phone_country_code="55",
+        )
+        self.assertIs(service.repository, repository)
+        self.assertEqual(service.applicant, "submit-inspector")
+        self.assertIs(service.readiness_checker, readiness_checker)

--- a/tests/test_applicant_contracts.py
+++ b/tests/test_applicant_contracts.py
@@ -1,0 +1,50 @@
+import unittest
+
+from job_hunter_agent.application.applicant import (
+    normalize_application_flow_inspection,
+    normalize_application_submission_result,
+)
+
+
+class ApplicantContractTests(unittest.TestCase):
+    def test_normalize_application_flow_inspection_accepts_structural_result(self) -> None:
+        result = normalize_application_flow_inspection(
+            type("Inspection", (), {"outcome": "ready", "detail": "preflight real ok"})()
+        )
+
+        self.assertEqual(result.outcome, "ready")
+        self.assertEqual(result.detail, "preflight real ok")
+
+    def test_normalize_application_flow_inspection_rejects_invalid_outcome(self) -> None:
+        result = normalize_application_flow_inspection(
+            type("Inspection", (), {"outcome": "weird", "detail": "abc"})()
+        )
+
+        self.assertEqual(result.outcome, "error")
+        self.assertIn("outcome invalido", result.detail)
+
+    def test_normalize_application_submission_result_accepts_structural_result(self) -> None:
+        result = normalize_application_submission_result(
+            type(
+                "SubmitResult",
+                (),
+                {
+                    "status": "submitted",
+                    "detail": "submissao real concluida",
+                    "submitted_at": "2026-04-05T10:00:00",
+                    "external_reference": "abc",
+                },
+            )()
+        )
+
+        self.assertEqual(result.status, "submitted")
+        self.assertEqual(result.submitted_at, "2026-04-05T10:00:00")
+        self.assertEqual(result.external_reference, "abc")
+
+    def test_normalize_application_submission_result_rejects_empty_detail(self) -> None:
+        result = normalize_application_submission_result(
+            type("SubmitResult", (), {"status": "submitted", "detail": ""})()
+        )
+
+        self.assertEqual(result.status, "error_submit")
+        self.assertIn("detail vazio", result.detail)

--- a/tests/test_application_insights.py
+++ b/tests/test_application_insights.py
@@ -1,6 +1,9 @@
 from unittest import TestCase
 
-from job_hunter_agent.core.application_insights import classify_application_operational_insight
+from job_hunter_agent.core.application_insights import (
+    classify_application_operational_insight,
+    classify_operational_detail,
+)
 from job_hunter_agent.core.domain import JobApplication
 
 
@@ -43,3 +46,11 @@ class ApplicationOperationalInsightsTests(TestCase):
 
         self.assertEqual(insight.classification, "ready")
         self.assertEqual(insight.reason_code, "pronto_para_envio")
+
+    def test_classify_operational_detail_handles_external_apply(self) -> None:
+        insight = classify_operational_detail(
+            "readiness=no_apply_cta | motivo=a vaga so oferece candidatura externa no site da empresa"
+        )
+
+        self.assertEqual(insight.classification, "blocked")
+        self.assertEqual(insight.reason_code, "candidatura_externa")

--- a/tests/test_application_insights.py
+++ b/tests/test_application_insights.py
@@ -1,0 +1,45 @@
+from unittest import TestCase
+
+from job_hunter_agent.core.application_insights import classify_application_operational_insight
+from job_hunter_agent.core.domain import JobApplication
+
+
+class ApplicationOperationalInsightsTests(TestCase):
+    def test_classifies_similar_jobs_as_blocked(self) -> None:
+        application = JobApplication(
+            id=1,
+            job_id=10,
+            status="error_submit",
+            last_error="readiness=listing_redirect | motivo=a navegacao caiu em listagem ou colecao do LinkedIn | pagina=https://www.linkedin.com/jobs/collections/similar-jobs/",
+        )
+
+        insight = classify_application_operational_insight(application)
+
+        self.assertEqual(insight.classification, "blocked")
+        self.assertEqual(insight.reason_code, "similar_jobs")
+
+    def test_classifies_unanswered_questions_as_manual_review(self) -> None:
+        application = JobApplication(
+            id=1,
+            job_id=10,
+            status="error_submit",
+            last_error="submissao real bloqueada: fluxo nao chegou ao botao de envio | bloqueio=perguntas_obrigatorias, etapa_intermediaria | perguntas_pendentes=ha quantos anos voce usa java?",
+        )
+
+        insight = classify_application_operational_insight(application)
+
+        self.assertEqual(insight.classification, "manual_review")
+        self.assertEqual(insight.reason_code, "perguntas_adicionais")
+
+    def test_classifies_ready_state(self) -> None:
+        application = JobApplication(
+            id=1,
+            job_id=10,
+            status="confirmed",
+            last_preflight_detail="preflight real | preenchidos=email, telefone | revisao_final_alcancada=sim | pronto_para_envio=sim | ok: fluxo pronto para submissao assistida no LinkedIn",
+        )
+
+        insight = classify_application_operational_insight(application)
+
+        self.assertEqual(insight.classification, "ready")
+        self.assertEqual(insight.reason_code, "pronto_para_envio")

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -650,6 +650,25 @@ class SqliteJobRepositoryTests(unittest.TestCase):
         self.assertEqual(latest_event.event_type, "preflight_ready")
         self.assertIn("preflight real ok", latest_event.detail)
 
+    def test_preflight_preserves_support_snapshot(self) -> None:
+        saved = self.repository.save_new_jobs([sample_job("https://www.linkedin.com/jobs/view/123", "key-1")])[0]
+        application = self.repository.create_application_draft(
+            saved.id,
+            support_level="manual_review",
+            support_rationale="snapshot inicial de suporte",
+        )
+        self.repository.mark_application_status(application.id, status="confirmed")
+
+        class _Inspector:
+            def inspect(self, job):
+                return type("Inspection", (), {"outcome": "ready", "detail": "preflight real ok: CTA encontrado"})()
+
+        ApplicationPreflightService(self.repository, flow_inspector=_Inspector()).run_for_application(application.id)
+        stored = self.repository.get_application(application.id)
+
+        self.assertEqual(stored.support_level, "manual_review")
+        self.assertEqual(stored.support_rationale, "snapshot inicial de suporte")
+
     def test_application_submission_requires_authorized_status(self) -> None:
         saved = self.repository.save_new_jobs([sample_job("https://www.linkedin.com/jobs/view/123", "key-1")])[0]
         application = self.repository.create_application_draft(
@@ -699,6 +718,31 @@ class SqliteJobRepositoryTests(unittest.TestCase):
         latest_event = self.repository.list_application_events(application.id, limit=1)[0]
         self.assertEqual(latest_event.event_type, "submit_submitted")
         self.assertIn("submissao real concluida", latest_event.detail)
+
+    def test_submit_preserves_support_snapshot(self) -> None:
+        class _Applicant:
+            def submit(self, application, job):
+                from job_hunter_agent.application.applicant import ApplicationSubmissionResult
+
+                return ApplicationSubmissionResult(
+                    status="submitted",
+                    detail="submissao real concluida",
+                    submitted_at="2026-04-05T10:00:00",
+                )
+
+        saved = self.repository.save_new_jobs([sample_job("https://www.linkedin.com/jobs/view/123", "key-1")])[0]
+        application = self.repository.create_application_draft(
+            saved.id,
+            support_level="manual_review",
+            support_rationale="snapshot inicial de suporte",
+        )
+        self.repository.mark_application_status(application.id, status="authorized_submit")
+
+        ApplicationSubmissionService(self.repository, applicant=_Applicant()).run_for_application(application.id)
+        stored = self.repository.get_application(application.id)
+
+        self.assertEqual(stored.support_level, "manual_review")
+        self.assertEqual(stored.support_rationale, "snapshot inicial de suporte")
 
     def test_application_submission_keeps_authorized_when_readiness_is_incomplete(self) -> None:
         class _Applicant:

--- a/tests/test_linkedin_application.py
+++ b/tests/test_linkedin_application.py
@@ -620,6 +620,10 @@ class LinkedInApplicationInspectorTests(unittest.TestCase):
         meta_files = list(Path(tmp).glob("*_meta.json"))
         self.assertEqual(len(meta_files), 1)
         payload = json.loads(meta_files[0].read_text(encoding="utf-8"))
+        self.assertEqual(payload["artifact_schema_version"], 1)
+        self.assertEqual(payload["artifact_type"], "submit")
+        self.assertTrue(payload["artifact_id"].startswith("submit-job-123-"))
+        self.assertEqual(payload["detail_slug"], "pagina-fechada")
         self.assertTrue(payload["page_closed"])
         self.assertEqual(payload["files"]["html"], "")
         self.assertEqual(payload["files"]["screenshot"], "")
@@ -662,6 +666,13 @@ class LinkedInApplicationInspectorTests(unittest.TestCase):
         self.assertEqual(result.status, "error_submit")
         self.assertIn("erro inesperado: boom", result.detail)
         self.assertIn("artefatos=", result.detail)
+        meta_files = list(Path(tmp).glob("*_meta.json"))
+        self.assertEqual(len(meta_files), 1)
+        payload = json.loads(meta_files[0].read_text(encoding="utf-8"))
+        self.assertEqual(payload["artifact_schema_version"], 1)
+        self.assertEqual(payload["detail_slug"], "submissao-real-falhou-com-erro-inesperado-boom")
+        self.assertTrue(payload["files"]["html"].endswith("_dom.html"))
+        self.assertTrue(payload["files"]["screenshot"].endswith("_screenshot.png"))
 
     def test_build_submit_exception_result_reports_closed_page_with_artifact_metadata(self) -> None:
         class _ClosedPage:

--- a/tests/test_linkedin_application_artifacts.py
+++ b/tests/test_linkedin_application_artifacts.py
@@ -1,0 +1,88 @@
+import json
+from pathlib import Path
+import unittest
+
+from job_hunter_agent.collectors.linkedin_application_artifacts import LinkedInFailureArtifactCapture
+from job_hunter_agent.collectors.linkedin_application_state import LinkedInApplicationPageState
+from tests.tmp_workspace import prepare_workspace_tmp_dir
+
+
+class LinkedInFailureArtifactCaptureTests(unittest.TestCase):
+    def test_capture_writes_html_and_metadata(self) -> None:
+        class _Page:
+            def is_closed(self):
+                return False
+
+            async def content(self):
+                return "<html><body>teste</body></html>"
+
+            async def screenshot(self, path, full_page):
+                Path(path).write_bytes(b"fake-png")
+
+        class _Job:
+            id = 999
+            title = "Backend Engineer"
+            url = "https://www.linkedin.com/jobs/view/999/"
+
+        tmp = prepare_workspace_tmp_dir("linkedin-artifacts-service")
+        capture = LinkedInFailureArtifactCapture(enabled=True, artifacts_dir=tmp)
+
+        import asyncio
+
+        detail = asyncio.run(
+            capture.capture(
+                _Page(),
+                state=LinkedInApplicationPageState(
+                    easy_apply=True,
+                    modal_open=False,
+                    cta_text="candidatura simplificada",
+                ),
+                job=_Job(),
+                phase="submit",
+                detail="falha de teste",
+            )
+        )
+
+        files = list(Path(tmp).iterdir())
+        self.assertTrue(any(path.suffix == ".html" for path in files))
+        self.assertTrue(any(path.suffix == ".json" for path in files))
+        self.assertTrue(any(path.suffix == ".png" for path in files))
+        self.assertIn("artefatos=", detail)
+
+    def test_build_submit_exception_result_reports_closed_page_with_artifact_metadata(self) -> None:
+        class _ClosedPage:
+            def is_closed(self):
+                return True
+
+            async def content(self):
+                raise RuntimeError("Target page, context or browser has been closed")
+
+            async def screenshot(self, path, full_page):
+                raise RuntimeError("Target page, context or browser has been closed")
+
+        class _Job:
+            id = 654
+            title = "Backend Engineer"
+            url = "https://www.linkedin.com/jobs/view/654/"
+
+        tmp = prepare_workspace_tmp_dir("linkedin-artifacts-service-closed")
+        capture = LinkedInFailureArtifactCapture(enabled=True, artifacts_dir=tmp)
+
+        import asyncio
+
+        result = asyncio.run(
+            capture.build_submit_exception_result(
+                RuntimeError("Page.evaluate: Target page, context or browser has been closed"),
+                page=_ClosedPage(),
+                state=LinkedInApplicationPageState(modal_open=True),
+                job=_Job(),
+            )
+        )
+
+        self.assertEqual(result.status, "error_submit")
+        self.assertIn("pagina do LinkedIn foi fechada", result.detail)
+        self.assertIn("artefatos=", result.detail)
+        meta_files = list(Path(tmp).glob("*_meta.json"))
+        self.assertEqual(len(meta_files), 1)
+        payload = json.loads(meta_files[0].read_text(encoding="utf-8"))
+        self.assertTrue(payload["page_closed"])

--- a/tests/test_linkedin_application_entrypoint.py
+++ b/tests/test_linkedin_application_entrypoint.py
@@ -1,0 +1,106 @@
+import unittest
+
+from job_hunter_agent.collectors.linkedin_application_entrypoint import (
+    build_linkedin_direct_apply_url,
+    canonical_linkedin_job_url,
+    classify_linkedin_job_page_readiness,
+    extract_linkedin_job_id,
+    needs_canonical_job_navigation,
+    recover_linkedin_direct_apply_url_from_html,
+)
+from job_hunter_agent.collectors.linkedin_application_state import LinkedInApplicationPageState
+
+
+class LinkedInApplicationEntrypointTests(unittest.TestCase):
+    def test_extract_linkedin_job_id_reads_view_route(self) -> None:
+        self.assertEqual(
+            extract_linkedin_job_id("https://www.linkedin.com/jobs/view/4390058075/?refId=abc"),
+            "4390058075",
+        )
+
+    def test_extract_linkedin_job_id_reads_current_job_id_from_listing_query(self) -> None:
+        self.assertEqual(
+            extract_linkedin_job_id(
+                "https://www.linkedin.com/jobs/collections/similar-jobs/?currentJobId=4391593841&referenceJobId=4390058075"
+            ),
+            "4391593841",
+        )
+
+    def test_canonical_linkedin_job_url_removes_tracking_query(self) -> None:
+        self.assertEqual(
+            canonical_linkedin_job_url(
+                "https://www.linkedin.com/jobs/view/4390058075/?refId=abc&trackingId=def"
+            ),
+            "https://www.linkedin.com/jobs/view/4390058075/",
+        )
+
+    def test_build_linkedin_direct_apply_url_uses_target_job_id(self) -> None:
+        self.assertEqual(
+            build_linkedin_direct_apply_url("https://www.linkedin.com/jobs/view/4389607214/"),
+            "https://www.linkedin.com/jobs/view/4389607214/apply/?openSDUIApplyFlow=true",
+        )
+
+    def test_needs_canonical_job_navigation_on_similar_jobs_page(self) -> None:
+        self.assertTrue(
+            needs_canonical_job_navigation(
+                "https://www.linkedin.com/jobs/collections/similar-jobs/?currentJobId=4391593841&referenceJobId=4390058075",
+                "https://www.linkedin.com/jobs/view/4390058075/",
+            )
+        )
+
+    def test_needs_canonical_job_navigation_is_false_for_apply_flow_of_same_job(self) -> None:
+        self.assertFalse(
+            needs_canonical_job_navigation(
+                "https://www.linkedin.com/jobs/view/4390058075/apply/?openSDUIApplyFlow=true",
+                "https://www.linkedin.com/jobs/view/4390058075/",
+            )
+        )
+
+    def test_classify_linkedin_job_page_readiness_marks_similar_jobs_as_listing_redirect(self) -> None:
+        readiness = classify_linkedin_job_page_readiness(
+            job_url="https://www.linkedin.com/jobs/view/4390058075/",
+            state=LinkedInApplicationPageState(
+                current_url="https://www.linkedin.com/jobs/collections/similar-jobs/?currentJobId=4391593841&referenceJobId=4390058075",
+                sample="https://www.linkedin.com/jobs/collections/similar-jobs/?currentJobId=4391593841 | vaga parecida",
+            ),
+        )
+
+        self.assertEqual(readiness.result, "listing_redirect")
+        self.assertIn("colecao", readiness.reason)
+
+    def test_classify_linkedin_job_page_readiness_marks_external_only_apply_as_no_apply_cta(self) -> None:
+        readiness = classify_linkedin_job_page_readiness(
+            job_url="https://www.linkedin.com/jobs/view/4390058075/",
+            state=LinkedInApplicationPageState(
+                current_url="https://www.linkedin.com/jobs/view/4390058075/",
+                external_apply=True,
+                sample="https://www.linkedin.com/jobs/view/4390058075/ | candidatar-se no site da empresa",
+            ),
+        )
+
+        self.assertEqual(readiness.result, "no_apply_cta")
+        self.assertIn("candidatura externa", readiness.reason)
+
+    def test_recover_linkedin_direct_apply_url_from_html_uses_hidden_internal_apply_metadata(self) -> None:
+        apply_url = recover_linkedin_direct_apply_url_from_html(
+            """
+            <html><body>
+            <code>{"onsiteApply":true,"applyCtaText":{"text":"Candidatura simplificada"},"companyApplyUrl":"https://www.linkedin.com/job-apply/4389607214"}</code>
+            </body></html>
+            """,
+            "https://www.linkedin.com/jobs/view/4389607214/",
+        )
+
+        self.assertEqual(
+            apply_url,
+            "https://www.linkedin.com/jobs/view/4389607214/apply/?openSDUIApplyFlow=true",
+        )
+
+    def test_recover_linkedin_direct_apply_url_from_html_returns_empty_without_internal_signal(self) -> None:
+        self.assertEqual(
+            recover_linkedin_direct_apply_url_from_html(
+                "<html><body>sem metadata de candidatura</body></html>",
+                "https://www.linkedin.com/jobs/view/4389607214/",
+            ),
+            "",
+        )

--- a/tests/test_linkedin_application_fields.py
+++ b/tests/test_linkedin_application_fields.py
@@ -1,0 +1,79 @@
+from pathlib import Path
+import unittest
+
+from job_hunter_agent.collectors.linkedin_application_fields import LinkedInEasyApplyFieldFiller
+from job_hunter_agent.collectors.linkedin_application_state import LinkedInApplicationPageState
+from job_hunter_agent.core.candidate_profile import CandidateProfile
+from tests.tmp_workspace import prepare_workspace_tmp_dir
+
+
+class LinkedInApplicationFieldsTests(unittest.TestCase):
+    def test_try_fill_safe_fields_returns_filled_field_names(self) -> None:
+        class _Locator:
+            async def count(self):
+                return 1
+
+        class _Page:
+            def locator(self, selector):
+                return _Locator()
+
+            async def evaluate(self, script, payload):
+                return ["email", "telefone", "codigo_pais"]
+
+        filler = LinkedInEasyApplyFieldFiller(
+            contact_email="vinicius@example.com",
+            phone="11999999999",
+            phone_country_code="+55",
+        )
+
+        import asyncio
+
+        filled = asyncio.run(filler.try_fill_safe_fields(_Page()))
+
+        self.assertEqual(filled, ("email", "telefone", "codigo_pais"))
+
+    def test_try_fill_supported_profile_answers_returns_answered_and_unresolved(self) -> None:
+        class _Page:
+            async def evaluate(self, script, answers):
+                return ["ha quantos anos voce usa java?"]
+
+        filler = LinkedInEasyApplyFieldFiller(
+            contact_email="",
+            phone="",
+            phone_country_code="",
+            candidate_profile=CandidateProfile(confirmed_experience_years={"java": 5}),
+        )
+
+        import asyncio
+
+        answered, unresolved = asyncio.run(
+            filler.try_fill_supported_profile_answers(
+                _Page(),
+                LinkedInApplicationPageState(
+                    modal_questions=(
+                        "ha quantos anos voce usa java?",
+                        "ha quantos anos voce usa cobol?",
+                    )
+                ),
+            )
+        )
+
+        self.assertEqual(answered, ("ha quantos anos voce usa java?",))
+        self.assertIn("ha quantos anos voce usa cobol?", unresolved)
+
+    def test_record_pending_questions_persists_when_profile_path_exists(self) -> None:
+        tmp = Path(prepare_workspace_tmp_dir("linkedin-fields-profile"))
+        profile_path = tmp / "candidate_profile.json"
+        profile_path.write_text('{"name":"Vinicius"}', encoding="utf-8")
+
+        filler = LinkedInEasyApplyFieldFiller(
+            contact_email="",
+            phone="",
+            phone_country_code="",
+            candidate_profile_path=profile_path,
+        )
+
+        filler.record_pending_questions(("pergunta x",))
+
+        content = profile_path.read_text(encoding="utf-8")
+        self.assertIn("pergunta x", content)

--- a/tests/test_linkedin_application_opening.py
+++ b/tests/test_linkedin_application_opening.py
@@ -1,0 +1,220 @@
+import unittest
+
+from job_hunter_agent.collectors.linkedin_application_opening import LinkedInEasyApplyFlowOpener
+from job_hunter_agent.collectors.linkedin_application_state import (
+    LinkedInApplicationPageState,
+    LinkedInJobPageReadiness,
+)
+
+
+class LinkedInEasyApplyFlowOpenerTests(unittest.TestCase):
+    def _build_opener(
+        self,
+        *,
+        prepare_job_page_for_apply,
+        read_page_state,
+        assess_job_page_readiness,
+        extract_easy_apply_href,
+        inspect_easy_apply_modal,
+        is_page_closed,
+    ) -> LinkedInEasyApplyFlowOpener:
+        return LinkedInEasyApplyFlowOpener(
+            prepare_job_page_for_apply=prepare_job_page_for_apply,
+            read_page_state=read_page_state,
+            assess_job_page_readiness=assess_job_page_readiness,
+            extract_easy_apply_href=extract_easy_apply_href,
+            inspect_easy_apply_modal=inspect_easy_apply_modal,
+            is_page_closed=is_page_closed,
+        )
+
+    def test_try_open_easy_apply_via_direct_url_reads_apply_route_when_modal_does_not_open(self) -> None:
+        class _Page:
+            def __init__(self):
+                self.navigated_to = ""
+
+            async def goto(self, url, wait_until="domcontentloaded"):
+                self.navigated_to = url
+
+            async def wait_for_timeout(self, timeout):
+                return None
+
+        async def fake_extract(page):
+            return "https://www.linkedin.com/jobs/view/123/apply/?openSDUIApplyFlow=true"
+
+        async def fake_prepare(page):
+            return None
+
+        async def fake_read(page):
+            return LinkedInApplicationPageState(
+                current_url="https://www.linkedin.com/jobs/view/123/apply/?openSDUIApplyFlow=true",
+                easy_apply=True,
+                modal_open=False,
+            )
+
+        async def fake_inspect(page, initial_state, close_modal):
+            return initial_state
+
+        opener = self._build_opener(
+            prepare_job_page_for_apply=fake_prepare,
+            read_page_state=fake_read,
+            assess_job_page_readiness=lambda job, state: LinkedInJobPageReadiness("ready", "ok", state.sample),
+            extract_easy_apply_href=fake_extract,
+            inspect_easy_apply_modal=fake_inspect,
+            is_page_closed=lambda page: False,
+        )
+
+        import asyncio
+
+        page = _Page()
+        state = asyncio.run(opener.try_open_easy_apply_via_direct_url(page, close_modal=False))
+
+        self.assertEqual(page.navigated_to, "https://www.linkedin.com/jobs/view/123/apply/?openSDUIApplyFlow=true")
+        self.assertTrue(state.easy_apply)
+
+    def test_try_open_easy_apply_via_direct_url_inspects_modal_when_route_opens_dialog(self) -> None:
+        class _Page:
+            async def goto(self, url, wait_until="domcontentloaded"):
+                return None
+
+            async def wait_for_timeout(self, timeout):
+                return None
+
+        async def fake_extract(page):
+            return "https://www.linkedin.com/jobs/view/123/apply/?openSDUIApplyFlow=true"
+
+        async def fake_prepare(page):
+            return None
+
+        async def fake_read(page):
+            return LinkedInApplicationPageState(
+                current_url="https://www.linkedin.com/jobs/view/123/apply/?openSDUIApplyFlow=true",
+                easy_apply=True,
+                modal_open=True,
+            )
+
+        async def fake_inspect(page, initial_state, close_modal):
+            return LinkedInApplicationPageState(
+                **{**initial_state.__dict__, "ready_to_submit": True}
+            )
+
+        opener = self._build_opener(
+            prepare_job_page_for_apply=fake_prepare,
+            read_page_state=fake_read,
+            assess_job_page_readiness=lambda job, state: LinkedInJobPageReadiness("ready", "ok", state.sample),
+            extract_easy_apply_href=fake_extract,
+            inspect_easy_apply_modal=fake_inspect,
+            is_page_closed=lambda page: False,
+        )
+
+        import asyncio
+
+        state = asyncio.run(opener.try_open_easy_apply_via_direct_url(_Page(), close_modal=False))
+
+        self.assertTrue(state.modal_open)
+        self.assertTrue(state.ready_to_submit)
+
+    def test_recover_easy_apply_from_page_html_uses_hidden_internal_apply_metadata(self) -> None:
+        class _Page:
+            def __init__(self):
+                self.navigated_to = ""
+
+            async def content(self):
+                return """
+                <html><body>
+                <code>{"onsiteApply":true,"applyCtaText":{"text":"Candidatura simplificada"},"companyApplyUrl":"https://www.linkedin.com/job-apply/4389607214"}</code>
+                </body></html>
+                """
+
+            async def goto(self, url, wait_until="domcontentloaded"):
+                self.navigated_to = url
+
+            async def wait_for_timeout(self, timeout):
+                return None
+
+        opener = self._build_opener(
+            prepare_job_page_for_apply=lambda page: None,
+            read_page_state=lambda page: None,
+            assess_job_page_readiness=lambda job, state: LinkedInJobPageReadiness("ready", "ok", state.sample),
+            extract_easy_apply_href=lambda page: "",
+            inspect_easy_apply_modal=lambda page, initial_state, close_modal: initial_state,
+            is_page_closed=lambda page: False,
+        )
+
+        import asyncio
+
+        page = _Page()
+        recovered = asyncio.run(
+            opener.recover_easy_apply_from_page_html(
+                page,
+                type("Job", (), {"url": "https://www.linkedin.com/jobs/view/4389607214/"})(),
+            )
+        )
+
+        self.assertTrue(recovered)
+        self.assertEqual(
+            page.navigated_to,
+            "https://www.linkedin.com/jobs/view/4389607214/apply/?openSDUIApplyFlow=true",
+        )
+
+    def test_read_state_with_hydration_retries_before_declaring_no_apply_cta(self) -> None:
+        class _Page:
+            async def wait_for_timeout(self, timeout):
+                return None
+
+            async def wait_for_load_state(self, state):
+                return None
+
+        calls = {"count": 0}
+
+        async def fake_prepare(page):
+            return None
+
+        async def fake_read(page):
+            calls["count"] += 1
+            if calls["count"] == 1:
+                return LinkedInApplicationPageState(
+                    current_url="https://www.linkedin.com/jobs/view/4389607214/",
+                )
+            return LinkedInApplicationPageState(
+                current_url="https://www.linkedin.com/jobs/view/4389607214/",
+                easy_apply=True,
+                cta_text="candidatura simplificada",
+            )
+
+        async def fake_extract(page):
+            return ""
+
+        async def fake_inspect(page, initial_state, close_modal):
+            return initial_state
+
+        readiness_calls = {"count": 0}
+
+        def fake_assess(job, state):
+            readiness_calls["count"] += 1
+            if state.easy_apply:
+                return LinkedInJobPageReadiness("ready", "ok", state.sample)
+            return LinkedInJobPageReadiness("no_apply_cta", "sem cta", state.sample)
+
+        opener = self._build_opener(
+            prepare_job_page_for_apply=fake_prepare,
+            read_page_state=fake_read,
+            assess_job_page_readiness=fake_assess,
+            extract_easy_apply_href=fake_extract,
+            inspect_easy_apply_modal=fake_inspect,
+            is_page_closed=lambda page: False,
+        )
+        opener.recover_easy_apply_from_page_html = fake_extract
+
+        import asyncio
+
+        state, readiness = asyncio.run(
+            opener.read_state_with_hydration(
+                _Page(),
+                type("Job", (), {"url": "https://www.linkedin.com/jobs/view/4389607214/"})(),
+            )
+        )
+
+        self.assertEqual(calls["count"], 2)
+        self.assertEqual(readiness_calls["count"], 2)
+        self.assertTrue(state.easy_apply)
+        self.assertEqual(readiness.result, "ready")

--- a/tests/test_linkedin_application_reader.py
+++ b/tests/test_linkedin_application_reader.py
@@ -1,0 +1,61 @@
+import unittest
+
+from job_hunter_agent.collectors.linkedin_application_reader import (
+    LINKEDIN_APPLICATION_PAGE_STATE_SCRIPT,
+    LinkedInApplicationPageReader,
+    normalize_linkedin_application_page_state_payload,
+)
+
+
+class LinkedInApplicationReaderTests(unittest.TestCase):
+    def test_script_contains_core_signals(self) -> None:
+        self.assertIn("easy apply", LINKEDIN_APPLICATION_PAGE_STATE_SCRIPT.lower())
+        self.assertIn("modal_submit_visible", LINKEDIN_APPLICATION_PAGE_STATE_SCRIPT)
+        self.assertIn("saveApplicationDialogVisible", LINKEDIN_APPLICATION_PAGE_STATE_SCRIPT)
+
+    def test_normalize_payload_converts_lists_to_tuples(self) -> None:
+        state = normalize_linkedin_application_page_state_payload(
+            {
+                "current_url": "https://www.linkedin.com/jobs/view/123/",
+                "easy_apply": True,
+                "resumable_fields": ["email", "telefone"],
+                "filled_fields": ["telefone"],
+                "modal_headings": ["informacoes de contato"],
+                "modal_buttons": ["next"],
+                "modal_fields": ["email"],
+                "modal_questions": ["autorizacao"],
+                "answered_questions": ["java"],
+                "unanswered_questions": ["ejb"],
+            }
+        )
+
+        self.assertEqual(state.resumable_fields, ("email", "telefone"))
+        self.assertEqual(state.filled_fields, ("telefone",))
+        self.assertEqual(state.modal_headings, ("informacoes de contato",))
+        self.assertEqual(state.answered_questions, ("java",))
+        self.assertEqual(state.unanswered_questions, ("ejb",))
+
+    def test_reader_evaluates_script_and_returns_state(self) -> None:
+        class _Page:
+            def __init__(self):
+                self.script = ""
+
+            async def evaluate(self, script):
+                self.script = script
+                return {
+                    "current_url": "https://www.linkedin.com/jobs/view/123/",
+                    "easy_apply": True,
+                    "modal_open": False,
+                    "resumable_fields": ["email"],
+                }
+
+        reader = LinkedInApplicationPageReader()
+
+        import asyncio
+
+        page = _Page()
+        state = asyncio.run(reader.read(page))
+
+        self.assertTrue(state.easy_apply)
+        self.assertEqual(state.resumable_fields, ("email",))
+        self.assertIn("easy apply", page.script.lower())

--- a/tests/test_linkedin_application_submit.py
+++ b/tests/test_linkedin_application_submit.py
@@ -1,0 +1,38 @@
+import unittest
+
+from job_hunter_agent.collectors.linkedin_application_state import LinkedInApplicationPageState
+from job_hunter_agent.collectors.linkedin_application_submit import (
+    evaluate_linkedin_submit_readiness,
+)
+
+
+class LinkedInApplicationSubmitTests(unittest.TestCase):
+    def test_evaluate_submit_readiness_accepts_open_modal_with_submit_button(self) -> None:
+        decision = evaluate_linkedin_submit_readiness(
+            LinkedInApplicationPageState(
+                modal_open=True,
+                modal_submit_visible=True,
+            )
+        )
+
+        self.assertTrue(decision.ready)
+        self.assertEqual(decision.detail, "")
+
+    def test_evaluate_submit_readiness_describes_blockers_when_submit_not_ready(self) -> None:
+        decision = evaluate_linkedin_submit_readiness(
+            LinkedInApplicationPageState(
+                easy_apply=True,
+                modal_open=True,
+                modal_next_visible=True,
+                modal_sample="next | upload resume",
+                cta_text="easy apply",
+                modal_headings=("informacoes de contato",),
+            ),
+            interpretation_detail=" | interpretacao_modal=acao=manual_review",
+        )
+
+        self.assertFalse(decision.ready)
+        self.assertIn("fluxo nao chegou ao botao de envio", decision.detail)
+        self.assertIn("bloqueio=", decision.detail)
+        self.assertIn("interpretacao_modal=acao=manual_review", decision.detail)
+        self.assertIn("snapshot_modal=", decision.detail)

--- a/tests/test_notifier.py
+++ b/tests/test_notifier.py
@@ -1,7 +1,7 @@
 import shutil
 from unittest import TestCase
 
-from job_hunter_agent.core.domain import JobPosting
+from job_hunter_agent.core.domain import JobApplication, JobPosting
 from job_hunter_agent.infrastructure.notifier import (
     NullNotifier,
     build_application_action_rows,
@@ -19,6 +19,7 @@ from job_hunter_agent.infrastructure.notifier import (
 from job_hunter_agent.infrastructure.notifier_rendering import (
     summarize_application_notes,
     summarize_application_operation,
+    summarize_operational_classifications,
 )
 from job_hunter_agent.infrastructure.repository import SqliteJobRepository
 from job_hunter_agent.llm.review_rationale import (
@@ -119,7 +120,7 @@ class ReviewActionTests(TestCase):
             line = build_application_preview_line(repository, draft)
 
             self.assertIn("Senior Kotlin Engineer", line)
-            self.assertIn("[draft | manual_review | prioridade alta]", line)
+            self.assertIn("[draft | manual_review | prioridade alta | op=sem_detalhe_operacional]", line)
             self.assertIn("manual_review", line)
         finally:
             shutil.rmtree(temp_dir, ignore_errors=True)
@@ -302,7 +303,7 @@ class PersistenceAndReviewIntegrationTests(TestCase):
         self.assertIn("Candidaturas:", message)
         self.assertIn("Autorizadas para envio: 1", message)
         self.assertIn("Com erro: 1", message)
-        self.assertIn("Senior Kotlin Engineer - ACME [authorized_submit | manual_review | prioridade alta]", message)
+        self.assertIn("Senior Kotlin Engineer - ACME [authorized_submit | manual_review | prioridade alta | op=sem_detalhe_operacional]", message)
 
     def test_build_application_queue_message_orders_by_priority(self) -> None:
         first_job = self.repository.save_new_jobs([sample_job(status="approved")])[0]
@@ -371,10 +372,39 @@ class PersistenceAndReviewIntegrationTests(TestCase):
         self.assertIn("Candidatura", message)
         self.assertIn("Vaga: Senior Kotlin Engineer", message)
         self.assertIn("Suporte: manual_review", message)
+        self.assertIn("Classificacao operacional: manual_review | cta detectado; validar fluxo", message)
         self.assertIn("Prioridade: media", message)
         self.assertIn("Sinais: senioridade=senior | stack=java, spring | ingles=avancado | lideranca=sim", message)
         self.assertIn("Contexto: rascunho criado apos aprovacao humana", message)
         self.assertIn("Operacao: Preflight: preflight real ok: CTA encontrado", message)
+
+    def test_summarize_operational_classifications_counts_known_variants(self) -> None:
+        summary = summarize_operational_classifications(
+            [
+                JobApplication(
+                    id=1,
+                    job_id=1,
+                    status="authorized_submit",
+                    last_preflight_detail="preflight real | pronto_para_envio=sim | ok: fluxo pronto para submissao assistida no LinkedIn",
+                ),
+                JobApplication(
+                    id=2,
+                    job_id=2,
+                    status="error_submit",
+                    last_error="readiness=listing_redirect | motivo=a navegacao caiu em listagem ou colecao do LinkedIn | pagina=https://www.linkedin.com/jobs/collections/similar-jobs/",
+                ),
+                JobApplication(
+                    id=3,
+                    job_id=3,
+                    status="error_submit",
+                    last_error="submissao real bloqueada | bloqueio=perguntas_obrigatorias | perguntas_pendentes=ha quantos anos voce usa java?",
+                ),
+            ]
+        )
+
+        self.assertIn("- pronto_para_envio=1", summary)
+        self.assertIn("- similar_jobs=1", summary)
+        self.assertIn("- perguntas_adicionais=1", summary)
 
     def test_summarize_application_notes_prefers_human_context_lines(self) -> None:
         notes = (


### PR DESCRIPTION
## Resumo
- extrai o fluxo de candidatura do LinkedIn em componentes menores para entrypoint, abertura, leitura de estado, preenchimento e decisao de submit
- endurece os contratos de `ApplicationFlowInspector` e `JobApplicant` com normalizacao estrutural dos resultados
- cobre o wiring de composicao para evitar caminhos especiais de producao sem teste e atualiza a checklist da refatoracao

## Testes
- pytest tests/test_app.py tests/test_applicant_contracts.py tests/test_database.py
- pytest tests/test_linkedin_application_fields.py tests/test_linkedin_application_reader.py tests/test_linkedin_application_submit.py tests/test_linkedin_application_artifacts.py tests/test_linkedin_application_opening.py tests/test_linkedin_application_entrypoint.py tests/test_linkedin_application.py