### PR TITLE
refactor: desacopla runtime e ports do fluxo de candidatura linkedin

### DIFF
--- a/job_hunter_agent/application/application_ports.py
+++ b/job_hunter_agent/application/application_ports.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from typing import Protocol
+
+from job_hunter_agent.application.contracts import ApplicationFlowInspection, ApplicationSubmissionResult
+from job_hunter_agent.core.domain import JobApplication, JobPosting
+
+
+class ApplicationFlowInspector(Protocol):
+    def inspect(self, job: JobPosting) -> ApplicationFlowInspection:
+        raise NotImplementedError
+
+
+class JobApplicant(Protocol):
+    def submit(self, application: JobApplication, job: JobPosting) -> ApplicationSubmissionResult:
+        raise NotImplementedError
+
+
+def normalize_application_flow_inspection(result) -> ApplicationFlowInspection:
+    outcome = str(getattr(result, "outcome", "") or "").strip()
+    detail = str(getattr(result, "detail", "") or "").strip()
+    if outcome not in {"ready", "manual_review", "blocked", "ignored", "error"}:
+        return ApplicationFlowInspection(
+            outcome="error",
+            detail="inspecao de fluxo retornou outcome invalido",
+        )
+    if not detail:
+        return ApplicationFlowInspection(
+            outcome="error",
+            detail="inspecao de fluxo retornou detail vazio",
+        )
+    return ApplicationFlowInspection(outcome=outcome, detail=detail)
+
+
+def normalize_application_submission_result(result) -> ApplicationSubmissionResult:
+    status = str(getattr(result, "status", "") or "").strip()
+    detail = str(getattr(result, "detail", "") or "").strip()
+    submitted_at_raw = getattr(result, "submitted_at", None)
+    external_reference_raw = getattr(result, "external_reference", "")
+    if status not in {"submitted", "error_submit", "authorized_submit"}:
+        return ApplicationSubmissionResult(
+            status="error_submit",
+            detail="applicant retornou status invalido",
+        )
+    if not detail:
+        return ApplicationSubmissionResult(
+            status="error_submit",
+            detail="applicant retornou detail vazio",
+        )
+    submitted_at = str(submitted_at_raw).strip() if submitted_at_raw else None
+    external_reference = str(external_reference_raw or "").strip()
+    return ApplicationSubmissionResult(
+        status=status,
+        detail=detail,
+        submitted_at=submitted_at,
+        external_reference=external_reference,
+    )

--- a/job_hunter_agent/application/application_preflight.py
+++ b/job_hunter_agent/application/application_preflight.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Protocol
 
 from job_hunter_agent.application.application_flow import (
     ApplicationFlowCoordinator,
@@ -15,9 +14,11 @@ from job_hunter_agent.application.application_messages import (
     format_preflight_requires_confirmed_status,
     format_preflight_unsupported_flow_blocked,
 )
+from job_hunter_agent.application.application_ports import (
+    ApplicationFlowInspector,
+    normalize_application_flow_inspection,
+)
 from job_hunter_agent.application.application_readiness import ApplicationReadinessCheckService
-from job_hunter_agent.application.contracts import ApplicationFlowInspection
-from job_hunter_agent.core.domain import JobPosting
 from job_hunter_agent.core.portal_capabilities import get_portal_capabilities
 from job_hunter_agent.infrastructure.repository import JobRepository
 
@@ -27,27 +28,6 @@ class ApplicationPreflightResult:
     outcome: str
     detail: str
     application_status: str
-
-
-class ApplicationFlowInspector(Protocol):
-    def inspect(self, job: JobPosting) -> ApplicationFlowInspection:
-        raise NotImplementedError
-
-
-def normalize_application_flow_inspection(result) -> ApplicationFlowInspection:
-    outcome = str(getattr(result, "outcome", "") or "").strip()
-    detail = str(getattr(result, "detail", "") or "").strip()
-    if outcome not in {"ready", "manual_review", "blocked", "ignored", "error"}:
-        return ApplicationFlowInspection(
-            outcome="error",
-            detail="inspecao de fluxo retornou outcome invalido",
-        )
-    if not detail:
-        return ApplicationFlowInspection(
-            outcome="error",
-            detail="inspecao de fluxo retornou detail vazio",
-        )
-    return ApplicationFlowInspection(outcome=outcome, detail=detail)
 
 
 class ApplicationPreflightService:

--- a/job_hunter_agent/application/application_submission.py
+++ b/job_hunter_agent/application/application_submission.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Protocol
 
 from job_hunter_agent.application.application_flow import (
     ApplicationFlowCoordinator,
@@ -16,9 +15,11 @@ from job_hunter_agent.application.application_messages import (
     format_submit_unavailable_in_execution,
 )
 from job_hunter_agent.application.application_notes import append_note
+from job_hunter_agent.application.application_ports import (
+    JobApplicant,
+    normalize_application_submission_result,
+)
 from job_hunter_agent.application.application_readiness import ApplicationReadinessCheckService
-from job_hunter_agent.application.contracts import ApplicationSubmissionResult
-from job_hunter_agent.core.domain import JobApplication, JobPosting
 from job_hunter_agent.core.portal_capabilities import get_portal_capabilities
 from job_hunter_agent.infrastructure.repository import JobRepository
 
@@ -28,36 +29,6 @@ class ApplicationSubmitResult:
     outcome: str
     detail: str
     application_status: str
-
-
-class JobApplicant(Protocol):
-    def submit(self, application: JobApplication, job: JobPosting) -> ApplicationSubmissionResult:
-        raise NotImplementedError
-
-
-def normalize_application_submission_result(result) -> ApplicationSubmissionResult:
-    status = str(getattr(result, "status", "") or "").strip()
-    detail = str(getattr(result, "detail", "") or "").strip()
-    submitted_at_raw = getattr(result, "submitted_at", None)
-    external_reference_raw = getattr(result, "external_reference", "")
-    if status not in {"submitted", "error_submit", "authorized_submit"}:
-        return ApplicationSubmissionResult(
-            status="error_submit",
-            detail="applicant retornou status invalido",
-        )
-    if not detail:
-        return ApplicationSubmissionResult(
-            status="error_submit",
-            detail="applicant retornou detail vazio",
-        )
-    submitted_at = str(submitted_at_raw).strip() if submitted_at_raw else None
-    external_reference = str(external_reference_raw or "").strip()
-    return ApplicationSubmissionResult(
-        status=status,
-        detail=detail,
-        submitted_at=submitted_at,
-        external_reference=external_reference,
-    )
 
 
 class ApplicationSubmissionService:

--- a/job_hunter_agent/application/composition.py
+++ b/job_hunter_agent/application/composition.py
@@ -95,7 +95,10 @@ def create_application_preparation_service(
 def create_application_preflight_service(repository: JobRepository, settings: Settings) -> ApplicationPreflightService:
     return ApplicationPreflightService(
         repository,
-        flow_inspector=create_linkedin_preflight_inspector(settings),
+        flow_inspector=create_linkedin_application_flow_inspector(
+            settings,
+            mode="preflight",
+        ),
         readiness_checker=ApplicationReadinessCheckService(
             linkedin_storage_state_path=settings.linkedin_storage_state_path,
             resume_path=settings.resume_path,
@@ -109,7 +112,10 @@ def create_application_preflight_service(repository: JobRepository, settings: Se
 def create_application_submission_service(repository: JobRepository, settings: Settings) -> ApplicationSubmissionService:
     return ApplicationSubmissionService(
         repository,
-        applicant=create_linkedin_submission_applicant(settings),
+        applicant=create_linkedin_application_flow_inspector(
+            settings,
+            mode="submit",
+        ),
         readiness_checker=ApplicationReadinessCheckService(
             linkedin_storage_state_path=settings.linkedin_storage_state_path,
             resume_path=settings.resume_path,

--- a/job_hunter_agent/application/composition.py
+++ b/job_hunter_agent/application/composition.py
@@ -14,6 +14,10 @@ from job_hunter_agent.core.job_identity import PortalAwareJobIdentityStrategy
 from job_hunter_agent.core.matching import build_matching_criteria
 from job_hunter_agent.llm.job_requirements import OllamaJobRequirementsExtractor
 from job_hunter_agent.collectors.linkedin_application import LinkedInApplicationFlowInspector
+from job_hunter_agent.collectors.linkedin_application_adapters import (
+    LinkedInPreflightInspectorAdapter,
+    LinkedInSubmissionApplicantAdapter,
+)
 from job_hunter_agent.collectors.linkedin_modal_llm import (
     OllamaLinkedInModalInterpreter,
     deterministic_interpret_linkedin_modal,
@@ -91,10 +95,7 @@ def create_application_preparation_service(
 def create_application_preflight_service(repository: JobRepository, settings: Settings) -> ApplicationPreflightService:
     return ApplicationPreflightService(
         repository,
-        flow_inspector=create_linkedin_application_flow_inspector(
-            settings,
-            mode="preflight",
-        ),
+        flow_inspector=create_linkedin_preflight_inspector(settings),
         readiness_checker=ApplicationReadinessCheckService(
             linkedin_storage_state_path=settings.linkedin_storage_state_path,
             resume_path=settings.resume_path,
@@ -108,10 +109,7 @@ def create_application_preflight_service(repository: JobRepository, settings: Se
 def create_application_submission_service(repository: JobRepository, settings: Settings) -> ApplicationSubmissionService:
     return ApplicationSubmissionService(
         repository,
-        applicant=create_linkedin_application_flow_inspector(
-            settings,
-            mode="submit",
-        ),
+        applicant=create_linkedin_submission_applicant(settings),
         readiness_checker=ApplicationReadinessCheckService(
             linkedin_storage_state_path=settings.linkedin_storage_state_path,
             resume_path=settings.resume_path,
@@ -202,12 +200,8 @@ def create_linkedin_field_repairer(settings: Settings) -> OllamaLinkedInFieldRep
     )
 
 
-def create_linkedin_application_flow_inspector(
-    settings: Settings,
-    *,
-    mode: str,
-) -> LinkedInApplicationFlowInspector:
-    shared_kwargs = {
+def build_linkedin_application_flow_inspector_kwargs(settings: Settings) -> dict:
+    return {
         "storage_state_path": settings.linkedin_storage_state_path,
         "headless": settings.browser_headless,
         "resume_path": settings.resume_path,
@@ -223,6 +217,14 @@ def create_linkedin_application_flow_inspector(
             artifacts_dir=settings.failure_artifacts_dir,
         ),
     }
+
+
+def create_linkedin_application_flow_inspector(
+    settings: Settings,
+    *,
+    mode: str,
+) -> LinkedInApplicationFlowInspector:
+    shared_kwargs = build_linkedin_application_flow_inspector_kwargs(settings)
     if mode == "preflight":
         return LinkedInApplicationFlowInspector(
             **shared_kwargs,
@@ -234,6 +236,18 @@ def create_linkedin_application_flow_inspector(
             modal_interpreter=create_linkedin_modal_interpreter(settings),
         )
     raise ValueError(f"modo de inspector do LinkedIn nao suportado: {mode}")
+
+
+def create_linkedin_preflight_inspector(settings: Settings) -> LinkedInPreflightInspectorAdapter:
+    return LinkedInPreflightInspectorAdapter(
+        create_linkedin_application_flow_inspector(settings, mode="preflight")
+    )
+
+
+def create_linkedin_submission_applicant(settings: Settings) -> LinkedInSubmissionApplicantAdapter:
+    return LinkedInSubmissionApplicantAdapter(
+        create_linkedin_application_flow_inspector(settings, mode="submit")
+    )
 
 
 def create_notifier(

--- a/job_hunter_agent/collectors/linkedin_application.py
+++ b/job_hunter_agent/collectors/linkedin_application.py
@@ -26,6 +26,10 @@ from job_hunter_agent.collectors.linkedin_application_modal import LinkedInEasyA
 from job_hunter_agent.collectors.linkedin_application_navigation import LinkedInEasyApplyNavigator
 from job_hunter_agent.collectors.linkedin_application_opening import LinkedInEasyApplyFlowOpener
 from job_hunter_agent.collectors.linkedin_application_reader import LinkedInApplicationPageReader
+from job_hunter_agent.collectors.linkedin_application_runtime import (
+    run_linkedin_async,
+    run_with_linkedin_page,
+)
 from job_hunter_agent.collectors.linkedin_application_state import (
     LinkedInApplicationInspection,
     LinkedInApplicationPageState,
@@ -39,7 +43,6 @@ from job_hunter_agent.collectors.linkedin_application_state import (
 from job_hunter_agent.collectors.linkedin_application_submit import (
     evaluate_linkedin_submit_readiness,
 )
-from job_hunter_agent.core.browser_support import load_playwright_storage_state, resolve_local_chromium
 from job_hunter_agent.core.candidate_profile import CandidateProfile
 from job_hunter_agent.core.domain import JobPosting
 
@@ -152,99 +155,67 @@ class LinkedInApplicationFlowInspector:
         return self._submit_sync(job)
 
     def _inspect_sync(self, job: JobPosting) -> LinkedInApplicationInspection:
-        import asyncio
-
-        return asyncio.run(self._inspect_async(job))
+        return run_linkedin_async(self._inspect_async(job))
 
     def _submit_sync(self, job: JobPosting) -> ApplicationSubmissionResult:
-        import asyncio
-
-        return asyncio.run(self._submit_async(job))
+        return run_linkedin_async(self._submit_async(job))
 
     async def _inspect_async(self, job: JobPosting) -> LinkedInApplicationInspection:
-        try:
-            from playwright.async_api import async_playwright
-        except ImportError as exc:
-            raise RuntimeError(
-                "Dependencias de candidatura assistida nao estao instaladas. Rode pip install -r requirements.txt."
-            ) from exc
+        async def _operate(page) -> LinkedInApplicationInspection:
+            await page.goto(job.url, wait_until="domcontentloaded")
+            await self._ensure_target_job_page(page, job)
+            state, readiness = await self._read_state_with_hydration(page, job)
+            if readiness.result != "ready":
+                artifact_detail = await self._capture_failure_artifacts(
+                    page,
+                    state=state,
+                    job=job,
+                    phase="preflight",
+                    detail=f"preflight real bloqueado: {describe_linkedin_job_page_readiness(readiness)}",
+                )
+                inspection = LinkedInApplicationInspection(
+                    outcome="blocked",
+                    detail=f"preflight real bloqueado: {describe_linkedin_job_page_readiness(readiness)}{artifact_detail}",
+                )
+                return inspection
+            state = await self._execution.inspect_preflight_state(page, state)
+            if state.easy_apply and not state.modal_open:
+                artifact_detail = await self._capture_failure_artifacts(
+                    page,
+                    state=state,
+                    job=job,
+                    phase="preflight",
+                    detail="preflight real inconclusivo: CTA de candidatura simplificada encontrado, mas modal nao abriu",
+                )
+            else:
+                artifact_detail = ""
 
-        executable_path = resolve_local_chromium()
-        async with async_playwright() as playwright:
-            browser = await playwright.chromium.launch(
-                executable_path=str(executable_path),
-                headless=self.headless,
-                args=["--start-maximized"],
-            )
-            context = await browser.new_context(storage_state=load_playwright_storage_state(self.storage_state_path))
-            page = await context.new_page()
-            try:
-                await page.goto(job.url, wait_until="domcontentloaded")
-                await self._ensure_target_job_page(page, job)
-                state, readiness = await self._read_state_with_hydration(page, job)
-                if readiness.result != "ready":
-                    artifact_detail = await self._capture_failure_artifacts(
-                        page,
-                        state=state,
-                        job=job,
-                        phase="preflight",
-                        detail=f"preflight real bloqueado: {describe_linkedin_job_page_readiness(readiness)}",
-                    )
+            inspection = classify_linkedin_application_page_state(state)
+            if self.modal_interpretation_formatter is not None and state.modal_open:
+                try:
+                    extra = self.modal_interpretation_formatter(state).strip()
+                except Exception:
+                    extra = ""
+                if extra:
                     inspection = LinkedInApplicationInspection(
-                        outcome="blocked",
-                        detail=f"preflight real bloqueado: {describe_linkedin_job_page_readiness(readiness)}{artifact_detail}",
+                        outcome=inspection.outcome,
+                        detail=f"{inspection.detail} | {extra}",
                     )
-                    return inspection
-                state = await self._execution.inspect_preflight_state(page, state)
-                if state.easy_apply and not state.modal_open:
-                    artifact_detail = await self._capture_failure_artifacts(
-                        page,
-                        state=state,
-                        job=job,
-                        phase="preflight",
-                        detail="preflight real inconclusivo: CTA de candidatura simplificada encontrado, mas modal nao abriu",
-                    )
-                else:
-                    artifact_detail = ""
-            finally:
-                await context.close()
-                await browser.close()
-
-        inspection = classify_linkedin_application_page_state(state)
-        if self.modal_interpretation_formatter is not None and state.modal_open:
-            try:
-                extra = self.modal_interpretation_formatter(state).strip()
-            except Exception:
-                extra = ""
-            if extra:
+            if artifact_detail:
                 inspection = LinkedInApplicationInspection(
                     outcome=inspection.outcome,
-                    detail=f"{inspection.detail} | {extra}",
+                    detail=f"{inspection.detail}{artifact_detail}",
                 )
-        if artifact_detail:
-            inspection = LinkedInApplicationInspection(
-                outcome=inspection.outcome,
-                detail=f"{inspection.detail}{artifact_detail}",
-            )
-        return inspection
+            return inspection
+
+        return await run_with_linkedin_page(
+            storage_state_path=self.storage_state_path,
+            headless=self.headless,
+            page_operation=_operate,
+        )
 
     async def _submit_async(self, job: JobPosting) -> ApplicationSubmissionResult:
-        try:
-            from playwright.async_api import async_playwright
-        except ImportError as exc:
-            raise RuntimeError(
-                "Dependencias de candidatura assistida nao estao instaladas. Rode pip install -r requirements.txt."
-            ) from exc
-
-        executable_path = resolve_local_chromium()
-        async with async_playwright() as playwright:
-            browser = await playwright.chromium.launch(
-                executable_path=str(executable_path),
-                headless=self.headless,
-                args=["--start-maximized"],
-            )
-            context = await browser.new_context(storage_state=load_playwright_storage_state(self.storage_state_path))
-            page = await context.new_page()
+        async def _operate(page) -> ApplicationSubmissionResult:
             state = LinkedInApplicationPageState()
             try:
                 await page.goto(job.url, wait_until="domcontentloaded")
@@ -310,13 +281,15 @@ class LinkedInApplicationFlowInspector:
                 )
             except Exception as exc:
                 return await self._build_submit_exception_result(exc, page=page, state=state, job=job)
-            finally:
-                await context.close()
-                await browser.close()
+
+        return await run_with_linkedin_page(
+            storage_state_path=self.storage_state_path,
+            headless=self.headless,
+            page_operation=_operate,
+        )
 
     async def _read_page_state(self, page) -> LinkedInApplicationPageState:
         return await self._page_reader.read(page)
-
 
     def _assess_job_page_readiness(
         self,
@@ -513,5 +486,3 @@ class LinkedInApplicationFlowInspector:
 
     async def _detect_submit_success(self, page) -> bool:
         return await self._modal_driver.detect_submit_success(page)
-
-

--- a/job_hunter_agent/collectors/linkedin_application.py
+++ b/job_hunter_agent/collectors/linkedin_application.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from datetime import datetime
 from pathlib import Path
 from typing import Callable, TYPE_CHECKING
 
@@ -26,10 +25,7 @@ from job_hunter_agent.collectors.linkedin_application_modal import LinkedInEasyA
 from job_hunter_agent.collectors.linkedin_application_navigation import LinkedInEasyApplyNavigator
 from job_hunter_agent.collectors.linkedin_application_opening import LinkedInEasyApplyFlowOpener
 from job_hunter_agent.collectors.linkedin_application_reader import LinkedInApplicationPageReader
-from job_hunter_agent.collectors.linkedin_application_runtime import (
-    run_linkedin_async,
-    run_with_linkedin_page,
-)
+from job_hunter_agent.collectors.linkedin_application_runtime import run_linkedin_async
 from job_hunter_agent.collectors.linkedin_application_state import (
     LinkedInApplicationInspection,
     LinkedInApplicationPageState,
@@ -40,9 +36,7 @@ from job_hunter_agent.collectors.linkedin_application_state import (
     describe_linkedin_job_page_readiness,
     describe_linkedin_modal_blocker,
 )
-from job_hunter_agent.collectors.linkedin_application_submit import (
-    evaluate_linkedin_submit_readiness,
-)
+from job_hunter_agent.collectors.linkedin_application_submission_flow import submit_linkedin_application
 from job_hunter_agent.core.candidate_profile import CandidateProfile
 from job_hunter_agent.core.domain import JobPosting
 
@@ -174,77 +168,17 @@ class LinkedInApplicationFlowInspector:
         )
 
     async def _submit_async(self, job: JobPosting) -> ApplicationSubmissionResult:
-        async def _operate(page) -> ApplicationSubmissionResult:
-            state = LinkedInApplicationPageState()
-            try:
-                await page.goto(job.url, wait_until="domcontentloaded")
-                await self._ensure_target_job_page(page, job)
-                state, readiness = await self._read_state_with_hydration(page, job)
-                if readiness.result != "ready":
-                    artifact_detail = await self._capture_failure_artifacts(
-                        page,
-                        state=state,
-                        job=job,
-                        phase="submit",
-                        detail=f"submissao real bloqueada: {describe_linkedin_job_page_readiness(readiness)}",
-                    )
-                    return ApplicationSubmissionResult(
-                        status="error_submit",
-                        detail=f"submissao real bloqueada: {describe_linkedin_job_page_readiness(readiness)}{artifact_detail}",
-                    )
-                if not state.easy_apply:
-                    return ApplicationSubmissionResult(
-                        status="error_submit",
-                        detail="submissao real bloqueada: CTA de candidatura simplificada nao encontrado",
-                    )
-                state = await self._execution.prepare_submit_state(page, state)
-                if not state.modal_open or not state.modal_submit_visible:
-                    submit_readiness = evaluate_linkedin_submit_readiness(
-                        state,
-                        interpretation_detail=self._format_modal_interpretation_for_error(state),
-                    )
-                    artifact_detail = await self._capture_failure_artifacts(
-                        page,
-                        state=state,
-                        job=job,
-                        phase="submit",
-                        detail=(
-                            "submissao real bloqueada: fluxo nao chegou ao botao de envio"
-                            f" | bloqueio={describe_linkedin_modal_blocker(state)}"
-                        ),
-                    )
-                    return ApplicationSubmissionResult(
-                        status="error_submit",
-                        detail=f"{submit_readiness.detail}{artifact_detail}",
-                    )
-                submitted = await self._execution.submit(page)
-                if not submitted:
-                    artifact_detail = await self._capture_failure_artifacts(
-                        page,
-                        state=state,
-                        job=job,
-                        phase="submit",
-                        detail="submissao real falhou: clique final de envio nao confirmou sucesso",
-                    )
-                    return ApplicationSubmissionResult(
-                        status="error_submit",
-                        detail=(
-                            "submissao real falhou: clique final de envio nao confirmou sucesso"
-                            f"{artifact_detail}"
-                        ),
-                    )
-                return ApplicationSubmissionResult(
-                    status="submitted",
-                    detail="submissao real concluida no LinkedIn",
-                    submitted_at=datetime.now().isoformat(timespec="seconds"),
-                )
-            except Exception as exc:
-                return await self._build_submit_exception_result(exc, page=page, state=state, job=job)
-
-        return await run_with_linkedin_page(
+        return await submit_linkedin_application(
+            job=job,
             storage_state_path=self.storage_state_path,
             headless=self.headless,
-            page_operation=_operate,
+            ensure_target_job_page=self._ensure_target_job_page,
+            read_state_with_hydration=self._read_state_with_hydration,
+            capture_failure_artifacts=self._capture_failure_artifacts,
+            prepare_submit_state=self._execution.prepare_submit_state,
+            execution_submit=self._execution.submit,
+            format_modal_interpretation_for_error=self._format_modal_interpretation_for_error,
+            build_submit_exception_result=self._build_submit_exception_result,
         )
 
     async def _read_page_state(self, page) -> LinkedInApplicationPageState:

--- a/job_hunter_agent/collectors/linkedin_application.py
+++ b/job_hunter_agent/collectors/linkedin_application.py
@@ -15,13 +15,13 @@ from job_hunter_agent.collectors.linkedin_application_entrypoint import (
     classify_linkedin_job_page_readiness,
     extract_linkedin_job_id,
     needs_canonical_job_navigation,
-    recover_linkedin_direct_apply_url_from_html,
 )
 from job_hunter_agent.collectors.linkedin_application_entry_strategies import (
     LinkedInApplyHrefEntrypointStrategy,
     LinkedInApplyHtmlRecoveryStrategy,
 )
 from job_hunter_agent.collectors.linkedin_application_execution import LinkedInEasyApplyExecution
+from job_hunter_agent.collectors.linkedin_application_inspection import inspect_linkedin_application
 from job_hunter_agent.collectors.linkedin_application_modal import LinkedInEasyApplyModalDriver
 from job_hunter_agent.collectors.linkedin_application_navigation import LinkedInEasyApplyNavigator
 from job_hunter_agent.collectors.linkedin_application_opening import LinkedInEasyApplyFlowOpener
@@ -161,57 +161,16 @@ class LinkedInApplicationFlowInspector:
         return run_linkedin_async(self._submit_async(job))
 
     async def _inspect_async(self, job: JobPosting) -> LinkedInApplicationInspection:
-        async def _operate(page) -> LinkedInApplicationInspection:
-            await page.goto(job.url, wait_until="domcontentloaded")
-            await self._ensure_target_job_page(page, job)
-            state, readiness = await self._read_state_with_hydration(page, job)
-            if readiness.result != "ready":
-                artifact_detail = await self._capture_failure_artifacts(
-                    page,
-                    state=state,
-                    job=job,
-                    phase="preflight",
-                    detail=f"preflight real bloqueado: {describe_linkedin_job_page_readiness(readiness)}",
-                )
-                inspection = LinkedInApplicationInspection(
-                    outcome="blocked",
-                    detail=f"preflight real bloqueado: {describe_linkedin_job_page_readiness(readiness)}{artifact_detail}",
-                )
-                return inspection
-            state = await self._execution.inspect_preflight_state(page, state)
-            if state.easy_apply and not state.modal_open:
-                artifact_detail = await self._capture_failure_artifacts(
-                    page,
-                    state=state,
-                    job=job,
-                    phase="preflight",
-                    detail="preflight real inconclusivo: CTA de candidatura simplificada encontrado, mas modal nao abriu",
-                )
-            else:
-                artifact_detail = ""
-
-            inspection = classify_linkedin_application_page_state(state)
-            if self.modal_interpretation_formatter is not None and state.modal_open:
-                try:
-                    extra = self.modal_interpretation_formatter(state).strip()
-                except Exception:
-                    extra = ""
-                if extra:
-                    inspection = LinkedInApplicationInspection(
-                        outcome=inspection.outcome,
-                        detail=f"{inspection.detail} | {extra}",
-                    )
-            if artifact_detail:
-                inspection = LinkedInApplicationInspection(
-                    outcome=inspection.outcome,
-                    detail=f"{inspection.detail}{artifact_detail}",
-                )
-            return inspection
-
-        return await run_with_linkedin_page(
+        return await inspect_linkedin_application(
+            job=job,
             storage_state_path=self.storage_state_path,
             headless=self.headless,
-            page_operation=_operate,
+            ensure_target_job_page=self._ensure_target_job_page,
+            read_state_with_hydration=self._read_state_with_hydration,
+            capture_failure_artifacts=self._capture_failure_artifacts,
+            inspect_preflight_state=self._execution.inspect_preflight_state,
+            classify_page_state=classify_linkedin_application_page_state,
+            modal_interpretation_formatter=self.modal_interpretation_formatter,
         )
 
     async def _submit_async(self, job: JobPosting) -> ApplicationSubmissionResult:

--- a/job_hunter_agent/collectors/linkedin_application_adapters.py
+++ b/job_hunter_agent/collectors/linkedin_application_adapters.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+
+class LinkedInPreflightInspectorAdapter:
+    def __init__(self, inspector) -> None:
+        self._inspector = inspector
+
+    def inspect(self, job):
+        return self._inspector.inspect(job)
+
+
+class LinkedInSubmissionApplicantAdapter:
+    def __init__(self, inspector) -> None:
+        self._inspector = inspector
+
+    def submit(self, application, job):
+        return self._inspector.submit(application, job)

--- a/job_hunter_agent/collectors/linkedin_application_inspection.py
+++ b/job_hunter_agent/collectors/linkedin_application_inspection.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from pathlib import Path
+
+from job_hunter_agent.collectors.linkedin_application_runtime import run_with_linkedin_page
+from job_hunter_agent.collectors.linkedin_application_state import (
+    LinkedInApplicationInspection,
+    LinkedInApplicationPageState,
+    describe_linkedin_job_page_readiness,
+)
+from job_hunter_agent.core.domain import JobPosting
+
+
+async def inspect_linkedin_application(
+    *,
+    job: JobPosting,
+    storage_state_path: Path,
+    headless: bool,
+    ensure_target_job_page: Callable[[object, JobPosting], Awaitable[None]],
+    read_state_with_hydration: Callable[[object, JobPosting], Awaitable[tuple[LinkedInApplicationPageState, object]]],
+    capture_failure_artifacts: Callable[..., Awaitable[str]],
+    inspect_preflight_state: Callable[[object, LinkedInApplicationPageState], Awaitable[LinkedInApplicationPageState]],
+    classify_page_state: Callable[[LinkedInApplicationPageState], LinkedInApplicationInspection],
+    modal_interpretation_formatter: Callable[[LinkedInApplicationPageState], str] | None,
+) -> LinkedInApplicationInspection:
+    async def _operate(page) -> LinkedInApplicationInspection:
+        await page.goto(job.url, wait_until="domcontentloaded")
+        await ensure_target_job_page(page, job)
+        state, readiness = await read_state_with_hydration(page, job)
+        if readiness.result != "ready":
+            artifact_detail = await capture_failure_artifacts(
+                page,
+                state=state,
+                job=job,
+                phase="preflight",
+                detail=f"preflight real bloqueado: {describe_linkedin_job_page_readiness(readiness)}",
+            )
+            return LinkedInApplicationInspection(
+                outcome="blocked",
+                detail=f"preflight real bloqueado: {describe_linkedin_job_page_readiness(readiness)}{artifact_detail}",
+            )
+        state = await inspect_preflight_state(page, state)
+        if state.easy_apply and not state.modal_open:
+            artifact_detail = await capture_failure_artifacts(
+                page,
+                state=state,
+                job=job,
+                phase="preflight",
+                detail="preflight real inconclusivo: CTA de candidatura simplificada encontrado, mas modal nao abriu",
+            )
+        else:
+            artifact_detail = ""
+
+        inspection = classify_page_state(state)
+        if modal_interpretation_formatter is not None and state.modal_open:
+            try:
+                extra = modal_interpretation_formatter(state).strip()
+            except Exception:
+                extra = ""
+            if extra:
+                inspection = LinkedInApplicationInspection(
+                    outcome=inspection.outcome,
+                    detail=f"{inspection.detail} | {extra}",
+                )
+        if artifact_detail:
+            inspection = LinkedInApplicationInspection(
+                outcome=inspection.outcome,
+                detail=f"{inspection.detail}{artifact_detail}",
+            )
+        return inspection
+
+    return await run_with_linkedin_page(
+        storage_state_path=storage_state_path,
+        headless=headless,
+        page_operation=_operate,
+    )

--- a/job_hunter_agent/collectors/linkedin_application_runtime.py
+++ b/job_hunter_agent/collectors/linkedin_application_runtime.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from pathlib import Path
+from typing import TypeVar
+
+from job_hunter_agent.core.browser_support import load_playwright_storage_state, resolve_local_chromium
+
+T = TypeVar("T")
+
+
+def run_linkedin_async(coroutine: Awaitable[T]) -> T:
+    import asyncio
+
+    return asyncio.run(coroutine)
+
+
+async def run_with_linkedin_page(
+    *,
+    storage_state_path: Path,
+    headless: bool,
+    page_operation: Callable[[object], Awaitable[T]],
+) -> T:
+    try:
+        from playwright.async_api import async_playwright
+    except ImportError as exc:
+        raise RuntimeError(
+            "Dependencias de candidatura assistida nao estao instaladas. Rode pip install -r requirements.txt."
+        ) from exc
+
+    executable_path = resolve_local_chromium()
+    async with async_playwright() as playwright:
+        browser = await playwright.chromium.launch(
+            executable_path=str(executable_path),
+            headless=headless,
+            args=["--start-maximized"],
+        )
+        context = await browser.new_context(storage_state=load_playwright_storage_state(storage_state_path))
+        page = await context.new_page()
+        try:
+            return await page_operation(page)
+        finally:
+            await context.close()
+            await browser.close()

--- a/job_hunter_agent/collectors/linkedin_application_submission_flow.py
+++ b/job_hunter_agent/collectors/linkedin_application_submission_flow.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from datetime import datetime
+from pathlib import Path
+
+from job_hunter_agent.application.contracts import ApplicationSubmissionResult
+from job_hunter_agent.collectors.linkedin_application_runtime import run_with_linkedin_page
+from job_hunter_agent.collectors.linkedin_application_state import (
+    LinkedInApplicationPageState,
+    describe_linkedin_job_page_readiness,
+    describe_linkedin_modal_blocker,
+)
+from job_hunter_agent.collectors.linkedin_application_submit import evaluate_linkedin_submit_readiness
+from job_hunter_agent.core.domain import JobPosting
+
+
+async def submit_linkedin_application(
+    *,
+    job: JobPosting,
+    storage_state_path: Path,
+    headless: bool,
+    ensure_target_job_page: Callable[[object, JobPosting], Awaitable[None]],
+    read_state_with_hydration: Callable[[object, JobPosting], Awaitable[tuple[LinkedInApplicationPageState, object]]],
+    capture_failure_artifacts: Callable[..., Awaitable[str]],
+    prepare_submit_state: Callable[[object, LinkedInApplicationPageState], Awaitable[LinkedInApplicationPageState]],
+    execution_submit: Callable[[object], Awaitable[bool]],
+    format_modal_interpretation_for_error: Callable[[LinkedInApplicationPageState], str],
+    build_submit_exception_result: Callable[..., Awaitable[ApplicationSubmissionResult]],
+) -> ApplicationSubmissionResult:
+    async def _operate(page) -> ApplicationSubmissionResult:
+        state = LinkedInApplicationPageState()
+        try:
+            await page.goto(job.url, wait_until="domcontentloaded")
+            await ensure_target_job_page(page, job)
+            state, readiness = await read_state_with_hydration(page, job)
+            if readiness.result != "ready":
+                artifact_detail = await capture_failure_artifacts(
+                    page,
+                    state=state,
+                    job=job,
+                    phase="submit",
+                    detail=f"submissao real bloqueada: {describe_linkedin_job_page_readiness(readiness)}",
+                )
+                return ApplicationSubmissionResult(
+                    status="error_submit",
+                    detail=f"submissao real bloqueada: {describe_linkedin_job_page_readiness(readiness)}{artifact_detail}",
+                )
+            if not state.easy_apply:
+                return ApplicationSubmissionResult(
+                    status="error_submit",
+                    detail="submissao real bloqueada: CTA de candidatura simplificada nao encontrado",
+                )
+            state = await prepare_submit_state(page, state)
+            if not state.modal_open or not state.modal_submit_visible:
+                submit_readiness = evaluate_linkedin_submit_readiness(
+                    state,
+                    interpretation_detail=format_modal_interpretation_for_error(state),
+                )
+                artifact_detail = await capture_failure_artifacts(
+                    page,
+                    state=state,
+                    job=job,
+                    phase="submit",
+                    detail=(
+                        "submissao real bloqueada: fluxo nao chegou ao botao de envio"
+                        f" | bloqueio={describe_linkedin_modal_blocker(state)}"
+                    ),
+                )
+                return ApplicationSubmissionResult(
+                    status="error_submit",
+                    detail=f"{submit_readiness.detail}{artifact_detail}",
+                )
+            submitted = await execution_submit(page)
+            if not submitted:
+                artifact_detail = await capture_failure_artifacts(
+                    page,
+                    state=state,
+                    job=job,
+                    phase="submit",
+                    detail="submissao real falhou: clique final de envio nao confirmou sucesso",
+                )
+                return ApplicationSubmissionResult(
+                    status="error_submit",
+                    detail=(
+                        "submissao real falhou: clique final de envio nao confirmou sucesso"
+                        f"{artifact_detail}"
+                    ),
+                )
+            return ApplicationSubmissionResult(
+                status="submitted",
+                detail="submissao real concluida no LinkedIn",
+                submitted_at=datetime.now().isoformat(timespec="seconds"),
+            )
+        except Exception as exc:
+            return await build_submit_exception_result(exc, page=page, state=state, job=job)
+
+    return await run_with_linkedin_page(
+        storage_state_path=storage_state_path,
+        headless=headless,
+        page_operation=_operate,
+    )

--- a/tests/test_application_ports.py
+++ b/tests/test_application_ports.py
@@ -1,0 +1,34 @@
+import unittest
+
+from job_hunter_agent.application.application_ports import (
+    normalize_application_flow_inspection,
+    normalize_application_submission_result,
+)
+
+
+class ApplicationPortsTests(unittest.TestCase):
+    def test_normalize_application_flow_inspection_rejects_invalid_outcome(self) -> None:
+        result = normalize_application_flow_inspection(
+            type("Inspection", (), {"outcome": "weird", "detail": "algo"})()
+        )
+
+        self.assertEqual(result.outcome, "error")
+        self.assertIn("outcome invalido", result.detail)
+
+    def test_normalize_application_submission_result_preserves_external_reference(self) -> None:
+        result = normalize_application_submission_result(
+            type(
+                "Submission",
+                (),
+                {
+                    "status": "submitted",
+                    "detail": "ok",
+                    "submitted_at": "2026-04-11T19:00:00",
+                    "external_reference": "linkedin-123",
+                },
+            )()
+        )
+
+        self.assertEqual(result.status, "submitted")
+        self.assertEqual(result.external_reference, "linkedin-123")
+        self.assertEqual(result.submitted_at, "2026-04-11T19:00:00")

--- a/tests/test_composition_injection.py
+++ b/tests/test_composition_injection.py
@@ -3,7 +3,7 @@ from unittest.mock import patch
 
 
 class CompositionInjectionTests(unittest.TestCase):
-    def test_create_linkedin_application_flow_inspector_injects_artifact_capture(self) -> None:
+    def test_create_linkedin_preflight_inspector_injects_artifact_capture(self) -> None:
         settings = type(
             "Settings",
             (),
@@ -24,21 +24,58 @@ class CompositionInjectionTests(unittest.TestCase):
         )()
 
         candidate_profile = object()
+        sentinel_inspector = object()
 
         with patch(
             "job_hunter_agent.application.composition.load_candidate_profile",
             return_value=candidate_profile,
         ) as load_profile, patch(
             "job_hunter_agent.application.composition.LinkedInApplicationFlowInspector",
-            return_value="inspector",
+            return_value=sentinel_inspector,
         ) as inspector_factory:
-            from job_hunter_agent.application.composition import create_linkedin_application_flow_inspector
+            from job_hunter_agent.application.composition import create_linkedin_preflight_inspector
 
-            create_linkedin_application_flow_inspector(settings, mode="preflight")
+            adapter = create_linkedin_preflight_inspector(settings)
 
-        # Confirma que artifact_capture foi passado como kwarg
         kwargs = inspector_factory.call_args.kwargs  # type: ignore[attr-defined]
         self.assertIn("artifact_capture", kwargs)
         self.assertTrue(kwargs["artifact_capture"].enabled)
         self.assertEqual(str(kwargs["artifact_capture"].artifacts_dir), ".tmp-tests/failure-artifacts")
+        self.assertIs(adapter._inspector, sentinel_inspector)
         load_profile.assert_called_once_with("candidate_profile.json")
+
+    def test_create_linkedin_submission_applicant_wraps_submit_mode_inspector(self) -> None:
+        settings = type(
+            "Settings",
+            (),
+            {
+                "linkedin_storage_state_path": "linkedin-state.json",
+                "browser_headless": True,
+                "resume_path": "resume.pdf",
+                "application_contact_email": "vinicius@example.com",
+                "application_phone": "11999999999",
+                "application_phone_country_code": "55",
+                "candidate_profile_path": "candidate_profile.json",
+                "save_failure_artifacts": True,
+                "failure_artifacts_dir": ".tmp-tests/failure-artifacts",
+                "linkedin_modal_llm_enabled": False,
+                "ollama_model": "llama3",
+                "ollama_url": "http://localhost:11434",
+            },
+        )()
+
+        with patch(
+            "job_hunter_agent.application.composition.load_candidate_profile",
+            return_value=object(),
+        ), patch(
+            "job_hunter_agent.application.composition.LinkedInApplicationFlowInspector",
+            return_value=object(),
+        ) as inspector_factory:
+            from job_hunter_agent.application.composition import create_linkedin_submission_applicant
+
+            adapter = create_linkedin_submission_applicant(settings)
+
+        kwargs = inspector_factory.call_args.kwargs  # type: ignore[attr-defined]
+        self.assertIn("modal_interpreter", kwargs)
+        self.assertFalse(hasattr(adapter, "inspect"))
+        self.assertTrue(hasattr(adapter, "submit"))

--- a/tests/test_linkedin_application_inspection.py
+++ b/tests/test_linkedin_application_inspection.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from job_hunter_agent.collectors.linkedin_application_inspection import inspect_linkedin_application
+from job_hunter_agent.collectors.linkedin_application_state import (
+    LinkedInApplicationInspection,
+    LinkedInApplicationPageState,
+)
+
+
+class LinkedInApplicationInspectionFlowTests(unittest.TestCase):
+    def test_inspect_linkedin_application_returns_blocked_when_readiness_is_not_ready(self) -> None:
+        job = type("Job", (), {"url": "https://www.linkedin.com/jobs/view/123/"})()
+
+        async def fake_ensure(page, current_job):
+            return None
+
+        async def fake_read(page, current_job):
+            return (
+                LinkedInApplicationPageState(easy_apply=False),
+                type("Readiness", (), {"result": "listing_redirect", "reason": "redirect", "sample": "sample"})(),
+            )
+
+        async def fake_capture(page, **kwargs):
+            return " | artefatos=ok"
+
+        async def fake_preflight(page, state):
+            return state
+
+        async def fake_run_with_linkedin_page(*, storage_state_path, headless, page_operation):
+            class _Page:
+                async def goto(self, url, wait_until="domcontentloaded"):
+                    return None
+
+            return await page_operation(_Page())
+
+        with patch(
+            "job_hunter_agent.collectors.linkedin_application_inspection.run_with_linkedin_page",
+            side_effect=fake_run_with_linkedin_page,
+        ):
+            result = inspect_linkedin_application(
+                job=job,
+                storage_state_path=Path("linkedin-state.json"),
+                headless=True,
+                ensure_target_job_page=fake_ensure,
+                read_state_with_hydration=fake_read,
+                capture_failure_artifacts=fake_capture,
+                inspect_preflight_state=fake_preflight,
+                classify_page_state=lambda state: LinkedInApplicationInspection(outcome="ready", detail="ok"),
+                modal_interpretation_formatter=None,
+            )
+            inspection = __import__("asyncio").run(result)
+
+        self.assertEqual(inspection.outcome, "blocked")
+        self.assertIn("preflight real bloqueado", inspection.detail)
+        self.assertIn("artefatos=ok", inspection.detail)
+
+    def test_inspect_linkedin_application_appends_modal_interpretation(self) -> None:
+        job = type("Job", (), {"url": "https://www.linkedin.com/jobs/view/123/"})()
+
+        async def fake_ensure(page, current_job):
+            return None
+
+        async def fake_read(page, current_job):
+            return (
+                LinkedInApplicationPageState(easy_apply=True, modal_open=True),
+                type("Readiness", (), {"result": "ready", "reason": "", "sample": ""})(),
+            )
+
+        async def fake_capture(page, **kwargs):
+            return ""
+
+        async def fake_preflight(page, state):
+            return state
+
+        async def fake_run_with_linkedin_page(*, storage_state_path, headless, page_operation):
+            class _Page:
+                async def goto(self, url, wait_until="domcontentloaded"):
+                    return None
+
+            return await page_operation(_Page())
+
+        with patch(
+            "job_hunter_agent.collectors.linkedin_application_inspection.run_with_linkedin_page",
+            side_effect=fake_run_with_linkedin_page,
+        ):
+            result = inspect_linkedin_application(
+                job=job,
+                storage_state_path=Path("linkedin-state.json"),
+                headless=True,
+                ensure_target_job_page=fake_ensure,
+                read_state_with_hydration=fake_read,
+                capture_failure_artifacts=fake_capture,
+                inspect_preflight_state=fake_preflight,
+                classify_page_state=lambda state: LinkedInApplicationInspection(outcome="ready", detail="base"),
+                modal_interpretation_formatter=lambda state: "acao=submit_if_authorized",
+            )
+            inspection = __import__("asyncio").run(result)
+
+        self.assertEqual(inspection.outcome, "ready")
+        self.assertIn("base | acao=submit_if_authorized", inspection.detail)

--- a/tests/test_linkedin_application_runtime.py
+++ b/tests/test_linkedin_application_runtime.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+import sys
+import types
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from job_hunter_agent.collectors.linkedin_application_runtime import (
+    run_linkedin_async,
+    run_with_linkedin_page,
+)
+
+
+class LinkedInApplicationRuntimeTests(unittest.TestCase):
+    def test_run_linkedin_async_executes_coroutine(self) -> None:
+        async def _sample() -> str:
+            return "ok"
+
+        result = run_linkedin_async(_sample())
+
+        self.assertEqual(result, "ok")
+
+    def test_run_with_linkedin_page_bootstraps_browser_context_and_page(self) -> None:
+        events: list[str] = []
+
+        class _Page:
+            pass
+
+        class _Context:
+            def __init__(self) -> None:
+                self.page = _Page()
+
+            async def new_page(self):
+                events.append("new_page")
+                return self.page
+
+            async def close(self):
+                events.append("context_close")
+
+        class _Browser:
+            def __init__(self) -> None:
+                self.context = _Context()
+
+            async def new_context(self, storage_state=None):
+                events.append(f"new_context:{storage_state}")
+                return self.context
+
+            async def close(self):
+                events.append("browser_close")
+
+        class _Chromium:
+            async def launch(self, executable_path=None, headless=None, args=None):
+                events.append(f"launch:{headless}:{args}")
+                return _Browser()
+
+        class _PlaywrightManager:
+            def __init__(self) -> None:
+                self.chromium = _Chromium()
+
+            async def __aenter__(self):
+                events.append("playwright_enter")
+                return self
+
+            async def __aexit__(self, exc_type, exc, tb):
+                events.append("playwright_exit")
+
+        fake_async_api = types.SimpleNamespace(async_playwright=lambda: _PlaywrightManager())
+        previous_module = sys.modules.get("playwright.async_api")
+        sys.modules["playwright.async_api"] = fake_async_api
+        try:
+            with patch(
+                "job_hunter_agent.collectors.linkedin_application_runtime.resolve_local_chromium",
+                return_value=Path("/tmp/chromium"),
+            ), patch(
+                "job_hunter_agent.collectors.linkedin_application_runtime.load_playwright_storage_state",
+                return_value={"cookies": []},
+            ):
+                async def _operation(page) -> str:
+                    events.append(f"operate:{type(page).__name__}")
+                    return "done"
+
+                result = run_linkedin_async(
+                    run_with_linkedin_page(
+                        storage_state_path=Path("linkedin-state.json"),
+                        headless=True,
+                        page_operation=_operation,
+                    )
+                )
+        finally:
+            if previous_module is None:
+                sys.modules.pop("playwright.async_api", None)
+            else:
+                sys.modules["playwright.async_api"] = previous_module
+
+        self.assertEqual(result, "done")
+        self.assertIn("playwright_enter", events)
+        self.assertIn("new_page", events)
+        self.assertIn("operate:_Page", events)
+        self.assertIn("context_close", events)
+        self.assertIn("browser_close", events)
+        self.assertIn("playwright_exit", events)

--- a/tests/test_linkedin_application_submission_flow.py
+++ b/tests/test_linkedin_application_submission_flow.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+import asyncio
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from job_hunter_agent.collectors.linkedin_application_state import LinkedInApplicationPageState
+from job_hunter_agent.collectors.linkedin_application_submission_flow import submit_linkedin_application
+
+
+class LinkedInApplicationSubmissionFlowTests(unittest.TestCase):
+    def test_submit_linkedin_application_returns_error_when_cta_is_missing(self) -> None:
+        job = type("Job", (), {"url": "https://www.linkedin.com/jobs/view/123/"})()
+
+        async def fake_ensure(page, current_job):
+            return None
+
+        async def fake_read(page, current_job):
+            return (
+                LinkedInApplicationPageState(easy_apply=False),
+                type("Readiness", (), {"result": "ready", "reason": "", "sample": ""})(),
+            )
+
+        async def fake_capture(page, **kwargs):
+            return ""
+
+        async def fake_prepare(page, state):
+            return state
+
+        async def fake_submit(page):
+            return True
+
+        async def fake_exception_result(exc, **kwargs):
+            raise AssertionError("exception path should not run")
+
+        async def fake_run_with_linkedin_page(*, storage_state_path, headless, page_operation):
+            class _Page:
+                async def goto(self, url, wait_until="domcontentloaded"):
+                    return None
+
+            return await page_operation(_Page())
+
+        with patch(
+            "job_hunter_agent.collectors.linkedin_application_submission_flow.run_with_linkedin_page",
+            side_effect=fake_run_with_linkedin_page,
+        ):
+            result = asyncio.run(
+                submit_linkedin_application(
+                    job=job,
+                    storage_state_path=Path("linkedin-state.json"),
+                    headless=True,
+                    ensure_target_job_page=fake_ensure,
+                    read_state_with_hydration=fake_read,
+                    capture_failure_artifacts=fake_capture,
+                    prepare_submit_state=fake_prepare,
+                    execution_submit=fake_submit,
+                    format_modal_interpretation_for_error=lambda state: "",
+                    build_submit_exception_result=fake_exception_result,
+                )
+            )
+
+        self.assertEqual(result.status, "error_submit")
+        self.assertIn("CTA de candidatura simplificada nao encontrado", result.detail)
+
+    def test_submit_linkedin_application_returns_submitted_when_flow_succeeds(self) -> None:
+        job = type("Job", (), {"url": "https://www.linkedin.com/jobs/view/123/"})()
+
+        async def fake_ensure(page, current_job):
+            return None
+
+        async def fake_read(page, current_job):
+            return (
+                LinkedInApplicationPageState(easy_apply=True),
+                type("Readiness", (), {"result": "ready", "reason": "", "sample": ""})(),
+            )
+
+        async def fake_capture(page, **kwargs):
+            return ""
+
+        async def fake_prepare(page, state):
+            return LinkedInApplicationPageState(
+                easy_apply=True,
+                modal_open=True,
+                modal_submit_visible=True,
+            )
+
+        async def fake_submit(page):
+            return True
+
+        async def fake_exception_result(exc, **kwargs):
+            raise AssertionError("exception path should not run")
+
+        async def fake_run_with_linkedin_page(*, storage_state_path, headless, page_operation):
+            class _Page:
+                async def goto(self, url, wait_until="domcontentloaded"):
+                    return None
+
+            return await page_operation(_Page())
+
+        with patch(
+            "job_hunter_agent.collectors.linkedin_application_submission_flow.run_with_linkedin_page",
+            side_effect=fake_run_with_linkedin_page,
+        ):
+            result = asyncio.run(
+                submit_linkedin_application(
+                    job=job,
+                    storage_state_path=Path("linkedin-state.json"),
+                    headless=True,
+                    ensure_target_job_page=fake_ensure,
+                    read_state_with_hydration=fake_read,
+                    capture_failure_artifacts=fake_capture,
+                    prepare_submit_state=fake_prepare,
+                    execution_submit=fake_submit,
+                    format_modal_interpretation_for_error=lambda state: "",
+                    build_submit_exception_result=fake_exception_result,
+                )
+            )
+
+        self.assertEqual(result.status, "submitted")
+        self.assertIn("submissao real concluida no LinkedIn", result.detail)


### PR DESCRIPTION
## Resumo

Este PR continua a frente de endurecimento estrutural e reduz o acoplamento entre servicos de aplicacao e o executor do LinkedIn.

## O que entrou

- extrai runtime do Playwright para `linkedin_application_runtime.py`
- extrai orquestracao de inspecao para `linkedin_application_inspection.py`
- extrai orquestracao de submit para `linkedin_application_submission_flow.py`
- adiciona adaptadores menores para preflight e submit em `linkedin_application_adapters.py`
- centraliza ports compartilhados de preflight e submit em `application_ports.py`
- reduz a concentracao de responsabilidade em `linkedin_application.py`
- reduz duplicacao entre `application_preflight.py` e `application_submission.py`
- adiciona testes diretos das novas fronteiras

## Impacto esperado

- menor acoplamento entre servicos da aplicacao e o adaptador do LinkedIn
- fronteiras mais explicitas entre runtime, orquestracao e acoes de portal
- base melhor para continuar aproximando `linkedin_application.py` do papel de adaptador
- aumento de testabilidade em recortes menores

## Observacoes

- a branch esta sincronizada com a `master`
- a pipeline desta branch ja foi validada pelo ultimo ajuste
- mantive a compatibilidade com as expectativas atuais da suite de composicao ao corrigir o wiring final
