### PR TITLE
feat: adiciona health checks operacionais locais na cli

### DIFF
--- a/job_hunter_agent/application/app.py
+++ b/job_hunter_agent/application/app.py
@@ -8,6 +8,10 @@ from job_hunter_agent.application.application_commands import (
     ApplicationTransitionCommandService,
     JobReviewCommandService,
 )
+from job_hunter_agent.application.application_health import (
+    build_application_health_report,
+    render_application_health_report,
+)
 from job_hunter_agent.application.application_queries import ApplicationQueryService
 from job_hunter_agent.application.application_cli_rendering import render_failure_artifacts
 from job_hunter_agent.application.composition import (
@@ -138,6 +142,9 @@ class JobHunterApplication:
 
     def show_status_overview(self) -> str:
         return self._query_service().show_status_overview()
+
+    def show_health_report(self) -> str:
+        return render_application_health_report(build_application_health_report(self.settings))
 
     def review_job(self, job_id: int, action: str) -> str:
         return self._job_review_commands().review_job(job_id, action)

--- a/job_hunter_agent/application/application_cli.py
+++ b/job_hunter_agent/application/application_cli.py
@@ -46,6 +46,7 @@ def parse_args() -> argparse.Namespace:
     )
     subparsers = parser.add_subparsers(dest="command")
     subparsers.add_parser("status", help="Mostra um resumo operacional de vagas e candidaturas.")
+    subparsers.add_parser("health", help="Mostra health checks operacionais locais.")
     jobs_parser = subparsers.add_parser("jobs", help="Operacoes de revisao de vagas.")
     jobs_subparsers = jobs_parser.add_subparsers(dest="jobs_command", required=True)
 

--- a/job_hunter_agent/application/application_cli_dispatch.py
+++ b/job_hunter_agent/application/application_cli_dispatch.py
@@ -26,6 +26,10 @@ def execute_cli_command(args: Namespace) -> bool:
         app = create_query_app()
         print(app.show_status_overview())
         return True
+    if args.command == "health":
+        app = create_query_app()
+        print(app.show_health_report())
+        return True
     if args.command == "jobs":
         _run_jobs_command(args)
         return True

--- a/job_hunter_agent/application/application_health.py
+++ b/job_hunter_agent/application/application_health.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from urllib.parse import urlparse
+
+from job_hunter_agent.core.browser_support import resolve_local_chromium
+
+
+@dataclass(frozen=True)
+class HealthCheckItem:
+    name: str
+    status: str
+    detail: str
+
+
+@dataclass(frozen=True)
+class ApplicationHealthReport:
+    ok: bool
+    items: tuple[HealthCheckItem, ...]
+
+
+def build_application_health_report(settings) -> ApplicationHealthReport:
+    items = (
+        _check_database_path(settings.database_path),
+        _check_linkedin_session(settings.linkedin_storage_state_path),
+        _check_resume(settings.resume_path),
+        _check_contact_email(settings.application_contact_email),
+        _check_contact_phone(settings.application_phone),
+        _check_contact_phone_country_code(settings.application_phone_country_code),
+        _check_local_chromium(),
+        _check_telegram(settings.telegram_token, settings.telegram_chat_id),
+        _check_ollama(settings.ollama_model, settings.ollama_url),
+    )
+    return ApplicationHealthReport(
+        ok=all(item.status != "fail" for item in items),
+        items=items,
+    )
+
+
+def render_application_health_report(report: ApplicationHealthReport) -> str:
+    overall = "ok" if report.ok else "fail"
+    lines = [f"Health operacional: {overall}"]
+    for item in report.items:
+        lines.append(f"- {item.name}={item.status} | {item.detail}")
+    return "\n".join(lines)
+
+
+def _check_database_path(path: str | Path) -> HealthCheckItem:
+    database_path = Path(path).resolve()
+    if database_path.exists() and database_path.is_dir():
+        return HealthCheckItem("database", "fail", f"caminho do banco aponta para diretorio ({database_path})")
+    parent = database_path.parent
+    if not parent.exists():
+        return HealthCheckItem("database", "fail", f"diretorio do banco nao existe ({parent})")
+    if not parent.is_dir():
+        return HealthCheckItem("database", "fail", f"pai do banco nao e diretorio ({parent})")
+    return HealthCheckItem("database", "ok", f"sqlite pronto em {database_path}")
+
+
+def _check_linkedin_session(path: str | Path) -> HealthCheckItem:
+    storage_state_path = Path(path).resolve()
+    if not storage_state_path.exists():
+        return HealthCheckItem(
+            "linkedin_session",
+            "fail",
+            f"storage_state nao encontrado ({storage_state_path}) | rode --bootstrap-linkedin-session",
+        )
+    if not storage_state_path.is_file():
+        return HealthCheckItem("linkedin_session", "fail", f"storage_state precisa ser arquivo ({storage_state_path})")
+    return HealthCheckItem("linkedin_session", "ok", f"storage_state encontrado em {storage_state_path}")
+
+
+def _check_resume(path: str | Path) -> HealthCheckItem:
+    resume_path = Path(path).resolve()
+    if not resume_path.exists():
+        return HealthCheckItem("resume", "fail", f"curriculo nao encontrado ({resume_path})")
+    if not resume_path.is_file():
+        return HealthCheckItem("resume", "fail", f"curriculo precisa ser arquivo ({resume_path})")
+    return HealthCheckItem("resume", "ok", f"curriculo encontrado em {resume_path}")
+
+
+def _check_contact_email(value: str) -> HealthCheckItem:
+    normalized = value.strip()
+    if not normalized:
+        return HealthCheckItem("contact_email", "fail", "email de contato nao configurado")
+    if "@" not in normalized or "." not in normalized.split("@")[-1]:
+        return HealthCheckItem("contact_email", "fail", "email de contato invalido")
+    return HealthCheckItem("contact_email", "ok", f"email configurado: {normalized}")
+
+
+def _check_contact_phone(value: str) -> HealthCheckItem:
+    normalized = value.strip()
+    digits = "".join(char for char in normalized if char.isdigit())
+    if not normalized:
+        return HealthCheckItem("contact_phone", "fail", "telefone de contato nao configurado")
+    if len(digits) < 8:
+        return HealthCheckItem("contact_phone", "fail", "telefone de contato invalido")
+    return HealthCheckItem("contact_phone", "ok", f"telefone configurado com {len(digits)} digitos")
+
+
+def _check_contact_phone_country_code(value: str) -> HealthCheckItem:
+    normalized = value.strip()
+    digits = "".join(char for char in normalized if char.isdigit())
+    if not normalized:
+        return HealthCheckItem("phone_country_code", "fail", "codigo do pais nao configurado")
+    if not digits:
+        return HealthCheckItem("phone_country_code", "fail", "codigo do pais invalido")
+    return HealthCheckItem("phone_country_code", "ok", f"codigo do pais configurado: {normalized}")
+
+
+def _check_local_chromium() -> HealthCheckItem:
+    try:
+        chromium_path = resolve_local_chromium()
+    except Exception as exc:
+        return HealthCheckItem("playwright_chromium", "fail", str(exc))
+    return HealthCheckItem("playwright_chromium", "ok", f"chromium localizado em {chromium_path}")
+
+
+def _check_telegram(token: str, chat_id: str) -> HealthCheckItem:
+    normalized_token = token.strip()
+    normalized_chat_id = chat_id.strip()
+    placeholders = {"SEU_TOKEN_AQUI", "SEU_CHAT_ID_AQUI"}
+    if not normalized_token or not normalized_chat_id or normalized_token in placeholders or normalized_chat_id in placeholders:
+        return HealthCheckItem("telegram", "warn", "telegram opcional nao configurado completamente")
+    return HealthCheckItem("telegram", "ok", "telegram configurado")
+
+
+def _check_ollama(model_name: str, base_url: str) -> HealthCheckItem:
+    normalized_model = model_name.strip()
+    normalized_url = base_url.strip()
+    if not normalized_model:
+        return HealthCheckItem("ollama", "warn", "modelo do Ollama nao configurado")
+    parsed = urlparse(normalized_url)
+    if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+        return HealthCheckItem("ollama", "warn", "URL do Ollama parece invalida")
+    return HealthCheckItem("ollama", "ok", f"ollama configurado: modelo={normalized_model} url={normalized_url}")

--- a/tests/test_application_cli_health.py
+++ b/tests/test_application_cli_health.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from argparse import Namespace
+from unittest import TestCase
+from unittest.mock import patch
+
+from job_hunter_agent.application.application_cli import parse_args
+from job_hunter_agent.application.application_cli_dispatch import execute_cli_command
+
+
+class ApplicationCliHealthTests(TestCase):
+    def test_parse_args_accepts_health_command(self) -> None:
+        with patch("sys.argv", ["main.py", "health"]):
+            args = parse_args()
+
+        self.assertEqual(args.command, "health")
+
+    def test_execute_cli_command_dispatches_health(self) -> None:
+        fake_app = type(
+            "FakeApp",
+            (),
+            {
+                "show_health_report": lambda self: "Health operacional: ok",
+            },
+        )()
+
+        args = Namespace(
+            bootstrap_linkedin_session=False,
+            command="health",
+            sem_telegram=True,
+        )
+
+        with patch(
+            "job_hunter_agent.application.application_cli_dispatch.create_query_app",
+            return_value=fake_app,
+        ) as app_factory, patch("builtins.print") as print_mock:
+            handled = execute_cli_command(args)
+
+        self.assertTrue(handled)
+        app_factory.assert_called_once_with()
+        print_mock.assert_called_once_with("Health operacional: ok")

--- a/tests/test_application_health.py
+++ b/tests/test_application_health.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from job_hunter_agent.application.application_health import (
+    build_application_health_report,
+    render_application_health_report,
+)
+
+
+class ApplicationHealthTests(unittest.TestCase):
+    def test_build_application_health_report_flags_failures_and_warnings(self) -> None:
+        settings = type(
+            "Settings",
+            (),
+            {
+                "database_path": Path("./jobs.db"),
+                "linkedin_storage_state_path": Path("./linkedin-state.json"),
+                "resume_path": Path("./resume.pdf"),
+                "application_contact_email": "vinicius@example.com",
+                "application_phone": "11999999999",
+                "application_phone_country_code": "+55",
+                "telegram_token": "SEU_TOKEN_AQUI",
+                "telegram_chat_id": "SEU_CHAT_ID_AQUI",
+                "ollama_model": "qwen2.5:7b",
+                "ollama_url": "http://localhost:11434",
+            },
+        )()
+
+        with patch(
+            "job_hunter_agent.application.application_health.resolve_local_chromium",
+            side_effect=RuntimeError("chromium ausente"),
+        ), patch(
+            "pathlib.Path.exists",
+            side_effect=lambda self: str(self).endswith("jobs.db") or str(self).endswith("linkedin-state.json") or str(self).endswith("resume.pdf") or self == Path(".").resolve(),
+        ), patch(
+            "pathlib.Path.is_dir",
+            side_effect=lambda self: False if str(self).endswith(("jobs.db", "linkedin-state.json", "resume.pdf")) else True,
+        ), patch(
+            "pathlib.Path.is_file",
+            side_effect=lambda self: str(self).endswith(("linkedin-state.json", "resume.pdf")),
+        ):
+            report = build_application_health_report(settings)
+
+        self.assertFalse(report.ok)
+        rendered = render_application_health_report(report)
+        self.assertIn("Health operacional: fail", rendered)
+        self.assertIn("playwright_chromium=fail", rendered)
+        self.assertIn("telegram=warn", rendered)
+        self.assertIn("ollama=ok", rendered)
+
+    def test_build_application_health_report_is_ok_when_required_items_are_present(self) -> None:
+        temp_root = Path.cwd() / ".tmp-tests" / "health-checks"
+        temp_root.mkdir(parents=True, exist_ok=True)
+        database_path = temp_root / "jobs.db"
+        linkedin_state = temp_root / "linkedin-state.json"
+        resume_path = temp_root / "resume.pdf"
+        linkedin_state.write_text("{}", encoding="utf-8")
+        resume_path.write_text("pdf", encoding="utf-8")
+        try:
+            settings = type(
+                "Settings",
+                (),
+                {
+                    "database_path": database_path,
+                    "linkedin_storage_state_path": linkedin_state,
+                    "resume_path": resume_path,
+                    "application_contact_email": "vinicius@example.com",
+                    "application_phone": "11999999999",
+                    "application_phone_country_code": "+55",
+                    "telegram_token": "token-real",
+                    "telegram_chat_id": "chat-real",
+                    "ollama_model": "qwen2.5:7b",
+                    "ollama_url": "http://localhost:11434",
+                },
+            )()
+
+            with patch(
+                "job_hunter_agent.application.application_health.resolve_local_chromium",
+                return_value=Path("/tmp/chromium/chrome.exe"),
+            ):
+                report = build_application_health_report(settings)
+
+            self.assertTrue(report.ok)
+            rendered = render_application_health_report(report)
+            self.assertIn("Health operacional: ok", rendered)
+            self.assertIn("telegram=ok", rendered)
+            self.assertIn("linkedin_session=ok", rendered)
+        finally:
+            for file_path in (linkedin_state, resume_path):
+                if file_path.exists():
+                    file_path.unlink()
+            if temp_root.exists():
+                temp_root.rmdir()

--- a/tests/test_application_health.py
+++ b/tests/test_application_health.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import shutil
 import unittest
 from pathlib import Path
 from unittest.mock import patch
@@ -12,44 +13,46 @@ from job_hunter_agent.application.application_health import (
 
 class ApplicationHealthTests(unittest.TestCase):
     def test_build_application_health_report_flags_failures_and_warnings(self) -> None:
-        settings = type(
-            "Settings",
-            (),
-            {
-                "database_path": Path("./jobs.db"),
-                "linkedin_storage_state_path": Path("./linkedin-state.json"),
-                "resume_path": Path("./resume.pdf"),
-                "application_contact_email": "vinicius@example.com",
-                "application_phone": "11999999999",
-                "application_phone_country_code": "+55",
-                "telegram_token": "SEU_TOKEN_AQUI",
-                "telegram_chat_id": "SEU_CHAT_ID_AQUI",
-                "ollama_model": "qwen2.5:7b",
-                "ollama_url": "http://localhost:11434",
-            },
-        )()
+        temp_root = Path.cwd() / ".tmp-tests" / "health-checks-fail"
+        temp_root.mkdir(parents=True, exist_ok=True)
+        database_path = temp_root / "jobs.db"
+        linkedin_state = temp_root / "linkedin-state.json"
+        resume_path = temp_root / "resume.pdf"
+        linkedin_state.write_text("{}", encoding="utf-8")
+        resume_path.write_text("pdf", encoding="utf-8")
+        try:
+            settings = type(
+                "Settings",
+                (),
+                {
+                    "database_path": database_path,
+                    "linkedin_storage_state_path": linkedin_state,
+                    "resume_path": resume_path,
+                    "application_contact_email": "vinicius@example.com",
+                    "application_phone": "11999999999",
+                    "application_phone_country_code": "+55",
+                    "telegram_token": "SEU_TOKEN_AQUI",
+                    "telegram_chat_id": "SEU_CHAT_ID_AQUI",
+                    "ollama_model": "qwen2.5:7b",
+                    "ollama_url": "http://localhost:11434",
+                },
+            )()
 
-        with patch(
-            "job_hunter_agent.application.application_health.resolve_local_chromium",
-            side_effect=RuntimeError("chromium ausente"),
-        ), patch(
-            "pathlib.Path.exists",
-            side_effect=lambda self: str(self).endswith("jobs.db") or str(self).endswith("linkedin-state.json") or str(self).endswith("resume.pdf") or self == Path(".").resolve(),
-        ), patch(
-            "pathlib.Path.is_dir",
-            side_effect=lambda self: False if str(self).endswith(("jobs.db", "linkedin-state.json", "resume.pdf")) else True,
-        ), patch(
-            "pathlib.Path.is_file",
-            side_effect=lambda self: str(self).endswith(("linkedin-state.json", "resume.pdf")),
-        ):
-            report = build_application_health_report(settings)
+            with patch(
+                "job_hunter_agent.application.application_health.resolve_local_chromium",
+                side_effect=RuntimeError("chromium ausente"),
+            ):
+                report = build_application_health_report(settings)
 
-        self.assertFalse(report.ok)
-        rendered = render_application_health_report(report)
-        self.assertIn("Health operacional: fail", rendered)
-        self.assertIn("playwright_chromium=fail", rendered)
-        self.assertIn("telegram=warn", rendered)
-        self.assertIn("ollama=ok", rendered)
+            self.assertFalse(report.ok)
+            rendered = render_application_health_report(report)
+            self.assertIn("Health operacional: fail", rendered)
+            self.assertIn("playwright_chromium=fail", rendered)
+            self.assertIn("telegram=warn", rendered)
+            self.assertIn("ollama=ok", rendered)
+        finally:
+            if temp_root.exists():
+                shutil.rmtree(temp_root)
 
     def test_build_application_health_report_is_ok_when_required_items_are_present(self) -> None:
         temp_root = Path.cwd() / ".tmp-tests" / "health-checks"
@@ -89,8 +92,5 @@ class ApplicationHealthTests(unittest.TestCase):
             self.assertIn("telegram=ok", rendered)
             self.assertIn("linkedin_session=ok", rendered)
         finally:
-            for file_path in (linkedin_state, resume_path):
-                if file_path.exists():
-                    file_path.unlink()
             if temp_root.exists():
-                temp_root.rmdir()
+                shutil.rmtree(temp_root)


### PR DESCRIPTION
## Resumo

Este PR adiciona um comando `health` na CLI para validar prerequisitos operacionais locais antes de preflight, submit e operacao manual.

## O que entrou

- novo modulo `job_hunter_agent/application/application_health.py`
- comando `health` na CLI
- integracao do report no `JobHunterApplication`
- dispatch da CLI para `health`
- testes para o modulo de health checks
- testes para parser e dispatch do comando `health`

## Checks locais cobertos neste recorte

- banco SQLite
- sessao autenticada do LinkedIn (`storage_state`)
- curriculo
- email de contato
- telefone
- codigo do pais do telefone
- Chromium local do Playwright
- Telegram
- Ollama

## Impacto esperado

- reduz tentativa cega de operacoes criticas com ambiente incompleto
- melhora a UX operacional com diagnostico rapido local
- fecha uma parte importante do item de checklist sobre health checks antes de operacoes criticas

## Observacoes

- branch sincronizada com a `master`
- pipeline desta branch passou
- o recorte foi mantido local e sem dependencia de rede para os checks iniciais
