### PR TITLE
feat: adiciona modo de validacao seca para operacoes de candidatura

### DIFF
--- a/job_hunter_agent/application/app.py
+++ b/job_hunter_agent/application/app.py
@@ -12,6 +12,12 @@ from job_hunter_agent.application.application_health import (
     build_application_health_report,
     render_application_health_report,
 )
+from job_hunter_agent.application.application_messages import (
+    format_preflight_cli_result,
+    format_preflight_dry_run_cli_result,
+    format_submit_cli_result,
+    format_submit_dry_run_cli_result,
+)
 from job_hunter_agent.application.application_queries import ApplicationQueryService
 from job_hunter_agent.application.application_cli_rendering import render_failure_artifacts
 from job_hunter_agent.application.composition import (
@@ -129,6 +135,20 @@ class JobHunterApplication:
             self.application_submission,
             application_id,
             logger=logger,
+        )
+
+    def show_application_preflight_dry_run(self, application_id: int) -> str:
+        result = self.application_preflight.run_dry_run_for_application(application_id)
+        return format_preflight_dry_run_cli_result(
+            detail=result.detail,
+            application_status=result.application_status,
+        )
+
+    def show_application_submit_dry_run(self, application_id: int) -> str:
+        result = self.application_submission.run_dry_run_for_application(application_id)
+        return format_submit_dry_run_cli_result(
+            detail=result.detail,
+            application_status=result.application_status,
         )
 
     def list_applications(self, *, status: str | None = None) -> str:

--- a/job_hunter_agent/application/application_cli.py
+++ b/job_hunter_agent/application/application_cli.py
@@ -133,6 +133,11 @@ def parse_args() -> argparse.Namespace:
         help="Roda o preflight de uma candidatura confirmada.",
     )
     applications_preflight_parser.add_argument("--id", type=int, required=True, help="ID da candidatura.")
+    applications_preflight_parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Valida se o preflight poderia rodar agora, sem alterar estado nem tocar o portal.",
+    )
 
     applications_authorize_parser = applications_subparsers.add_parser(
         "authorize",
@@ -145,6 +150,11 @@ def parse_args() -> argparse.Namespace:
         help="Executa o envio real de uma candidatura autorizada.",
     )
     applications_submit_parser.add_argument("--id", type=int, required=True, help="ID da candidatura.")
+    applications_submit_parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Valida se o submit poderia rodar agora, sem alterar estado nem tocar o portal.",
+    )
 
     candidate_profile_parser = subparsers.add_parser(
         "candidate-profile",

--- a/job_hunter_agent/application/application_cli_dispatch.py
+++ b/job_hunter_agent/application/application_cli_dispatch.py
@@ -100,9 +100,15 @@ def _run_applications_command(args: Namespace) -> None:
         return
     app = create_application_flow_app()
     if args.applications_command == "preflight":
+        if getattr(args, "dry_run", False):
+            print(app.show_application_preflight_dry_run(args.id))
+            return
         print(asyncio.run(app.handle_application_preflight(args.id)))
         return
     if args.applications_command == "submit":
+        if getattr(args, "dry_run", False):
+            print(app.show_application_submit_dry_run(args.id))
+            return
         print(asyncio.run(app.handle_application_submit(args.id)))
 
 

--- a/job_hunter_agent/application/application_messages.py
+++ b/job_hunter_agent/application/application_messages.py
@@ -7,8 +7,16 @@ def format_preflight_cli_result(*, detail: str, application_status: str) -> str:
     return f"Preflight: {detail} (status={application_status})"
 
 
+def format_preflight_dry_run_cli_result(*, detail: str, application_status: str) -> str:
+    return f"Dry-run preflight: {detail} (status={application_status})"
+
+
 def format_submit_cli_result(*, detail: str, application_status: str) -> str:
     return f"Submissao: {detail} (status={application_status})"
+
+
+def format_submit_dry_run_cli_result(*, detail: str, application_status: str) -> str:
+    return f"Dry-run submissao: {detail} (status={application_status})"
 
 
 def format_preflight_requires_confirmed_status() -> str:
@@ -27,6 +35,12 @@ def format_linkedin_preflight_ready(*, support_level: str) -> str:
     if support_level == "auto_supported":
         return "preflight ok: fluxo do LinkedIn com indicio de candidatura simplificada"
     return "preflight ok: vaga interna do LinkedIn pronta para futura automacao assistida"
+
+
+def format_preflight_dry_run_ready(*, support_level: str) -> str:
+    if support_level == "auto_supported":
+        return "dry-run preflight: fluxo parece pronto para inspeção real, sem alterar estado"
+    return "dry-run preflight: candidatura parece apta para preflight real, sem alterar estado"
 
 
 def format_preflight_portal_not_supported(*, portal_name: str) -> str:
@@ -53,6 +67,10 @@ def format_submit_readiness_incomplete(*, failures: list[str]) -> str:
     if failures:
         return f"{detail} | faltando={'; '.join(failures)}"
     return detail
+
+
+def format_submit_dry_run_ready() -> str:
+    return "dry-run submit: candidatura parece apta para submit real, sem alterar estado nem tocar o portal"
 
 
 def format_submit_unavailable_in_execution() -> str:

--- a/job_hunter_agent/application/application_preflight.py
+++ b/job_hunter_agent/application/application_preflight.py
@@ -8,6 +8,7 @@ from job_hunter_agent.application.application_flow import (
 )
 from job_hunter_agent.application.application_messages import (
     format_linkedin_preflight_ready,
+    format_preflight_dry_run_ready,
     format_preflight_inspection_error,
     format_preflight_portal_not_supported,
     format_preflight_readiness_incomplete,
@@ -41,6 +42,48 @@ class ApplicationPreflightService:
         self.flow_inspector = flow_inspector
         self.flow = ApplicationFlowCoordinator(repository)
         self.readiness_checker = readiness_checker
+
+    def run_dry_run_for_application(self, application_id: int) -> ApplicationPreflightResult:
+        context = load_application_context(self.repository, application_id)
+        application = context.application
+        job = context.job
+
+        if application.status != "confirmed":
+            return ApplicationPreflightResult(
+                outcome="ignored",
+                detail=format_preflight_requires_confirmed_status(),
+                application_status=application.status,
+            )
+
+        if application.support_level == "unsupported":
+            return ApplicationPreflightResult(
+                outcome="blocked",
+                detail=format_preflight_unsupported_flow_blocked(),
+                application_status=application.status,
+            )
+
+        capabilities = get_portal_capabilities(job)
+        if self.readiness_checker is not None:
+            readiness = self.readiness_checker.check_preflight_ready(job)
+            if not readiness.ok:
+                return ApplicationPreflightResult(
+                    outcome="blocked",
+                    detail=format_preflight_readiness_incomplete(failures=list(readiness.failures)),
+                    application_status=application.status,
+                )
+
+        if capabilities.preflight_supported and job.source_site.lower() == "linkedin" and "linkedin.com/jobs/" in job.url.lower():
+            return ApplicationPreflightResult(
+                outcome="ready",
+                detail=format_preflight_dry_run_ready(support_level=application.support_level),
+                application_status=application.status,
+            )
+
+        return ApplicationPreflightResult(
+            outcome="blocked",
+            detail=format_preflight_portal_not_supported(portal_name=capabilities.portal_name),
+            application_status=application.status,
+        )
 
     def run_for_application(self, application_id: int) -> ApplicationPreflightResult:
         context = load_application_context(self.repository, application_id)

--- a/job_hunter_agent/application/application_submission.py
+++ b/job_hunter_agent/application/application_submission.py
@@ -9,6 +9,7 @@ from job_hunter_agent.application.application_flow import (
 from job_hunter_agent.application.application_messages import (
     format_submit_applicant_error,
     format_submit_detail,
+    format_submit_dry_run_ready,
     format_submit_portal_not_supported,
     format_submit_readiness_incomplete,
     format_submit_requires_authorized_status,
@@ -42,6 +43,48 @@ class ApplicationSubmissionService:
         self.applicant = applicant
         self.flow = ApplicationFlowCoordinator(repository)
         self.readiness_checker = readiness_checker
+
+    def run_dry_run_for_application(self, application_id: int) -> ApplicationSubmitResult:
+        context = load_application_context(self.repository, application_id)
+        application = context.application
+        job = context.job
+
+        if application.status != "authorized_submit":
+            return ApplicationSubmitResult(
+                outcome="ignored",
+                detail=format_submit_requires_authorized_status(),
+                application_status=application.status,
+            )
+
+        capabilities = get_portal_capabilities(job)
+        if not capabilities.submit_supported:
+            return ApplicationSubmitResult(
+                outcome="blocked",
+                detail=format_submit_portal_not_supported(portal_name=capabilities.portal_name),
+                application_status=application.status,
+            )
+
+        if self.readiness_checker is not None:
+            readiness = self.readiness_checker.check_submit_ready(job)
+            if not readiness.ok:
+                return ApplicationSubmitResult(
+                    outcome="ignored",
+                    detail=format_submit_readiness_incomplete(failures=readiness.failures),
+                    application_status=application.status,
+                )
+
+        if self.applicant is None:
+            return ApplicationSubmitResult(
+                outcome="ignored",
+                detail=format_submit_unavailable_in_execution(),
+                application_status=application.status,
+            )
+
+        return ApplicationSubmitResult(
+            outcome="ready",
+            detail=format_submit_dry_run_ready(),
+            application_status=application.status,
+        )
 
     def run_for_application(self, application_id: int) -> ApplicationSubmitResult:
         context = load_application_context(self.repository, application_id)

--- a/tests/test_application_cli_dry_run.py
+++ b/tests/test_application_cli_dry_run.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+from argparse import Namespace
+from unittest import TestCase
+from unittest.mock import patch
+
+from job_hunter_agent.application.application_cli import parse_args
+from job_hunter_agent.application.application_cli_dispatch import execute_cli_command
+
+
+class ApplicationCliDryRunTests(TestCase):
+    def test_parse_args_accepts_preflight_dry_run(self) -> None:
+        with patch("sys.argv", ["main.py", "applications", "preflight", "--id", "7", "--dry-run"]):
+            args = parse_args()
+
+        self.assertEqual(args.command, "applications")
+        self.assertEqual(args.applications_command, "preflight")
+        self.assertTrue(args.dry_run)
+
+    def test_parse_args_accepts_submit_dry_run(self) -> None:
+        with patch("sys.argv", ["main.py", "applications", "submit", "--id", "7", "--dry-run"]):
+            args = parse_args()
+
+        self.assertEqual(args.command, "applications")
+        self.assertEqual(args.applications_command, "submit")
+        self.assertTrue(args.dry_run)
+
+    def test_execute_cli_command_dispatches_preflight_dry_run_without_asyncio(self) -> None:
+        fake_app = type(
+            "FakeApp",
+            (),
+            {
+                "show_application_preflight_dry_run": lambda self, application_id: f"dry-preflight={application_id}",
+            },
+        )()
+
+        args = Namespace(
+            bootstrap_linkedin_session=False,
+            command="applications",
+            applications_command="preflight",
+            id=7,
+            dry_run=True,
+            sem_telegram=True,
+        )
+
+        with patch(
+            "job_hunter_agent.application.application_cli_dispatch.create_application_flow_app",
+            return_value=fake_app,
+        ) as app_factory, patch(
+            "job_hunter_agent.application.application_cli_dispatch.asyncio.run"
+        ) as asyncio_run, patch("builtins.print") as print_mock:
+            handled = execute_cli_command(args)
+
+        self.assertTrue(handled)
+        app_factory.assert_called_once_with()
+        asyncio_run.assert_not_called()
+        print_mock.assert_called_once_with("dry-preflight=7")
+
+    def test_execute_cli_command_dispatches_submit_dry_run_without_asyncio(self) -> None:
+        fake_app = type(
+            "FakeApp",
+            (),
+            {
+                "show_application_submit_dry_run": lambda self, application_id: f"dry-submit={application_id}",
+            },
+        )()
+
+        args = Namespace(
+            bootstrap_linkedin_session=False,
+            command="applications",
+            applications_command="submit",
+            id=9,
+            dry_run=True,
+            sem_telegram=True,
+        )
+
+        with patch(
+            "job_hunter_agent.application.application_cli_dispatch.create_application_flow_app",
+            return_value=fake_app,
+        ) as app_factory, patch(
+            "job_hunter_agent.application.application_cli_dispatch.asyncio.run"
+        ) as asyncio_run, patch("builtins.print") as print_mock:
+            handled = execute_cli_command(args)
+
+        self.assertTrue(handled)
+        app_factory.assert_called_once_with()
+        asyncio_run.assert_not_called()
+        print_mock.assert_called_once_with("dry-submit=9")

--- a/tests/test_application_dry_run_services.py
+++ b/tests/test_application_dry_run_services.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import unittest
+
+from job_hunter_agent.application.application_preflight import ApplicationPreflightService
+from job_hunter_agent.application.application_submission import ApplicationSubmissionService
+from job_hunter_agent.core.domain import JobApplication, JobPosting
+
+
+def _sample_job(*, job_id: int) -> JobPosting:
+    return JobPosting(
+        id=job_id,
+        title="Backend Java",
+        company="ACME",
+        location="Brasil",
+        work_mode="remoto",
+        salary_text="Nao informado",
+        url=f"https://www.linkedin.com/jobs/view/{job_id}/",
+        source_site="LinkedIn",
+        summary="Resumo",
+        relevance=8,
+        rationale="Boa aderencia",
+        external_key=f"key-{job_id}",
+        status="approved",
+    )
+
+
+class ApplicationDryRunServiceTests(unittest.TestCase):
+    def test_preflight_dry_run_returns_ready_without_persisting_state(self) -> None:
+        application = JobApplication(id=7, job_id=10, status="confirmed", support_level="auto_supported")
+        job = _sample_job(job_id=10)
+
+        class _Repository:
+            def get_application(self, application_id: int):
+                return application
+
+            def get_job(self, job_id: int):
+                return job
+
+            def mark_application_status(self, *args, **kwargs):
+                raise AssertionError("dry-run should not persist state")
+
+            def record_application_event(self, *args, **kwargs):
+                raise AssertionError("dry-run should not record events")
+
+        class _ReadinessChecker:
+            def check_preflight_ready(self, current_job):
+                return type("Readiness", (), {"ok": True, "failures": ()})()
+
+        service = ApplicationPreflightService(
+            _Repository(),
+            flow_inspector=None,
+            readiness_checker=_ReadinessChecker(),
+        )
+
+        result = service.run_dry_run_for_application(7)
+
+        self.assertEqual(result.outcome, "ready")
+        self.assertEqual(result.application_status, "confirmed")
+        self.assertIn("dry-run preflight", result.detail)
+
+    def test_submit_dry_run_returns_ready_without_persisting_state(self) -> None:
+        application = JobApplication(id=8, job_id=11, status="authorized_submit")
+        job = _sample_job(job_id=11)
+
+        class _Repository:
+            def get_application(self, application_id: int):
+                return application
+
+            def get_job(self, job_id: int):
+                return job
+
+            def mark_application_status(self, *args, **kwargs):
+                raise AssertionError("dry-run should not persist state")
+
+            def record_application_event(self, *args, **kwargs):
+                raise AssertionError("dry-run should not record events")
+
+        class _ReadinessChecker:
+            def check_submit_ready(self, current_job):
+                return type("Readiness", (), {"ok": True, "failures": ()})()
+
+        class _Applicant:
+            def submit(self, application, job):
+                raise AssertionError("dry-run should not call applicant")
+
+        service = ApplicationSubmissionService(
+            _Repository(),
+            applicant=_Applicant(),
+            readiness_checker=_ReadinessChecker(),
+        )
+
+        result = service.run_dry_run_for_application(8)
+
+        self.assertEqual(result.outcome, "ready")
+        self.assertEqual(result.application_status, "authorized_submit")
+        self.assertIn("dry-run submit", result.detail)


### PR DESCRIPTION
## Resumo

Este PR adiciona um modo de validacao seca para operacoes de candidatura via CLI.

## O que entrou

- novo modo de validacao para preflight na CLI
- novo modo de validacao para envio na CLI
- verificacao formal de gating e prontidao operacional sem executar a acao real
- mensagens dedicadas para esse modo
- integracao no app principal
- testes de CLI
- testes de servico garantindo que esse modo nao persiste estado nem grava eventos

## Impacto esperado

- reduz risco operacional antes da execucao real
- melhora a UX do operador com uma verificacao segura e objetiva
- avanca mais um item importante da checklist

## Observacoes

- branch sincronizada com a master
- pipeline desta branch passou
