### PR TITLE
refactor: separa bootstrap leve e runtime operacional da aplicacao

### DIFF
--- a/job_hunter_agent/application/app.py
+++ b/job_hunter_agent/application/app.py
@@ -1,8 +1,6 @@
 from __future__ import annotations
 
-import asyncio
 import logging
-from datetime import datetime, timedelta
 from pathlib import Path
 
 from job_hunter_agent.application.application_commands import (
@@ -10,13 +8,8 @@ from job_hunter_agent.application.application_commands import (
     ApplicationTransitionCommandService,
     JobReviewCommandService,
 )
-from job_hunter_agent.application.application_messages import (
-    format_preflight_cli_result,
-    format_submit_cli_result,
-)
 from job_hunter_agent.application.application_queries import ApplicationQueryService
 from job_hunter_agent.application.application_cli_rendering import render_failure_artifacts
-from job_hunter_agent.collectors.collector import JobCollectionService
 from job_hunter_agent.application.composition import (
     create_application_preflight_service,
     create_application_preparation_service,
@@ -26,19 +19,30 @@ from job_hunter_agent.application.composition import (
     create_repository,
     create_runtime_guard,
 )
+from job_hunter_agent.application.runtime_execution import (
+    run_application as run_application_runtime,
+    run_collection_cycle as run_collection_cycle_runtime,
+    run_fixed_cycles as run_fixed_cycles_runtime,
+    run_scheduler as run_scheduler_runtime,
+    wait_for_review_window as wait_for_review_window_runtime,
+)
+from job_hunter_agent.application.runtime_handlers import (
+    handle_application_preflight as run_application_preflight_handler,
+    handle_application_submit as run_application_submit_handler,
+    handle_approved_jobs as run_approved_jobs_handler,
+)
 from job_hunter_agent.llm.candidate_profile_extractor import (
     OllamaCandidateProfileSuggester,
     extract_resume_text,
     merge_candidate_profile_suggestions,
 )
-from job_hunter_agent.infrastructure.notifier import NullNotifier, TelegramNotifier
-from job_hunter_agent.infrastructure.repository import JobRepository
 from job_hunter_agent.core.settings import load_settings
-from job_hunter_agent.core.runtime import RuntimeGuard
 
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s")
 logger = logging.getLogger(__name__)
+
+
 def suggest_candidate_profile(
     *,
     resume_path: Path,
@@ -62,22 +66,17 @@ def suggest_candidate_profile(
         return f"Perfil sugerido sem tecnologias mapeadas: {written_path}"
     mapped = ", ".join(f"{skill}={years}" for skill, years in sorted(suggestion.experience_years.items()))
     return f"Perfil sugerido atualizado: {written_path} | sugestoes={mapped}"
+
+
 class JobHunterApplication:
     def __init__(self, *, enable_telegram: bool = True) -> None:
         self.enable_telegram = enable_telegram
         self.settings = load_settings()
         self.repository = create_repository(self.settings)
+        self._initialize_query_services()
+        self._initialize_review_services()
+        self._initialize_flow_services()
         self.runtime_guard = create_runtime_guard(self.settings)
-        self.application_preparation = create_application_preparation_service(self.repository, self.settings)
-        self.application_preflight = create_application_preflight_service(self.repository, self.settings)
-        self.application_submission = create_application_submission_service(self.repository, self.settings)
-        self.query = ApplicationQueryService(self.repository)
-        self.job_review_commands = JobReviewCommandService(self.repository)
-        self.application_draft_commands = ApplicationDraftCommandService(
-            self.repository,
-            self.application_preparation,
-        )
-        self.application_transition_commands = ApplicationTransitionCommandService(self.repository)
         self.collector = create_collection_service(
             settings=self.settings,
             repository=self.repository,
@@ -91,38 +90,41 @@ class JobHunterApplication:
             on_application_submit=self.handle_application_submit,
         )
 
-    async def handle_approved_jobs(self, job_ids: list[int]) -> None:
-        drafts = self.application_preparation.create_drafts_for_approved_jobs(
-            job_ids,
-            notes="rascunho criado apos aprovacao humana",
+    def _initialize_query_services(self) -> None:
+        self.query = ApplicationQueryService(self.repository)
+
+    def _initialize_review_services(self) -> None:
+        self.application_preparation = create_application_preparation_service(self.repository, self.settings)
+        self.job_review_commands = JobReviewCommandService(self.repository)
+        self.application_draft_commands = ApplicationDraftCommandService(
+            self.repository,
+            self.application_preparation,
         )
-        if drafts:
-            logger.info("Pre-fase de candidatura criou %s rascunho(s) para vagas aprovadas.", len(drafts))
+        self.application_transition_commands = ApplicationTransitionCommandService(self.repository)
+
+    def _initialize_flow_services(self) -> None:
+        self.application_preflight = create_application_preflight_service(self.repository, self.settings)
+        self.application_submission = create_application_submission_service(self.repository, self.settings)
+
+    async def handle_approved_jobs(self, job_ids: list[int]) -> None:
+        await run_approved_jobs_handler(
+            self.application_preparation,
+            job_ids,
+            logger=logger,
+        )
 
     async def handle_application_preflight(self, application_id: int) -> str:
-        result = await asyncio.to_thread(self.application_preflight.run_for_application, application_id)
-        logger.info(
-            "Preflight de candidatura concluido. application_id=%s outcome=%s status=%s",
+        return await run_application_preflight_handler(
+            self.application_preflight,
             application_id,
-            result.outcome,
-            result.application_status,
-        )
-        return format_preflight_cli_result(
-            detail=result.detail,
-            application_status=result.application_status,
+            logger=logger,
         )
 
     async def handle_application_submit(self, application_id: int) -> str:
-        result = await asyncio.to_thread(self.application_submission.run_for_application, application_id)
-        logger.info(
-            "Submissao de candidatura concluida. application_id=%s outcome=%s status=%s",
+        return await run_application_submit_handler(
+            self.application_submission,
             application_id,
-            result.outcome,
-            result.application_status,
-        )
-        return format_submit_cli_result(
-            detail=result.detail,
-            application_status=result.application_status,
+            logger=logger,
         )
 
     def list_applications(self, *, status: str | None = None) -> str:
@@ -169,93 +171,51 @@ class JobHunterApplication:
         )
 
     async def run_collection_cycle(self) -> bool:
-        run = self.repository.start_collection_run()
-        logger.info("Ciclo de coleta iniciado. run_id=%s", run.id)
-        try:
-            report = await self.collector.collect_new_jobs_report()
-            self.repository.finish_collection_run(
-                run.id,
-                status="success",
-                jobs_seen=report.jobs_seen,
-                jobs_saved=report.jobs_saved,
-                errors=report.errors,
-            )
-        except Exception as exc:
-            self.repository.finish_collection_run(
-                run.id,
-                status="error",
-                jobs_seen=0,
-                jobs_saved=0,
-                errors=1,
-            )
-            logger.exception("Falha no ciclo de coleta.")
-            await self.notifier.send_text(f"Falha no ciclo de coleta: {exc}")
-            return False
-
-        jobs = list(report.jobs)
-        if not jobs:
-            await self.notifier.send_text("Nenhuma vaga nova passou na triagem de hoje.")
-            return False
-        await self.notifier.notify_jobs_for_review(jobs)
-        return True
+        return await run_collection_cycle_runtime(
+            self.repository,
+            self.collector,
+            self.notifier,
+            logger=logger,
+        )
 
     async def wait_for_review_window(self) -> None:
-        if not self.enable_telegram:
-            return
-        grace_seconds = self.settings.review_polling_grace_seconds
-        if grace_seconds <= 0:
-            return
-        logger.info("Aguardando callbacks do Telegram por %ss antes de encerrar.", grace_seconds)
-        await asyncio.sleep(grace_seconds)
+        await wait_for_review_window_runtime(
+            enable_telegram=self.enable_telegram,
+            grace_seconds=self.settings.review_polling_grace_seconds,
+            logger=logger,
+        )
 
     async def run_scheduler(self) -> None:
-        hour_text, minute_text = self.settings.collection_time.split(":")
-        target_hour = int(hour_text)
-        target_minute = int(minute_text)
-
-        while True:
-            now = datetime.now()
-            run_at = now.replace(hour=target_hour, minute=target_minute, second=0, microsecond=0)
-            if run_at <= now:
-                run_at += timedelta(days=1)
-            delay_seconds = max(1, int((run_at - now).total_seconds()))
-            logger.info("Proxima coleta agendada para %s", run_at.isoformat(timespec="minutes"))
-            await asyncio.sleep(delay_seconds)
-            await self.run_collection_cycle()
+        await run_scheduler_runtime(
+            collection_time=self.settings.collection_time,
+            run_collection_cycle=self.run_collection_cycle,
+            logger=logger,
+        )
 
     async def run_fixed_cycles(self, cycles: int, interval_seconds: int = 0) -> None:
-        for cycle_number in range(1, cycles + 1):
-            logger.info("Executando ciclo controlado %s/%s.", cycle_number, cycles)
-            jobs_sent_for_review = await self.run_collection_cycle()
-            if jobs_sent_for_review:
-                await self.wait_for_review_window()
-            if cycle_number < cycles and interval_seconds > 0:
-                logger.info("Aguardando %ss antes do proximo ciclo controlado.", interval_seconds)
-                await asyncio.sleep(interval_seconds)
+        await run_fixed_cycles_runtime(
+            cycles=cycles,
+            interval_seconds=interval_seconds,
+            run_collection_cycle=self.run_collection_cycle,
+            wait_for_review_window=self.wait_for_review_window,
+            logger=logger,
+        )
 
     async def run(self, run_once: bool, fixed_cycles: int | None = None, cycle_interval_seconds: int = 0) -> None:
-        execution_started_at = datetime.now().isoformat(timespec="seconds")
-        terminated_processes = self.runtime_guard.prepare_for_startup()
-        interrupted_runs = self.repository.interrupt_running_collection_runs()
-        if terminated_processes:
-            logger.info("Startup limpou processos antigos do projeto: %s", terminated_processes)
-        if interrupted_runs:
-            logger.info("Startup marcou runs presos como interrompidos: %s", interrupted_runs)
-        await self.notifier.start()
-        try:
-            if run_once:
-                jobs_sent_for_review = await self.run_collection_cycle()
-                if jobs_sent_for_review:
-                    await self.wait_for_review_window()
-                return
-            if fixed_cycles is not None:
-                await self.run_fixed_cycles(fixed_cycles, interval_seconds=cycle_interval_seconds)
-                return
-            await self.run_scheduler()
-        finally:
-            logger.info("Resumo final da execucao:\n%s", self.build_execution_summary(execution_started_at))
-            await self.notifier.stop()
-            self.runtime_guard.release()
+        await run_application_runtime(
+            run_once=run_once,
+            fixed_cycles=fixed_cycles,
+            cycle_interval_seconds=cycle_interval_seconds,
+            runtime_guard=self.runtime_guard,
+            repository=self.repository,
+            notifier=self.notifier,
+            build_execution_summary=self.build_execution_summary,
+            run_collection_cycle=self.run_collection_cycle,
+            wait_for_review_window=self.wait_for_review_window,
+            run_fixed_cycles_callback=self.run_fixed_cycles,
+            run_scheduler_callback=self.run_scheduler,
+            logger=logger,
+        )
 
     def build_execution_summary(self, since: str) -> str:
         return self._query_service().build_execution_summary(since)
@@ -287,6 +247,7 @@ class JobHunterApplication:
             service = ApplicationTransitionCommandService(self.repository)
             self.application_transition_commands = service
         return service
+
 
 def run() -> None:
     from job_hunter_agent.application.application_cli import run as run_cli

--- a/job_hunter_agent/application/application_cli_dispatch.py
+++ b/job_hunter_agent/application/application_cli_dispatch.py
@@ -3,10 +3,15 @@ from __future__ import annotations
 import asyncio
 from argparse import Namespace
 
-from job_hunter_agent.application.app import JobHunterApplication, suggest_candidate_profile
+from job_hunter_agent.application.app import suggest_candidate_profile
 from job_hunter_agent.application.application_cli import (
     APPLICATION_STATUS_ALIASES,
     JOB_STATUS_ALIASES,
+)
+from job_hunter_agent.application.cli_bootstrap import (
+    create_application_flow_app,
+    create_query_app,
+    create_review_app,
 )
 from job_hunter_agent.collectors.linkedin_auth import bootstrap_linkedin_storage_state
 from job_hunter_agent.core.settings import load_settings
@@ -18,7 +23,7 @@ def execute_cli_command(args: Namespace) -> bool:
         asyncio.run(bootstrap_linkedin_storage_state(settings))
         return True
     if args.command == "status":
-        app = JobHunterApplication(enable_telegram=not args.sem_telegram)
+        app = create_query_app()
         print(app.show_status_overview())
         return True
     if args.command == "jobs":
@@ -34,14 +39,16 @@ def execute_cli_command(args: Namespace) -> bool:
 
 
 def _run_jobs_command(args: Namespace) -> None:
-    app = JobHunterApplication(enable_telegram=not args.sem_telegram)
     if args.jobs_command == "list":
+        app = create_query_app()
         status = JOB_STATUS_ALIASES.get(args.status, args.status)
         print(app.list_jobs(status=status))
         return
     if args.jobs_command == "show":
+        app = create_query_app()
         print(app.show_job(args.id))
         return
+    app = create_review_app()
     if args.jobs_command == "approve":
         print(app.review_job(args.id, "approve"))
         return
@@ -50,35 +57,44 @@ def _run_jobs_command(args: Namespace) -> None:
 
 
 def _run_applications_command(args: Namespace) -> None:
-    app = JobHunterApplication(enable_telegram=not args.sem_telegram)
     if args.applications_command == "list":
+        app = create_query_app()
         status = APPLICATION_STATUS_ALIASES.get(args.status, args.status)
         print(app.list_applications(status=status))
         return
-    if args.applications_command == "create":
-        print(app.create_application_draft_for_job(args.job_id))
-        return
     if args.applications_command == "show":
+        app = create_query_app()
         print(app.show_application(args.id))
         return
     if args.applications_command == "events":
+        app = create_query_app()
         print(app.show_application_events(args.id, limit=args.limit))
         return
+    if args.applications_command == "artifacts":
+        app = create_query_app()
+        print(app.show_latest_failure_artifacts(limit=args.limit))
+        return
+    if args.applications_command == "create":
+        app = create_review_app()
+        print(app.create_application_draft_for_job(args.job_id))
+        return
     if args.applications_command == "prepare":
+        app = create_review_app()
         print(app.transition_application(args.id, "app_prepare"))
         return
     if args.applications_command == "confirm":
+        app = create_review_app()
         print(app.transition_application(args.id, "app_confirm"))
         return
     if args.applications_command == "cancel":
+        app = create_review_app()
         print(app.transition_application(args.id, "app_cancel"))
         return
-    if args.applications_command == "artifacts":
-        print(app.show_latest_failure_artifacts(limit=args.limit))
-        return
     if args.applications_command == "authorize":
+        app = create_review_app()
         print(app.authorize_application(args.id))
         return
+    app = create_application_flow_app()
     if args.applications_command == "preflight":
         print(asyncio.run(app.handle_application_preflight(args.id)))
         return

--- a/job_hunter_agent/application/cli_bootstrap.py
+++ b/job_hunter_agent/application/cli_bootstrap.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from job_hunter_agent.application.app import JobHunterApplication
+from job_hunter_agent.application.composition import create_repository
+from job_hunter_agent.core.settings import load_settings
+
+
+def create_query_app() -> JobHunterApplication:
+    app = _create_cli_app_base()
+    app._initialize_query_services()
+    return app
+
+
+def create_review_app() -> JobHunterApplication:
+    app = _create_cli_app_base()
+    app._initialize_query_services()
+    app._initialize_review_services()
+    return app
+
+
+def create_application_flow_app() -> JobHunterApplication:
+    app = _create_cli_app_base()
+    app._initialize_query_services()
+    app._initialize_flow_services()
+    return app
+
+
+def _create_cli_app_base() -> JobHunterApplication:
+    app = JobHunterApplication.__new__(JobHunterApplication)
+    app.enable_telegram = False
+    app.settings = load_settings()
+    app.repository = create_repository(app.settings)
+    return app

--- a/job_hunter_agent/application/runtime_execution.py
+++ b/job_hunter_agent/application/runtime_execution.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+from datetime import datetime, timedelta
+from typing import Awaitable, Callable
+
+
+async def run_collection_cycle(
+    repository,
+    collector,
+    notifier,
+    *,
+    logger: logging.Logger,
+) -> bool:
+    run = repository.start_collection_run()
+    logger.info("Ciclo de coleta iniciado. run_id=%s", run.id)
+    try:
+        report = await collector.collect_new_jobs_report()
+        repository.finish_collection_run(
+            run.id,
+            status="success",
+            jobs_seen=report.jobs_seen,
+            jobs_saved=report.jobs_saved,
+            errors=report.errors,
+        )
+    except Exception as exc:
+        repository.finish_collection_run(
+            run.id,
+            status="error",
+            jobs_seen=0,
+            jobs_saved=0,
+            errors=1,
+        )
+        logger.exception("Falha no ciclo de coleta.")
+        await notifier.send_text(f"Falha no ciclo de coleta: {exc}")
+        return False
+
+    jobs = list(report.jobs)
+    if not jobs:
+        await notifier.send_text("Nenhuma vaga nova passou na triagem de hoje.")
+        return False
+    await notifier.notify_jobs_for_review(jobs)
+    return True
+
+
+async def wait_for_review_window(
+    *,
+    enable_telegram: bool,
+    grace_seconds: int,
+    logger: logging.Logger,
+) -> None:
+    if not enable_telegram:
+        return
+    if grace_seconds <= 0:
+        return
+    logger.info("Aguardando callbacks do Telegram por %ss antes de encerrar.", grace_seconds)
+    await asyncio.sleep(grace_seconds)
+
+
+async def run_scheduler(
+    *,
+    collection_time: str,
+    run_collection_cycle: Callable[[], Awaitable[bool]],
+    logger: logging.Logger,
+) -> None:
+    hour_text, minute_text = collection_time.split(":")
+    target_hour = int(hour_text)
+    target_minute = int(minute_text)
+
+    while True:
+        now = datetime.now()
+        run_at = now.replace(hour=target_hour, minute=target_minute, second=0, microsecond=0)
+        if run_at <= now:
+            run_at += timedelta(days=1)
+        delay_seconds = max(1, int((run_at - now).total_seconds()))
+        logger.info("Proxima coleta agendada para %s", run_at.isoformat(timespec="minutes"))
+        await asyncio.sleep(delay_seconds)
+        await run_collection_cycle()
+
+
+async def run_fixed_cycles(
+    *,
+    cycles: int,
+    interval_seconds: int,
+    run_collection_cycle: Callable[[], Awaitable[bool]],
+    wait_for_review_window: Callable[[], Awaitable[None]],
+    logger: logging.Logger,
+) -> None:
+    for cycle_number in range(1, cycles + 1):
+        logger.info("Executando ciclo controlado %s/%s.", cycle_number, cycles)
+        jobs_sent_for_review = await run_collection_cycle()
+        if jobs_sent_for_review:
+            await wait_for_review_window()
+        if cycle_number < cycles and interval_seconds > 0:
+            logger.info("Aguardando %ss antes do proximo ciclo controlado.", interval_seconds)
+            await asyncio.sleep(interval_seconds)
+
+
+async def run_application(
+    *,
+    run_once: bool,
+    fixed_cycles: int | None,
+    cycle_interval_seconds: int,
+    runtime_guard,
+    repository,
+    notifier,
+    build_execution_summary: Callable[[str], str],
+    run_collection_cycle: Callable[[], Awaitable[bool]],
+    wait_for_review_window: Callable[[], Awaitable[None]],
+    run_fixed_cycles_callback: Callable[[int, int], Awaitable[None]],
+    run_scheduler_callback: Callable[[], Awaitable[None]],
+    logger: logging.Logger,
+) -> None:
+    execution_started_at = datetime.now().isoformat(timespec="seconds")
+    terminated_processes = runtime_guard.prepare_for_startup()
+    interrupted_runs = repository.interrupt_running_collection_runs()
+    if terminated_processes:
+        logger.info("Startup limpou processos antigos do projeto: %s", terminated_processes)
+    if interrupted_runs:
+        logger.info("Startup marcou runs presos como interrompidos: %s", interrupted_runs)
+    await notifier.start()
+    try:
+        if run_once:
+            jobs_sent_for_review = await run_collection_cycle()
+            if jobs_sent_for_review:
+                await wait_for_review_window()
+            return
+        if fixed_cycles is not None:
+            await run_fixed_cycles_callback(fixed_cycles, cycle_interval_seconds)
+            return
+        await run_scheduler_callback()
+    finally:
+        logger.info("Resumo final da execucao:\n%s", build_execution_summary(execution_started_at))
+        await notifier.stop()
+        runtime_guard.release()

--- a/job_hunter_agent/application/runtime_handlers.py
+++ b/job_hunter_agent/application/runtime_handlers.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+
+from job_hunter_agent.application.application_messages import (
+    format_preflight_cli_result,
+    format_submit_cli_result,
+)
+
+
+async def handle_approved_jobs(
+    application_preparation,
+    job_ids: list[int],
+    *,
+    logger: logging.Logger,
+) -> None:
+    drafts = application_preparation.create_drafts_for_approved_jobs(
+        job_ids,
+        notes="rascunho criado apos aprovacao humana",
+    )
+    if drafts:
+        logger.info("Pre-fase de candidatura criou %s rascunho(s) para vagas aprovadas.", len(drafts))
+
+
+async def handle_application_preflight(
+    application_preflight,
+    application_id: int,
+    *,
+    logger: logging.Logger,
+) -> str:
+    result = await asyncio.to_thread(application_preflight.run_for_application, application_id)
+    logger.info(
+        "Preflight de candidatura concluido. application_id=%s outcome=%s status=%s",
+        application_id,
+        result.outcome,
+        result.application_status,
+    )
+    return format_preflight_cli_result(
+        detail=result.detail,
+        application_status=result.application_status,
+    )
+
+
+async def handle_application_submit(
+    application_submission,
+    application_id: int,
+    *,
+    logger: logging.Logger,
+) -> str:
+    result = await asyncio.to_thread(application_submission.run_for_application, application_id)
+    logger.info(
+        "Submissao de candidatura concluida. application_id=%s outcome=%s status=%s",
+        application_id,
+        result.outcome,
+        result.application_status,
+    )
+    return format_submit_cli_result(
+        detail=result.detail,
+        application_status=result.application_status,
+    )

--- a/tests/test_app_bootstrap.py
+++ b/tests/test_app_bootstrap.py
@@ -1,0 +1,88 @@
+from unittest import TestCase
+from unittest.mock import patch
+
+from job_hunter_agent.application.app import JobHunterApplication
+from job_hunter_agent.application.cli_bootstrap import (
+    create_application_flow_app,
+    create_query_app,
+    create_review_app,
+)
+
+
+class JobHunterApplicationBootstrapTests(TestCase):
+    def test_create_query_app_avoids_runtime_collection_and_notifier(self) -> None:
+        settings = object()
+        repository = object()
+
+        with patch("job_hunter_agent.application.cli_bootstrap.load_settings", return_value=settings) as load_settings_mock, patch(
+            "job_hunter_agent.application.cli_bootstrap.create_repository",
+            return_value=repository,
+        ) as create_repository_mock, patch.object(
+            JobHunterApplication,
+            "_initialize_query_services",
+        ) as initialize_query_mock, patch.object(
+            JobHunterApplication,
+            "_initialize_review_services",
+        ) as initialize_review_mock, patch.object(
+            JobHunterApplication,
+            "_initialize_flow_services",
+        ) as initialize_flow_mock:
+            app = create_query_app()
+
+        load_settings_mock.assert_called_once_with()
+        create_repository_mock.assert_called_once_with(settings)
+        initialize_query_mock.assert_called_once_with()
+        initialize_review_mock.assert_not_called()
+        initialize_flow_mock.assert_not_called()
+        self.assertIs(app.repository, repository)
+        self.assertFalse(app.enable_telegram)
+
+    def test_create_review_app_initializes_review_services_only(self) -> None:
+        settings = object()
+        repository = object()
+
+        with patch("job_hunter_agent.application.cli_bootstrap.load_settings", return_value=settings), patch(
+            "job_hunter_agent.application.cli_bootstrap.create_repository",
+            return_value=repository,
+        ), patch.object(
+            JobHunterApplication,
+            "_initialize_query_services",
+        ) as initialize_query_mock, patch.object(
+            JobHunterApplication,
+            "_initialize_review_services",
+        ) as initialize_review_mock, patch.object(
+            JobHunterApplication,
+            "_initialize_flow_services",
+        ) as initialize_flow_mock:
+            app = create_review_app()
+
+        initialize_query_mock.assert_called_once_with()
+        initialize_review_mock.assert_called_once_with()
+        initialize_flow_mock.assert_not_called()
+        self.assertIs(app.repository, repository)
+        self.assertFalse(app.enable_telegram)
+
+    def test_create_application_flow_app_initializes_flow_services_only(self) -> None:
+        settings = object()
+        repository = object()
+
+        with patch("job_hunter_agent.application.cli_bootstrap.load_settings", return_value=settings), patch(
+            "job_hunter_agent.application.cli_bootstrap.create_repository",
+            return_value=repository,
+        ), patch.object(
+            JobHunterApplication,
+            "_initialize_query_services",
+        ) as initialize_query_mock, patch.object(
+            JobHunterApplication,
+            "_initialize_review_services",
+        ) as initialize_review_mock, patch.object(
+            JobHunterApplication,
+            "_initialize_flow_services",
+        ) as initialize_flow_mock:
+            app = create_application_flow_app()
+
+        initialize_query_mock.assert_called_once_with()
+        initialize_review_mock.assert_not_called()
+        initialize_flow_mock.assert_called_once_with()
+        self.assertIs(app.repository, repository)
+        self.assertFalse(app.enable_telegram)

--- a/tests/test_application_cli_dispatch.py
+++ b/tests/test_application_cli_dispatch.py
@@ -22,13 +22,13 @@ class ApplicationCliDispatchTests(TestCase):
         )
 
         with patch(
-            "job_hunter_agent.application.application_cli_dispatch.JobHunterApplication",
+            "job_hunter_agent.application.application_cli_dispatch.create_query_app",
             return_value=fake_app,
         ) as app_factory, patch("builtins.print") as print_mock:
             handled = execute_cli_command(args)
 
         self.assertTrue(handled)
-        app_factory.assert_called_once_with(enable_telegram=False)
+        app_factory.assert_called_once_with()
         print_mock.assert_called_once_with("resumo")
 
     def test_execute_cli_command_dispatches_application_list_alias(self) -> None:
@@ -49,14 +49,45 @@ class ApplicationCliDispatchTests(TestCase):
         )
 
         with patch(
-            "job_hunter_agent.application.application_cli_dispatch.JobHunterApplication",
+            "job_hunter_agent.application.application_cli_dispatch.create_query_app",
             return_value=fake_app,
         ) as app_factory, patch("builtins.print") as print_mock:
             handled = execute_cli_command(args)
 
         self.assertTrue(handled)
-        app_factory.assert_called_once_with(enable_telegram=True)
+        app_factory.assert_called_once_with()
         print_mock.assert_called_once_with("status=authorized_submit")
+
+    def test_execute_cli_command_dispatches_application_preflight_with_flow_app(self) -> None:
+        fake_app = type(
+            "FakeApp",
+            (),
+            {
+                "handle_application_preflight": lambda self, application_id: f"preflight={application_id}",
+            },
+        )()
+
+        args = Namespace(
+            bootstrap_linkedin_session=False,
+            command="applications",
+            applications_command="preflight",
+            id=7,
+            sem_telegram=True,
+        )
+
+        with patch(
+            "job_hunter_agent.application.application_cli_dispatch.create_application_flow_app",
+            return_value=fake_app,
+        ) as app_factory, patch(
+            "job_hunter_agent.application.application_cli_dispatch.asyncio.run",
+            side_effect=lambda value: value,
+        ) as asyncio_run, patch("builtins.print") as print_mock:
+            handled = execute_cli_command(args)
+
+        self.assertTrue(handled)
+        app_factory.assert_called_once_with()
+        asyncio_run.assert_called_once_with("preflight=7")
+        print_mock.assert_called_once_with("preflight=7")
 
     def test_execute_cli_command_returns_false_for_scheduler_mode(self) -> None:
         args = Namespace(

--- a/tests/test_runtime_handlers.py
+++ b/tests/test_runtime_handlers.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+from unittest import IsolatedAsyncioTestCase
+from unittest.mock import patch
+
+from job_hunter_agent.application.runtime_handlers import (
+    handle_application_preflight,
+    handle_application_submit,
+    handle_approved_jobs,
+)
+
+
+class RuntimeHandlersTests(IsolatedAsyncioTestCase):
+    async def test_handle_approved_jobs_creates_drafts_for_approved_jobs(self) -> None:
+        class _PreparationService:
+            def __init__(self) -> None:
+                self.calls: list[tuple[list[int], str]] = []
+
+            def create_drafts_for_approved_jobs(self, job_ids: list[int], notes: str = ""):
+                self.calls.append((job_ids, notes))
+                return [object()]
+
+        logger = type("Logger", (), {"info": lambda *args, **kwargs: None})()
+        service = _PreparationService()
+
+        await handle_approved_jobs(service, [1, 2], logger=logger)
+
+        self.assertEqual(
+            service.calls,
+            [([1, 2], "rascunho criado apos aprovacao humana")],
+        )
+
+    async def test_handle_application_preflight_formats_reply(self) -> None:
+        class _PreflightService:
+            def run_for_application(self, application_id: int):
+                return type(
+                    "Result",
+                    (),
+                    {
+                        "outcome": "ready",
+                        "detail": "preflight ok",
+                        "application_status": "confirmed",
+                    },
+                )
+
+        logger = type("Logger", (), {"info": lambda *args, **kwargs: None})()
+
+        reply = await handle_application_preflight(_PreflightService(), 42, logger=logger)
+
+        self.assertEqual(reply, "Preflight: preflight ok (status=confirmed)")
+
+    async def test_handle_application_submit_formats_reply(self) -> None:
+        class _SubmissionService:
+            def run_for_application(self, application_id: int):
+                return type(
+                    "Result",
+                    (),
+                    {
+                        "outcome": "submitted",
+                        "detail": "submissao real concluida",
+                        "application_status": "submitted",
+                    },
+                )
+
+        logger = type("Logger", (), {"info": lambda *args, **kwargs: None})()
+
+        reply = await handle_application_submit(_SubmissionService(), 42, logger=logger)
+
+        self.assertEqual(reply, "Submissao: submissao real concluida (status=submitted)")
+
+    async def test_handle_application_preflight_uses_asyncio_to_thread(self) -> None:
+        class _PreflightService:
+            def run_for_application(self, application_id: int):
+                return type(
+                    "Result",
+                    (),
+                    {
+                        "outcome": "ready",
+                        "detail": "preflight ok",
+                        "application_status": "confirmed",
+                    },
+                )
+
+        logger = type("Logger", (), {"info": lambda *args, **kwargs: None})()
+
+        async def fake_to_thread(fn, *args, **kwargs):
+            return fn(*args, **kwargs)
+
+        with patch("job_hunter_agent.application.runtime_handlers.asyncio.to_thread", side_effect=fake_to_thread) as to_thread_mock:
+            reply = await handle_application_preflight(_PreflightService(), 7, logger=logger)
+
+        to_thread_mock.assert_called_once()
+        self.assertEqual(reply, "Preflight: preflight ok (status=confirmed)")


### PR DESCRIPTION
## Resumo

Este PR reduz a concentracao de responsabilidades em `job_hunter_agent/application/app.py` e melhora o bootstrap da CLI, separando caminhos leves de leitura/revisao do runtime completo da aplicacao.

## O que entrou

- separa bootstraps leves da CLI por tipo de comando
- extrai bootstrap leve para modulo dedicado (`cli_bootstrap.py`)
- extrai handlers operacionais assincronos para modulo dedicado (`runtime_handlers.py`)
- extrai runtime de coleta e agendamento para modulo dedicado (`runtime_execution.py`)
- mantém `JobHunterApplication` mais focado em composicao e delegacao
- adiciona testes para bootstrap leve e runtime handlers
- ajusta testes de dispatch da CLI para refletir a nova composicao

## Impacto esperado

- startup mais leve para comandos de leitura da CLI
- menor acoplamento entre CLI, runtime completo e fluxo operacional
- base mais clara para continuar desacoplando o fluxo de candidatura
- melhoria de testabilidade por fronteiras mais explicitas

## Observacoes

- a branch foi reaplicada sobre a `master` atual para remover a divergencia anterior
- o comportamento publico da aplicacao foi preservado neste recorte
