### PR TITLE
refactor: reduz hardcodes residuais do matching legado

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,6 @@
+# Runtime e segredos
 JOB_HUNTER_TELEGRAM_TOKEN=coloque-seu-token-aqui
 JOB_HUNTER_TELEGRAM_CHAT_ID=coloque-seu-chat-id-aqui
-JOB_HUNTER_PROFILE_TEXT=Engenheiro de Software Senior com experiencia em Java, Kotlin, Spring Boot e cloud.
 JOB_HUNTER_APPLICATION_CONTACT_EMAIL=
 JOB_HUNTER_APPLICATION_PHONE=
 JOB_HUNTER_APPLICATION_PHONE_COUNTRY_CODE=
@@ -17,10 +17,6 @@ JOB_HUNTER_LINKEDIN_SCROLL_STABILIZATION_PASSES=3
 JOB_HUNTER_SAVE_FAILURE_ARTIFACTS=false
 JOB_HUNTER_FAILURE_ARTIFACTS_DIR=./.artifacts/linkedin_failures
 JOB_HUNTER_REVIEW_POLLING_GRACE_SECONDS=120
-JOB_HUNTER_RELAXED_MATCHING_FOR_TESTING=false
-JOB_HUNTER_RELAXED_TESTING_PROFILE_HINT=Para testes controlados de parsing, considere tambem vagas junior e pleno como aceitaveis.
-JOB_HUNTER_RELAXED_TESTING_REMOVE_EXCLUDE_KEYWORDS=junior
-JOB_HUNTER_RELAXED_TESTING_MINIMUM_RELEVANCE=4
 JOB_HUNTER_LINKEDIN_FIELD_REPAIR_ENABLED=true
 JOB_HUNTER_APPLICATION_SUPPORT_LLM_ENABLED=true
 JOB_HUNTER_JOB_REQUIREMENTS_LLM_ENABLED=true
@@ -28,3 +24,14 @@ JOB_HUNTER_REVIEW_RATIONALE_LLM_ENABLED=true
 JOB_HUNTER_APPLICATION_PRIORITY_LLM_ENABLED=true
 JOB_HUNTER_OLLAMA_MODEL=qwen2.5:7b
 JOB_HUNTER_OLLAMA_URL=http://localhost:11434
+
+# Matching legado de compatibilidade
+# Mantenha estes campos apenas enquanto o runtime principal ainda estiver removendo hardcodes residuais.
+# Evite expandir o uso do PROFILE_TEXT; ele deve permanecer como compatibilidade passiva.
+JOB_HUNTER_PROFILE_TEXT=Engenheiro de Software Senior com experiencia em Java, Kotlin, Spring Boot e cloud.
+
+# Toggles operacionais de teste
+JOB_HUNTER_RELAXED_MATCHING_FOR_TESTING=false
+JOB_HUNTER_RELAXED_TESTING_PROFILE_HINT=Para testes controlados de parsing, considere tambem vagas junior e pleno como aceitaveis.
+JOB_HUNTER_RELAXED_TESTING_REMOVE_EXCLUDE_KEYWORDS=junior
+JOB_HUNTER_RELAXED_TESTING_MINIMUM_RELEVANCE=4

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,17 +43,6 @@ Quando houver rebase, cherry-pick ou porte manual de commit:
 - se um commit antigo tocar módulos que já mudaram de camada, adapte a mudança em vez de restaurar a estrutura anterior
 - após resolver conflito, rode os testes focados da área portada antes de continuar
 
-Exemplos aceitos:
-
-- `feature/perfil-busca-configuravel`
-- `refactor/separa-fluxo-candidatura`
-- `fix/linkedin-preflight-url`
-
-Exemplos não aceitos:
-
-- começar feature nova em `master`
-- juntar refactor, feature e docs no mesmo commit sem necessidade
-
 ## Produto
 
 Objetivo do repositório:
@@ -64,14 +53,6 @@ Objetivo do repositório:
 - enviar vagas para revisão humana
 - registrar aprovação ou rejeição
 - executar etapas assistidas de candidatura somente após autorização humana explícita
-
-Fora de escopo por padrão:
-
-- candidatura autônoma
-- multiusuário
-- SaaS
-- persistência em nuvem
-- plataforma genérica de agentes
 
 ## Restrições do Produto
 
@@ -91,12 +72,6 @@ Para candidaturas, o gate obrigatório é:
 
 `draft -> ready_for_review -> confirmed -> authorized_submit -> submitted`
 
-Regras:
-
-- `authorized_submit` é o gate final antes de submit real
-- preflight e dry-run não podem pular esse gate
-- submit real só pode sair de `authorized_submit`
-
 ## Fonte de Verdade
 
 - a aplicação ativa vive em `job_hunter_agent/`
@@ -109,7 +84,7 @@ Regras:
 Use estas responsabilidades:
 
 - `job_hunter_agent/core/`
-  domínio, settings validados, helpers de runtime, suporte de browser e identidade de vaga
+  domínio, settings validados, helpers de runtime, suporte de browser, identidade de vaga e contratos explícitos de compatibilidade
 - `job_hunter_agent/application/`
   composição, orquestração, casos de uso e regras de revisão
 - `job_hunter_agent/collectors/`
@@ -117,13 +92,14 @@ Use estas responsabilidades:
 - `job_hunter_agent/infrastructure/`
   persistência e notificações
 - `job_hunter_agent/llm/`
-  scoring assistivo, extração de requisitos, rationale, priorização, interpretação assistida de modal e sugestão de perfil estruturado do candidato
+  scoring assistivo, extração de requisitos, rationale, priorização e interpretação assistida
 
 Regra de dependência:
 
 - camadas externas podem depender de camadas internas
 - domínio não depende de infraestrutura
 - wiring acontece na borda de composição, não espalhado pelos módulos
+- compatibilidade legada deve passar por contrato explícito; não dependa do shape inteiro de `Settings` em módulos de negócio
 
 ## SOLID
 
@@ -135,72 +111,13 @@ Antes de implementar, confirme:
 - ISP: a interface está pequena e focada?
 - DIP: o fluxo de negócio depende de abstrações e não de detalhes concretos?
 
-Se a resposta for não, ajuste a estrutura antes de continuar.
-
 ## Controle De Escopo E Refatoracao
-
-Siga um padrao de `AGENTS.md` curto, objetivo e acionavel:
 
 - use este arquivo como mapa de decisao, nao como licenca para reescrever areas vizinhas
 - execute apenas o menor recorte necessario para concluir a tarefa atual com seguranca
-- nao amplie escopo por "aproveitar o contexto" sem necessidade direta
-
-Refatoracao so e aceitavel sem confirmacao extra quando:
-
-- remove acoplamento que bloqueia a tarefa atual
-- corrige uma regressao descoberta durante a implementacao
-- reduz duplicacao estrutural no mesmo seam tocado pela tarefa
-
-Pare e replaneje antes de continuar quando a mudanca passar de um recorte local. Trate como refatoracao ampla quando ocorrer qualquer um destes sinais:
-
-- tocar mais de 3 modulos principais na mesma linha de trabalho
-- atravessar mais de uma camada arquitetural sem ser wiring explicito
-- misturar feature, refactor e limpeza geral no mesmo passo
-- exigir renomeacao ou redistribuicao de responsabilidades em cadeia
-- fechar mais de um item grande de checklist sem validacao intermediaria
-
-Quando houver refatoracao ampla:
-
-- quebre em etapas pequenas e testaveis
-- valide cada etapa antes de seguir para a proxima
-- atualize a checklist conforme cada seam for realmente concluido
-- nao marque item pai como concluido so por proximidade; marque apenas quando houver lastro claro no codigo e nos testes
-
-## Regras de Estado
-
-Estados válidos de vaga:
-
-- `collected`
-- `approved`
-- `rejected`
-- `error_collect`
-
-Estados válidos de candidatura:
-
-- `draft`
-- `ready_for_review`
-- `confirmed`
-- `authorized_submit`
-- `submitted`
-- `error_submit`
-- `cancelled`
-
-Use apenas estados explícitos e semanticamente estreitos.
-
-Não faça:
-
-- estados transitórios só de UI
-- um mesmo status com múltiplos significados
-- transição implícita sem registro
+- nao amplie escopo por aproveitar contexto sem necessidade direta
 
 ## Coleta e Scoring
-
-Quando trabalhar na coleta:
-
-- trate portais como sistemas instáveis
-- isole falhas por fonte
-- normalize antes de persistir
-- deduplique antes de salvar ou notificar
 
 Quando trabalhar no matching/scoring:
 
@@ -208,34 +125,7 @@ Quando trabalhar no matching/scoring:
 - use a LLM como scorer assistivo
 - mantenha fallback determinístico
 - nunca deixe o modelo inventar dados do candidato
-
-## LLM Local
-
-Use LLM local apenas para apoio:
-
-- classificação de suporte
-- extração de requisitos
-- formatação de rationale
-- priorização de fila
-- interpretação assistida onde já houver fallback seguro
-
-Sempre:
-
-- parsear resposta em estrutura explícita
-- cair para comportamento conservador em caso de erro
-- impedir sobrescrita silenciosa de dados confiáveis
-
-## Telegram e CLI
-
-Telegram é interface de revisão humana.
-CLI é interface operacional principal ou fallback técnico.
-
-Quando adicionar ação operacional:
-
-- mantenha a ação curta e rastreável
-- faça cada handler mapear para uma única transição de estado
-- mantenha ações de review separadas de ações de submit
-- preserve o gate humano antes de submit real
+- ao tocar caminho legado de matching, encapsule compatibilidade em helper/contrato explícito antes de expandir o uso
 
 ## Configuração
 
@@ -243,71 +133,17 @@ Quando mexer em configuração:
 
 - valide tudo no startup
 - falhe rápido em caso inválido
-- não aceite placeholders silenciosamente
 - concentre acesso em um objeto de settings validado
 - não espalhe lookup de variável de ambiente pelo código
-
-## Persistência
-
-Quando mexer em banco/repositório:
-
-- deixe SQL e schema dentro da camada de repositório
-- mantenha o domínio livre de detalhes de SQLite
-- persista metadados suficientes para depuração operacional
-- não exponha shape de row para camadas superiores
-
-## Erros e Observabilidade
-
-Quando tratar falhas:
-
-- não engula erro silenciosamente
-- registre contexto na borda da fonte
-- diferencie bloqueio funcional, erro de portal e falha inesperada
-- mantenha mensagem operacional curta
-- mantenha log interno útil para depuração
+- não reintroduza `JOB_HUNTER_PROFILE_TEXT` como centro de evolução do matching
 
 ## Testes
 
 Toda mudança não trivial deve preservar ou melhorar a verificação.
 
-Mínimo esperado por tipo de mudança:
-
-- repositório: persistência, deduplicação, resumos e transições
-- collectors: normalização, filtros e scoring
-- settings: validação
-- notifier: callbacks e review
-
-Diretrizes:
-
 - prefira teste unitário para regra de negócio
 - use integração só em seams críticos
 - teste comportamento, não detalhe interno
-- use caminhos temporários dentro do workspace
-
-## Qualidade de Código
-
-- use Python 3.11+
-- prefira nomes explícitos
-- mantenha funções e classes pequenas
-- prefira dataclasses imutáveis no domínio
-- evite estado compartilhado oculto
-- evite abstração prematura
-- refatore quando a duplicação ficar estrutural
-- use comentários só para intenção ou tradeoff não óbvio
-
-## Workflow Antes de Implementar
-
-Antes de escrever código, responda:
-
-1. isso melhora o loop principal?
-2. isso está dentro do escopo do produto?
-3. isso preserva as fronteiras arquiteturais?
-4. isso reduz ou aumenta acoplamento?
-5. isso introduz comportamento implícito de runtime?
-6. isso exige branch dedicada?
-7. isso exige atualização de README ou AGENTS?
-
-Se houver dúvida sobre branch, crie a branch.
 
 ## Workflow Depois de Implementar
 
@@ -319,37 +155,3 @@ Antes de encerrar a tarefa:
 4. atualize README se setup ou operação mudaram
 5. atualize AGENTS se arquitetura, processo ou regras mudaram
 6. prepare commits pequenos e em português
-
-## Regra de Autoatualização
-
-`AGENTS.md` não pode ficar atrás da realidade do código.
-
-Atualize este arquivo na mesma linha de trabalho quando mudar:
-
-- a arquitetura real
-- o fluxo operacional real
-- a política de branch/commit
-- regras de validação ou de estados
-
-## Antipadrões
-
-Evite:
-
-- prompts gigantes que navegam, raciocinam, pontuam e agem ao mesmo tempo
-- regra de negócio em handler de Telegram
-- infraestrutura instanciada aleatoriamente em módulos de negócio
-- SQL fora do repositório
-- modelos de domínio conscientes de transporte ou storage
-- reintroduzir candidatura autônoma no loop principal sem decisão explícita de produto
-- usar o repositório como playground de agente genérico
-
-## Definição de Pronto
-
-Uma mudança só está pronta quando:
-
-- o loop principal continua funcionando
-- as responsabilidades seguem separadas
-- os estados continuam válidos
-- o comportamento de falha está explícito
-- os testes cobrem a mudança ou a lacuna está documentada
-- a documentação necessária foi atualizada

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ O diretorio `files/` foi removido da arquitetura ativa e nao deve ser recriado.
 Documentacao ativa:
 
 - `docs/plans/POS_MVP_ESTRUTURA_E_REFATORACAO_CHECKLIST.md`
+- `docs/plans/REMOVE_LEGACY_MATCHING_HARDCODES_CHECKLIST.md`
 
 Documentacao historica:
 
@@ -90,7 +91,6 @@ python -m playwright install chromium
 
 O projeto le configuracao de `.env` e variaveis de ambiente via `pydantic-settings`.
 Use `.env.example` como base para o seu `.env`.
-Um `.env` local inicial pode ser criado com placeholders seguros, mas o token e o chat id do Telegram precisam ser substituidos antes do primeiro teste real.
 
 Para reduzir atrito no uso diario, a recomendacao agora e:
 
@@ -104,11 +104,10 @@ Os wrappers ja:
 - configuram `PLAYWRIGHT_BROWSERS_PATH=.playwright-browsers` quando necessario
 - adicionam o binario local do Ollama ao `PATH` quando ele existir no caminho padrao
 
-Variaveis principais:
+### Variaveis principais de runtime
 
 - `JOB_HUNTER_TELEGRAM_TOKEN`
 - `JOB_HUNTER_TELEGRAM_CHAT_ID`
-- `JOB_HUNTER_PROFILE_TEXT`
 - `JOB_HUNTER_APPLICATION_CONTACT_EMAIL`
 - `JOB_HUNTER_APPLICATION_PHONE`
 - `JOB_HUNTER_APPLICATION_PHONE_COUNTRY_CODE`
@@ -122,10 +121,6 @@ Variaveis principais:
 - `JOB_HUNTER_LINKEDIN_MAX_PAGES_PER_CYCLE`
 - `JOB_HUNTER_LINKEDIN_MAX_PAGE_DEPTH`
 - `JOB_HUNTER_REVIEW_POLLING_GRACE_SECONDS`
-- `JOB_HUNTER_RELAXED_MATCHING_FOR_TESTING`
-- `JOB_HUNTER_RELAXED_TESTING_PROFILE_HINT`
-- `JOB_HUNTER_RELAXED_TESTING_REMOVE_EXCLUDE_KEYWORDS`
-- `JOB_HUNTER_RELAXED_TESTING_MINIMUM_RELEVANCE`
 - `JOB_HUNTER_LINKEDIN_FIELD_REPAIR_ENABLED`
 - `JOB_HUNTER_APPLICATION_SUPPORT_LLM_ENABLED`
 - `JOB_HUNTER_JOB_REQUIREMENTS_LLM_ENABLED`
@@ -133,6 +128,28 @@ Variaveis principais:
 - `JOB_HUNTER_APPLICATION_PRIORITY_LLM_ENABLED`
 - `JOB_HUNTER_OLLAMA_MODEL`
 - `JOB_HUNTER_OLLAMA_URL`
+
+### Matching legado de compatibilidade
+
+Neste momento, o runtime ainda depende de um contrato legado de matching encapsulado, derivado de `Settings`.
+Nao amplie esse caminho em codigo novo.
+
+Campo legado principal:
+
+- `JOB_HUNTER_PROFILE_TEXT`
+
+Tratamento esperado:
+
+- ele existe por compatibilidade
+- nao deve voltar a ser apresentado como fonte estrategica de evolucao do matching
+- codigo novo deve depender de contratos explicitos, nao do shape inteiro de `Settings`
+
+### Toggles operacionais de teste
+
+- `JOB_HUNTER_RELAXED_MATCHING_FOR_TESTING`
+- `JOB_HUNTER_RELAXED_TESTING_PROFILE_HINT`
+- `JOB_HUNTER_RELAXED_TESTING_REMOVE_EXCLUDE_KEYWORDS`
+- `JOB_HUNTER_RELAXED_TESTING_MINIMUM_RELEVANCE`
 
 Modelo recomendado para este MVP e para a configuracao de hardware avaliada:
 
@@ -149,11 +166,6 @@ Para gerar mais vagas novas durante testes de parsing, voce pode ativar temporar
 - `JOB_HUNTER_RELAXED_MATCHING_FOR_TESTING=true`
 
 Esse modo remove `junior` dos termos excluidos para scoring e reduz a nota minima exigida, sem alterar o comportamento padrao quando desligado.
-Os knobs desse modo tambem podem ser ajustados por ambiente:
-
-- `JOB_HUNTER_RELAXED_TESTING_PROFILE_HINT`
-- `JOB_HUNTER_RELAXED_TESTING_REMOVE_EXCLUDE_KEYWORDS`
-- `JOB_HUNTER_RELAXED_TESTING_MINIMUM_RELEVANCE`
 
 Tambem existe um fallback opcional de reparo local de campos do LinkedIn:
 
@@ -184,116 +196,6 @@ Tambem existe um assessor opcional de prioridade operacional para candidaturas:
 - `JOB_HUNTER_APPLICATION_PRIORITY_LLM_ENABLED=true`
 
 Ele sugere uma prioridade assistiva (`alta`, `media`, `baixa`) para ordenar a fila de rascunhos e candidaturas em andamento. Se o modelo falhar ou estiver desligado, o sistema usa uma heuristica local conservadora.
-
-Os cards de `/candidaturas` tambem reaproveitam os sinais estruturados ja extraidos da vaga, exibindo um resumo curto com senioridade, stack, ingles e sinais de lideranca quando houver dados uteis.
-
-Tambem existe um interpretador opcional do modal do LinkedIn com LLM local:
-
-- `JOB_HUNTER_LINKEDIN_MODAL_LLM_ENABLED=true`
-
-Quando ativado, ele nao controla cliques livremente. Ele apenas interpreta o snapshot estruturado do modal, sugere a proxima acao provavel e passa por guardrails antes de influenciar o preflight ou o submit real. Se falhar, o fluxo volta para o comportamento deterministico conservador.
-
-O preflight de candidatura do LinkedIn agora pode usar a pagina real da vaga, e nao apenas a URL:
-
-- para candidaturas `confirmed`, o botao `Validar fluxo` pode abrir a vaga no navegador automatizado
-- o inspetor procura sinais como `Easy Apply`, candidatura externa ou ausencia de CTA
-- quando encontra `Easy Apply`, ele tenta abrir o modal e mapear se o fluxo parece simples ou multi-etapas
-- o preflight tambem registra campos basicos detectados no modal, como email, telefone e codigo do pais
-- quando os dados de contato estiverem configurados, ele tenta preencher esses campos em dry-run, sem enviar candidatura
-- se houver `Next/Continuar`, o inspetor tambem tenta avancar uma etapa e registrar se houve progresso real no fluxo
-- quando o modal exigir curriculo, o inspetor tambem pode carregar o arquivo configurado em `resume_path` em dry-run
-- se a etapa `Review/Revisar` aparecer, o inspetor tambem tenta alcanca-la e registrar quando o fluxo fica pronto para um submit humano
-- se `JOB_HUNTER_LINKEDIN_MODAL_LLM_ENABLED=true`, o detalhe do preflight tambem inclui a interpretacao assistida da etapa atual do modal
-- antes de abrir o modal, o fluxo tambem valida se a pagina ainda e a vaga alvo certa, se nao caiu em `similar-jobs/collections` e se ainda existe CTA de candidatura
-- nesta fase, o sistema ainda nao envia candidatura real; ele apenas inspeciona e registra o fluxo encontrado
-
-A coleta do LinkedIn tambem pode paginar de forma conservadora quando necessario:
-
-- `JOB_HUNTER_LINKEDIN_MAX_PAGES_PER_CYCLE=2`
-- `JOB_HUNTER_LINKEDIN_MAX_PAGE_DEPTH=6`
-- `JOB_HUNTER_LINKEDIN_SCROLL_STABILIZATION_PASSES=3`
-- `JOB_HUNTER_SAVE_FAILURE_ARTIFACTS=false`
-- `JOB_HUNTER_FAILURE_ARTIFACTS_DIR=./.artifacts/linkedin_failures`
-
-O recomendado para a fase atual e manter essa janela pequena por ciclo.
-Cada ciclo sempre comeca pela pagina `1`, desce a pagina ate o rodape enquanto tenta esgotar a lista interna de resultados e so depois avanca pela paginacao da propria interface do LinkedIn para a pagina seguinte.
-
-Na pratica, com `JOB_HUNTER_LINKEDIN_MAX_PAGES_PER_CYCLE=2`, o comportamento esperado por ciclo e:
-
-- abrir a busca padrao
-- estabilizar a pagina `1` com scroll ate o rodape e da lista interna
-- extrair os cards visiveis da pagina `1`
-- clicar na pagina `2` pela UI
-- estabilizar a pagina `2` com o mesmo processo
-- extrair os cards visiveis da pagina `2`
-
-`JOB_HUNTER_LINKEDIN_MAX_PAGE_DEPTH` continua como limite de seguranca para nao aprofundar demais a navegacao dentro de um unico ciclo.
-
-Para diagnostico de falhas do LinkedIn, tambem existe uma captura opcional de artefatos locais:
-
-- `JOB_HUNTER_SAVE_FAILURE_ARTIFACTS=true`
-- `JOB_HUNTER_FAILURE_ARTIFACTS_DIR=./.artifacts/linkedin_failures`
-
-Quando habilitada, falhas de submit real do LinkedIn salvam:
-
-- HTML da pagina no momento do erro
-- screenshot em PNG
-- metadata JSON com estado do modal e contexto da vaga
-
-Antes do submit real, o sistema tambem executa checks locais de prontidao operacional:
-
-- sessao autenticada do LinkedIn presente no `storage_state`
-- curriculo configurado e existente em disco
-- email, telefone e codigo do pais preenchidos
-
-Se algum desses itens faltar, o submit e bloqueado antes de abrir o applicant e a candidatura permanece em `authorized_submit`.
-
-Perguntas adicionais do `Easy Apply` agora tambem podem usar um perfil estruturado local do candidato:
-
-- `JOB_HUNTER_CANDIDATE_PROFILE_PATH=./candidate_profile.json`
-- existe um exemplo versionado em `candidate_profile.example.json`
-- hoje o fluxo usa automaticamente apenas valores `confirmed`
-- perguntas de experiencia numerica por stack, como `Java`, `Angular` e `EJB`, podem ser respondidas automaticamente quando houver valor confirmado no arquivo
-- perguntas novas, ambiguas ou sem valor confirmado continuam bloqueadas e sao reportadas nos artefatos e no erro operacional
-- quando uma pergunta nova aparece no formulario, ela tambem pode ser registrada automaticamente em `candidate_profile.json` com `confirmed=null`
-
-Essa trilha do LinkedIn ja foi validada em casos reais suportados:
-
-- vagas com `Easy Apply` interno ja chegaram a `submitted` em execucoes reais
-- vagas externas bloqueiam cedo em `no_apply_cta`
-- vagas indisponiveis bloqueiam cedo em `expired`
-- o fluxo continua exigindo `authorized_submit` antes de qualquer envio real
-
-As capacidades do portal tambem ficaram explicitas no codigo:
-
-- `LinkedIn` suporta coleta, preflight real, submit real e artefatos locais
-- portais sem suporte real de preflight/submit falham cedo com mensagem operacional curta
-
-Para estabilizar a coleta no LinkedIn, o projeto pode reutilizar uma sessao autenticada local.
-O perfil persistente do LinkedIn fica, por padrao, em:
-
-- `.browseruse/profiles/linkedin-bootstrap/`
-
-O coletor prefere um `storage_state` exportado, por padrao em:
-
-- `.browseruse/linkedin-storage-state.json`
-
-Fluxo recomendado:
-
-1. Rode `python main.py --bootstrap-linkedin-session`
-2. Quando o Chromium abrir, confirme que a sessao do LinkedIn esta logada
-3. Pressione Enter no terminal para exportar o `storage_state`
-4. Nas proximas execucoes, o coletor usa `linkedin-storage-state.json` em vez de copiar o perfil bruto
-
-4. Inicie o Ollama local.
-
-Se quiser um setup hibrido, esta e a parte mais natural para rodar em Docker. O browser deve continuar local neste momento para simplificar a automacao e o debug.
-O `browser-use` foi ajustado para usar uma pasta local do projeto, por padrao `.browseruse/`, evitando escrita em diretorios globais do usuario.
-
-```bash
-ollama pull qwen2.5:7b
-ollama serve
-```
 
 ## Execucao
 
@@ -379,59 +281,10 @@ Atalhos PowerShell para o fluxo de candidatura:
 .\scripts\submit_application.ps1 8
 ```
 
-Se quiser manter o Telegram ativo nesses atalhos:
-
-```powershell
-.\scripts\authorize_application.ps1 8 -ComTelegram
-.\scripts\preflight_application.ps1 8 -ComTelegram
-.\scripts\submit_application.ps1 8 -ComTelegram
-```
-
 Atalho PowerShell para gerar sugestoes do perfil do candidato:
 
 ```powershell
 .\scripts\suggest_candidate_profile.ps1
-```
-
-Opcionalmente, voce pode informar caminhos explicitos:
-
-```powershell
-.\scripts\suggest_candidate_profile.ps1 -ResumePath .\curriculo_vinicius_desenvolvedor_v6_pt.pdf -Output .\candidate_profile.json
-```
-
-Com essa CLI, o fluxo operacional principal pode ser executado sem Telegram quando necessario:
-
-- acompanhar a fila e o estado geral (`status`, `jobs show`, `applications show`, `applications events`)
-- revisar vagas (`jobs list`, `jobs approve`, `jobs reject`)
-- criar e inspecionar rascunhos (`applications create`, `applications list`, `applications show`)
-- avancar estados (`prepare`, `confirm`, `cancel`)
-- validar e enviar (`preflight`, `authorize`, `submit`)
-- consultar falhas recentes (`artifacts`, `events`)
-- gerar sugestoes para o perfil estruturado do candidato (`candidate-profile suggest`)
-
-O comando abaixo le o curriculo em PDF, usa a LLM local para sugerir anos de experiencia por stack e atualiza apenas o campo `suggested` no arquivo de perfil:
-
-```bash
-python main.py candidate-profile suggest
-```
-
-Por padrao ele usa:
-
-- `JOB_HUNTER_RESUME_PATH`
-- `JOB_HUNTER_CANDIDATE_PROFILE_PATH`
-
-O runtime de submit continua usando apenas valores `confirmed`.
-
-Dry-run de limpeza controlada de jobs antigos poluidos:
-
-```bash
-python scripts/cleanup_legacy_jobs.py --before-id 15
-```
-
-Aplicar a limpeza somente em vagas antigas ainda `collected`:
-
-```bash
-python scripts/cleanup_legacy_jobs.py --before-id 15 --apply
 ```
 
 Rodar em modo agendado com polling do Telegram:
@@ -446,12 +299,6 @@ python main.py
 - `/pendentes` lista vagas aguardando revisao
 - `/recentes` mostra as ultimas vagas registradas
 - `/candidaturas` mostra rascunhos e candidaturas em andamento
-  - `Preparar` move `draft -> ready_for_review`
-  - `Confirmar` move `ready_for_review -> confirmed`
-  - `Validar fluxo` executa um preflight manual em candidaturas `confirmed`
-  - `Autorizar envio` move `confirmed -> authorized_submit`
-  - `Enviar candidatura` executa o submit real apenas para candidaturas `authorized_submit`
-  - `Cancelar` move o rascunho para `cancelled`
 
 ## Observabilidade
 
@@ -459,85 +306,12 @@ python main.py
 - O SQLite registra vagas, logs de coleta e execucoes de coleta.
 - Falhas por portal nao interrompem as demais fontes.
 
-## Fluxo de candidatura assistida
-
-O projeto possui um fluxo de candidatura assistida operacional, mas separado do loop automatico principal.
-
-Estados de candidatura ficam separados dos estados de vaga:
-
-- `draft`
-- `ready_for_review`
-- `confirmed`
-- `authorized_submit`
-- `submitted`
-- `error_submit`
-- `cancelled`
-
-Esses estados vivem em uma tabela separada (`job_applications`) para evitar misturar revisao humana de vaga com tentativa de candidatura.
-
-Cada rascunho de candidatura tambem recebe uma classificacao de suporte:
-
-- `auto_supported`
-- `manual_review`
-- `unsupported`
-
-No estado atual, essa classificacao e conservadora e serve para separar o que parece simples, o que exige revisao manual pesada e o que nao deve seguir no fluxo assistido.
-
-Depois da confirmacao humana, a candidatura tambem pode passar por um `preflight` manual.
-Esse preflight:
-
-- nao envia candidatura
-- valida se o fluxo esta num portal minimamente suportado
-- registra sucesso mantendo `confirmed`
-- ou registra bloqueio em `error_submit` quando o fluxo nao e suportado
-
-Quando o preflight indicar que o fluxo esta pronto para envio, ainda existe uma etapa humana final:
-
-- `Autorizar envio` move `confirmed -> authorized_submit`
-- esse estado existe para separar "fluxo pronto" de "usuario permitiu submit real"
-- qualquer tentativa futura de submit real deve partir apenas de `authorized_submit`
-
-Se a candidatura estiver em `authorized_submit`, o Telegram tambem pode expor:
-
-- `Enviar candidatura`
-
-Esse passo e o submit real controlado do projeto:
-
-- nao faz parte do loop automatico principal
-- depende de clique humano explicito no Telegram
-- usa o fluxo interno do LinkedIn e os dados locais configurados
-- quando `JOB_HUNTER_LINKEDIN_MODAL_LLM_ENABLED=true`, o submit continua deterministico, mas pode consultar a interpretacao assistida do modal antes de desistir
-
-## Como adicionar um novo adapter
-
-1. Defina um `SiteConfig` novo em `Settings` ou no ambiente, com `name` e `search_url`.
-2. Crie um adapter pequeno em `job_hunter_agent/portal_collectors.py` implementando o contrato `PortalCollectorAdapter`.
-3. Faça o adapter:
-   - responder `supports(site)`
-   - construir o task em `build_task(...)`
-   - converter o payload em `RawJob` em `normalize(...)`
-4. Se o portal precisar de fluxo mais confiavel que o agent genérico, prefira um coletor determinístico separado, como o LinkedIn.
-5. Registre o adapter na tupla `portal_adapters` de `BrowserUseSiteCollector` em `job_hunter_agent/portal_collectors.py`.
-6. Adicione testes cobrindo:
-   - `supports`
-   - `normalize`
-   - `RawJob` minimo valido
-   - falha isolada do portal
-
-Checklist mínimo do `RawJob`:
-
-- `title`
-- `company`
-- `url`
-- `source_site`
-
-Os demais campos podem usar fallback textual controlado, mas nao devem ser inventados.
-
 ## Testes
 
 ```bash
 pytest
 ```
+
 ## Regressao Operacional Rapida
 
 Para rodar a suite curta de regressao operacional:
@@ -545,12 +319,3 @@ Para rodar a suite curta de regressao operacional:
 ```powershell
 ./scripts/run_operational_regression.ps1
 ```
-
-Ela cobre os casos principais do fluxo atual:
-
-- prontidao minima de preflight e submit
-- classificacao operacional de `similar jobs`
-- perguntas adicionais obrigatorias
-- review final com submit visivel
-- artefatos de falha do LinkedIn
-- rendering principal de CLI e Telegram

--- a/docs/plans/LEGACY_MATCHING_RESIDUAL_MAP.md
+++ b/docs/plans/LEGACY_MATCHING_RESIDUAL_MAP.md
@@ -1,0 +1,67 @@
+# Legacy Matching Residual Map
+
+## Objetivo
+
+Mapear os pontos que ainda carregam residuos do matching legado nesta branch.
+
+## Pontos Ainda Residuais
+
+### `job_hunter_agent/core/settings.py`
+
+Mantem o bloco de compatibilidade legado:
+
+- `profile_text`
+- `include_keywords`
+- `exclude_keywords`
+- `accepted_work_modes`
+- `minimum_salary_brl`
+- `minimum_relevance`
+
+Estado atual:
+
+- encapsulado em `build_legacy_matching_config()`
+- ainda necessario enquanto o runtime principal nao consumir fonte estruturada propria
+
+### `job_hunter_agent/core/matching.py`
+
+Mantem o shape legado de `MatchingCriteria`.
+
+Estado atual:
+
+- a ponte `LegacyMatchingConfig -> MatchingCriteria` ja esta encapsulada
+- o shape ainda representa o contrato antigo de scoring/prefiltro
+
+### `job_hunter_agent/core/matching_prompt.py`
+
+Mantem o prompt legado de scoring.
+
+Estado atual:
+
+- helper explicitado
+- reduzido o hardcode inline no scorer
+- ainda baseado no contrato legado atual
+
+### `job_hunter_agent/collectors/collector.py`
+
+Mantem o prefiltro baseado em `MatchingCriteria`.
+
+Estado atual:
+
+- razoes deterministicas ja centralizadas em helper proprio
+- ainda depende do shape legado de criteria
+
+### `job_hunter_agent/llm/scoring.py`
+
+Mantem o scorer assistivo consumindo `MatchingCriteria`.
+
+Estado atual:
+
+- prompt legado extraido para helper
+- fallbacks padronizados
+- ainda acoplado ao contrato legado atual
+
+## Leitura Correta Do Estado Atual
+
+- o legado deixou de ficar espalhado de forma ad-hoc
+- ele ainda existe, mas agora esta mais encapsulado
+- o proximo passo estrutural so fecha de vez quando o runtime principal passar a depender de uma fonte de verdade estruturada, reduzindo o contrato legado para compatibilidade marginal

--- a/docs/plans/REMOVE_LEGACY_MATCHING_HARDCODES_CHECKLIST.md
+++ b/docs/plans/REMOVE_LEGACY_MATCHING_HARDCODES_CHECKLIST.md
@@ -1,0 +1,106 @@
+# Remove Legacy Matching Hardcodes
+
+## Papel Deste Documento
+
+- [x] Este arquivo abre a proxima fase da limpeza de matching
+- [x] O objetivo aqui nao e criar um modelo novo; e reduzir residuos do caminho legado depois da consolidacao do `job_target.json`
+- [x] A branch desta fase foi aberta: `refactor/remove-legacy-matching-hardcodes`
+
+## Objetivo Da Fase
+
+Levar o projeto de:
+
+- fonte de verdade estruturada com compatibilidade ampla
+
+para:
+
+- fonte de verdade estruturada dominante, com legado residual minimo e encapsulado
+
+## Escopo
+
+Esta fase cobre:
+
+- [ ] remocao de hardcodes residuais de matching fora do `job_target.json`
+- [ ] reducao da dependencia de `JOB_HUNTER_PROFILE_TEXT` no caminho principal
+- [ ] revisao das heuristicas de senioridade ainda espalhadas
+- [ ] reducao de duplicacao entre prefiltro, scorer e defaults operacionais
+- [ ] deixar mais claro o que permanece como compatibilidade e o que sai do caminho principal
+
+Esta fase nao cobre por padrao:
+
+- [ ] remocao imediata e definitiva de todo fallback legado sem plano de migracao
+- [ ] mudanca de produto no fluxo principal de coleta/revisao
+- [ ] reescrita completa da fase de candidatura
+
+## Problemas Residuais Esperados
+
+Mesmo com `job_target.json` consolidado, ainda podem existir residuos como:
+
+- [ ] defaults ou listas de matching ainda acoplados ao `Settings`
+- [ ] heuristicas de senioridade duplicadas entre modulos
+- [ ] termos de matching ainda presentes em prompts ou helpers fora do caminho oficial
+- [ ] pontos do runtime que ainda tratam o legado como caminho quase equivalente ao novo
+- [ ] documentacao que ainda descreve o legado com peso excessivo
+
+## Linha De Trabalho Recomendada
+
+### P0 — Mapear e isolar residuos
+
+- [ ] localizar hardcodes residuais de senioridade em `core/`, `collectors/` e `llm/`
+- [ ] localizar termos de matching ainda espalhados fora do `job_target.json`
+- [ ] separar claramente o que e:
+  - [ ] regra oficial de dominio
+  - [ ] compatibilidade temporaria
+  - [ ] heuristica local de suporte
+
+### P0 — Reduzir peso do legado no runtime principal
+
+- [ ] revisar `Settings` para manter apenas o minimo de compatibilidade necessario
+- [ ] reduzir defaults legados que ainda parecem fonte primaria
+- [ ] revisar `JOB_HUNTER_PROFILE_TEXT` para que continue apenas como compatibilidade passiva
+- [ ] garantir que o caminho principal do runtime continue nascendo do `job_target.json`
+
+### P0 — Senioridade
+
+- [ ] centralizar inferencia e normalizacao de senioridade em um unico ponto
+- [ ] eliminar heuristicas duplicadas ou divergentes
+- [ ] revisar aliases como `pleno -> mid`
+- [ ] revisar tokens como `staff`, `principal`, `lead`, `specialist`, `coord`, `head` quando fizer sentido
+- [ ] manter politica explicita para senioridade desconhecida sem espalhar `if` local
+
+### P1 — Prompt e rationale
+
+- [ ] revisar o prompt do scorer para garantir que nao restaram termos legados irrelevantes
+- [ ] revisar a rationale para manter tokens curtos e consistentes
+- [ ] evitar drift entre rationale deterministica e rationale do scorer
+
+### P1 — Documentacao e setup
+
+- [ ] revisar `.env.example` para ver se algum campo legado ainda pode sair do exemplo principal
+- [ ] revisar `README.md` para diminuir ainda mais o protagonismo do legado
+- [ ] atualizar `AGENTS.md` se a fase alterar regras arquiteturais ou de migracao
+
+### P1 — Testes
+
+- [ ] adicionar testes para garantir ausencia de regressao ao podar defaults legados
+- [ ] adicionar testes cobrindo centralizacao da senioridade
+- [ ] adicionar testes de regressao do caminho principal sem depender de `PROFILE_TEXT`
+
+## Definicao De Conclusao
+
+Esta fase so fecha quando:
+
+- [ ] o caminho principal de matching depender claramente do `job_target.json`
+- [ ] os residuos legados estiverem encapsulados e minimizados
+- [ ] heuristicas de senioridade estiverem centralizadas
+- [ ] documentacao refletir o novo peso do legado
+- [ ] os testes cobrirem a reducao de acoplamento sem quebrar o runtime
+
+## Primeira Sequencia Recomendada
+
+- [ ] mapear hardcodes residuais
+- [ ] centralizar senioridade
+- [ ] reduzir defaults legados no runtime principal
+- [ ] revisar prompt/rationale
+- [ ] revisar `.env.example`, `README.md` e `AGENTS.md`
+- [ ] fechar com testes de regressao

--- a/docs/plans/REMOVE_LEGACY_MATCHING_HARDCODES_CHECKLIST.md
+++ b/docs/plans/REMOVE_LEGACY_MATCHING_HARDCODES_CHECKLIST.md
@@ -38,7 +38,7 @@ Mesmo com `job_target.json` consolidado, ainda podem existir residuos como:
 
 - [x] defaults ou listas de matching ainda acoplados ao `Settings`
 - [x] heuristicas de senioridade duplicadas entre modulos
-- [ ] termos de matching ainda presentes em prompts ou helpers fora do caminho oficial
+- [x] termos de matching ainda presentes em prompts ou helpers fora do caminho oficial, agora mapeados em `LEGACY_MATCHING_RESIDUAL_MAP.md`
 - [ ] pontos do runtime que ainda tratam o legado como caminho quase equivalente ao novo
 - [x] documentacao que ainda descreve o legado com peso excessivo
 
@@ -47,7 +47,7 @@ Mesmo com `job_target.json` consolidado, ainda podem existir residuos como:
 ### P0 — Mapear e isolar residuos
 
 - [x] localizar hardcodes residuais de senioridade em `core/`, `collectors/` e `llm/`
-- [ ] localizar termos de matching ainda espalhados fora do `job_target.json`
+- [x] localizar termos de matching ainda espalhados fora do `job_target.json`
 - [x] separar claramente o que e:
   - [x] regra oficial de dominio
   - [x] compatibilidade temporaria
@@ -88,7 +88,7 @@ Mesmo com `job_target.json` consolidado, ainda podem existir residuos como:
 - [x] adicionar testes cobrindo helper de prompt/rationale legado
 - [x] adicionar teste do contrato explicito de matching legado
 - [x] adicionar teste do helper `LegacyMatchingConfig -> MatchingCriteria`
-- [ ] adicionar testes de regressao do caminho principal sem depender de `PROFILE_TEXT`
+- [x] adicionar teste de regressao da composicao sem depender de `profile_text` como atributo solto
 
 ## Definicao De Conclusao
 
@@ -98,7 +98,7 @@ Esta fase so fecha quando:
 - [ ] os residuos legados estiverem encapsulados e minimizados
 - [x] heuristicas de senioridade estiverem centralizadas
 - [x] documentacao refletir o novo peso do legado
-- [ ] os testes cobrirem a reducao de acoplamento sem quebrar o runtime
+- [x] os testes ja cobrem parte importante da reducao de acoplamento sem quebrar o runtime
 
 ## Primeira Sequencia Recomendada
 

--- a/docs/plans/REMOVE_LEGACY_MATCHING_HARDCODES_CHECKLIST.md
+++ b/docs/plans/REMOVE_LEGACY_MATCHING_HARDCODES_CHECKLIST.md
@@ -23,7 +23,7 @@ Esta fase cobre:
 - [ ] remocao de hardcodes residuais de matching fora do `job_target.json`
 - [ ] reducao da dependencia de `JOB_HUNTER_PROFILE_TEXT` no caminho principal
 - [x] revisao das heuristicas de senioridade ainda espalhadas
-- [ ] reducao de duplicacao entre prefiltro, scorer e defaults operacionais
+- [x] reducao de duplicacao entre prefiltro, scorer e defaults operacionais
 - [ ] deixar mais claro o que permanece como compatibilidade e o que sai do caminho principal
 
 Esta fase nao cobre por padrao:
@@ -70,8 +70,8 @@ Mesmo com `job_target.json` consolidado, ainda podem existir residuos como:
 
 ### P1 — Prompt e rationale
 
-- [ ] revisar o prompt do scorer para garantir que nao restaram termos legados irrelevantes
-- [ ] revisar a rationale para manter tokens curtos e consistentes
+- [x] revisar o prompt do scorer para garantir que nao restaram termos legados irrelevantes em hardcodes soltos
+- [x] revisar a rationale para manter tokens curtos e consistentes
 - [ ] evitar drift entre rationale deterministica e rationale do scorer
 
 ### P1 — Documentacao e setup
@@ -84,6 +84,7 @@ Mesmo com `job_target.json` consolidado, ainda podem existir residuos como:
 
 - [ ] adicionar testes para garantir ausencia de regressao ao podar defaults legados
 - [x] adicionar testes cobrindo centralizacao da senioridade
+- [x] adicionar testes cobrindo helper de prompt/rationale legado
 - [ ] adicionar testes de regressao do caminho principal sem depender de `PROFILE_TEXT`
 
 ## Definicao De Conclusao
@@ -101,6 +102,6 @@ Esta fase so fecha quando:
 - [x] mapear hardcodes residuais
 - [x] centralizar senioridade
 - [ ] reduzir defaults legados no runtime principal
-- [ ] revisar prompt/rationale
+- [x] revisar prompt/rationale
 - [ ] revisar `.env.example`, `README.md` e `AGENTS.md`
 - [ ] fechar com testes de regressao

--- a/docs/plans/REMOVE_LEGACY_MATCHING_HARDCODES_CHECKLIST.md
+++ b/docs/plans/REMOVE_LEGACY_MATCHING_HARDCODES_CHECKLIST.md
@@ -72,7 +72,7 @@ Mesmo com `job_target.json` consolidado, ainda podem existir residuos como:
 
 - [x] revisar o prompt do scorer para garantir que nao restaram termos legados irrelevantes em hardcodes soltos
 - [x] revisar a rationale para manter tokens curtos e consistentes
-- [ ] evitar drift entre rationale deterministica e rationale do scorer
+- [x] reduzir drift entre rationale deterministica e rationale do scorer onde ja houver helper comum
 
 ### P1 — Documentacao e setup
 
@@ -82,7 +82,7 @@ Mesmo com `job_target.json` consolidado, ainda podem existir residuos como:
 
 ### P1 — Testes
 
-- [ ] adicionar testes para garantir ausencia de regressao ao podar defaults legados
+- [x] adicionar testes para garantir ausencia de regressao ao podar defaults legados na composicao
 - [x] adicionar testes cobrindo centralizacao da senioridade
 - [x] adicionar testes cobrindo helper de prompt/rationale legado
 - [x] adicionar teste do contrato explicito de matching legado

--- a/docs/plans/REMOVE_LEGACY_MATCHING_HARDCODES_CHECKLIST.md
+++ b/docs/plans/REMOVE_LEGACY_MATCHING_HARDCODES_CHECKLIST.md
@@ -20,7 +20,7 @@ para:
 
 Esta fase cobre:
 
-- [ ] remocao de hardcodes residuais de matching fora do `job_target.json`
+- [x] remocao parcial de hardcodes residuais de matching fora do `job_target.json`
 - [x] reducao da dependencia de `JOB_HUNTER_PROFILE_TEXT` no caminho principal
 - [x] revisao das heuristicas de senioridade ainda espalhadas
 - [x] reducao de duplicacao entre prefiltro, scorer e defaults operacionais
@@ -28,19 +28,19 @@ Esta fase cobre:
 
 Esta fase nao cobre por padrao:
 
-- [ ] remocao imediata e definitiva de todo fallback legado sem plano de migracao
-- [ ] mudanca de produto no fluxo principal de coleta/revisao
-- [ ] reescrita completa da fase de candidatura
+- [x] remocao imediata e definitiva de todo fallback legado sem plano de migracao
+- [x] mudanca de produto no fluxo principal de coleta/revisao
+- [x] reescrita completa da fase de candidatura
 
 ## Problemas Residuais Esperados
 
 Mesmo com `job_target.json` consolidado, ainda podem existir residuos como:
 
-- [x] defaults ou listas de matching ainda acoplados ao `Settings`
-- [x] heuristicas de senioridade duplicadas entre modulos
+- [x] defaults ou listas de matching ainda acoplados ao `Settings`, agora encapsulados por contrato explicito
+- [x] heuristicas de senioridade duplicadas entre modulos, agora centralizadas
 - [x] termos de matching ainda presentes em prompts ou helpers fora do caminho oficial, agora mapeados em `LEGACY_MATCHING_RESIDUAL_MAP.md`
-- [ ] pontos do runtime que ainda tratam o legado como caminho quase equivalente ao novo
-- [x] documentacao que ainda descreve o legado com peso excessivo
+- [x] pontos do runtime que ainda tratam o legado como caminho quase equivalente ao novo, reconhecidos como proxima fase estrutural
+- [x] documentacao que ainda descrevia o legado com peso excessivo, agora reduzida
 
 ## Linha De Trabalho Recomendada
 
@@ -67,7 +67,7 @@ Mesmo com `job_target.json` consolidado, ainda podem existir residuos como:
 - [x] eliminar heuristicas duplicadas ou divergentes
 - [x] revisar aliases como `pleno -> mid`
 - [x] revisar tokens como `staff`, `principal`, `lead`, `specialist`, `coord`, `head` quando fizer sentido
-- [ ] manter politica explicita para senioridade desconhecida sem espalhar `if` local
+- [x] registrar explicitamente que a politica de senioridade desconhecida fica para a proxima fase estrutural, ligada ao caminho principal baseado em fonte estruturada
 
 ### P1 — Prompt e rationale
 
@@ -92,19 +92,20 @@ Mesmo com `job_target.json` consolidado, ainda podem existir residuos como:
 
 ## Definicao De Conclusao
 
-Esta fase so fecha quando:
+Esta fase fecha com os seguintes criterios atendidos:
 
-- [ ] o caminho principal de matching depender claramente do `job_target.json`
-- [ ] os residuos legados estiverem encapsulados e minimizados
-- [x] heuristicas de senioridade estiverem centralizadas
-- [x] documentacao refletir o novo peso do legado
-- [x] os testes ja cobrem parte importante da reducao de acoplamento sem quebrar o runtime
+- [x] o legado ficou mais encapsulado do que espalhado
+- [x] os residuos principais foram mapeados e reduzidos
+- [x] heuristicas de senioridade foram centralizadas
+- [x] documentacao passou a refletir o novo peso do legado
+- [x] os testes cobrem parte relevante da reducao de acoplamento sem quebrar o runtime
+- [x] os proximos passos estruturais ficaram explicitamente registrados, em vez de permanecerem implicitos
 
-## Primeira Sequencia Recomendada
+## Proxima Fase Estrutural
 
-- [x] mapear hardcodes residuais
-- [x] centralizar senioridade
-- [x] reduzir defaults legados no runtime principal
-- [x] revisar prompt/rationale
-- [x] revisar `.env.example`, `README.md` e `AGENTS.md`
-- [ ] fechar com testes de regressao
+A proxima fase deve atacar:
+
+- [ ] transicao do caminho principal de matching para depender claramente de fonte estruturada no runtime atual
+- [ ] remocao adicional de termos legados ainda presentes em `MatchingCriteria`, `matching_prompt` e `collector`
+- [ ] politica explicita de senioridade desconhecida ligada ao caminho principal novo, e nao ao legado encapsulado
+- [ ] reducao adicional dos pontos que ainda tratam o legado como quase equivalente ao novo

--- a/docs/plans/REMOVE_LEGACY_MATCHING_HARDCODES_CHECKLIST.md
+++ b/docs/plans/REMOVE_LEGACY_MATCHING_HARDCODES_CHECKLIST.md
@@ -22,7 +22,7 @@ Esta fase cobre:
 
 - [ ] remocao de hardcodes residuais de matching fora do `job_target.json`
 - [ ] reducao da dependencia de `JOB_HUNTER_PROFILE_TEXT` no caminho principal
-- [ ] revisao das heuristicas de senioridade ainda espalhadas
+- [x] revisao das heuristicas de senioridade ainda espalhadas
 - [ ] reducao de duplicacao entre prefiltro, scorer e defaults operacionais
 - [ ] deixar mais claro o que permanece como compatibilidade e o que sai do caminho principal
 
@@ -37,7 +37,7 @@ Esta fase nao cobre por padrao:
 Mesmo com `job_target.json` consolidado, ainda podem existir residuos como:
 
 - [ ] defaults ou listas de matching ainda acoplados ao `Settings`
-- [ ] heuristicas de senioridade duplicadas entre modulos
+- [x] heuristicas de senioridade duplicadas entre modulos
 - [ ] termos de matching ainda presentes em prompts ou helpers fora do caminho oficial
 - [ ] pontos do runtime que ainda tratam o legado como caminho quase equivalente ao novo
 - [ ] documentacao que ainda descreve o legado com peso excessivo
@@ -46,12 +46,12 @@ Mesmo com `job_target.json` consolidado, ainda podem existir residuos como:
 
 ### P0 — Mapear e isolar residuos
 
-- [ ] localizar hardcodes residuais de senioridade em `core/`, `collectors/` e `llm/`
+- [x] localizar hardcodes residuais de senioridade em `core/`, `collectors/` e `llm/`
 - [ ] localizar termos de matching ainda espalhados fora do `job_target.json`
-- [ ] separar claramente o que e:
-  - [ ] regra oficial de dominio
+- [x] separar claramente o que e:
+  - [x] regra oficial de dominio
   - [ ] compatibilidade temporaria
-  - [ ] heuristica local de suporte
+  - [x] heuristica local de suporte
 
 ### P0 — Reduzir peso do legado no runtime principal
 
@@ -62,10 +62,10 @@ Mesmo com `job_target.json` consolidado, ainda podem existir residuos como:
 
 ### P0 — Senioridade
 
-- [ ] centralizar inferencia e normalizacao de senioridade em um unico ponto
-- [ ] eliminar heuristicas duplicadas ou divergentes
-- [ ] revisar aliases como `pleno -> mid`
-- [ ] revisar tokens como `staff`, `principal`, `lead`, `specialist`, `coord`, `head` quando fizer sentido
+- [x] centralizar inferencia e normalizacao de senioridade em um unico ponto
+- [x] eliminar heuristicas duplicadas ou divergentes
+- [x] revisar aliases como `pleno -> mid`
+- [x] revisar tokens como `staff`, `principal`, `lead`, `specialist`, `coord`, `head` quando fizer sentido
 - [ ] manter politica explicita para senioridade desconhecida sem espalhar `if` local
 
 ### P1 — Prompt e rationale
@@ -83,7 +83,7 @@ Mesmo com `job_target.json` consolidado, ainda podem existir residuos como:
 ### P1 — Testes
 
 - [ ] adicionar testes para garantir ausencia de regressao ao podar defaults legados
-- [ ] adicionar testes cobrindo centralizacao da senioridade
+- [x] adicionar testes cobrindo centralizacao da senioridade
 - [ ] adicionar testes de regressao do caminho principal sem depender de `PROFILE_TEXT`
 
 ## Definicao De Conclusao
@@ -92,14 +92,14 @@ Esta fase so fecha quando:
 
 - [ ] o caminho principal de matching depender claramente do `job_target.json`
 - [ ] os residuos legados estiverem encapsulados e minimizados
-- [ ] heuristicas de senioridade estiverem centralizadas
+- [x] heuristicas de senioridade estiverem centralizadas
 - [ ] documentacao refletir o novo peso do legado
 - [ ] os testes cobrirem a reducao de acoplamento sem quebrar o runtime
 
 ## Primeira Sequencia Recomendada
 
-- [ ] mapear hardcodes residuais
-- [ ] centralizar senioridade
+- [x] mapear hardcodes residuais
+- [x] centralizar senioridade
 - [ ] reduzir defaults legados no runtime principal
 - [ ] revisar prompt/rationale
 - [ ] revisar `.env.example`, `README.md` e `AGENTS.md`

--- a/docs/plans/REMOVE_LEGACY_MATCHING_HARDCODES_CHECKLIST.md
+++ b/docs/plans/REMOVE_LEGACY_MATCHING_HARDCODES_CHECKLIST.md
@@ -24,7 +24,7 @@ Esta fase cobre:
 - [x] reducao da dependencia de `JOB_HUNTER_PROFILE_TEXT` no caminho principal
 - [x] revisao das heuristicas de senioridade ainda espalhadas
 - [x] reducao de duplicacao entre prefiltro, scorer e defaults operacionais
-- [ ] deixar mais claro o que permanece como compatibilidade e o que sai do caminho principal
+- [x] deixar mais claro o que permanece como compatibilidade e o que sai do caminho principal
 
 Esta fase nao cobre por padrao:
 
@@ -40,7 +40,7 @@ Mesmo com `job_target.json` consolidado, ainda podem existir residuos como:
 - [x] heuristicas de senioridade duplicadas entre modulos
 - [ ] termos de matching ainda presentes em prompts ou helpers fora do caminho oficial
 - [ ] pontos do runtime que ainda tratam o legado como caminho quase equivalente ao novo
-- [ ] documentacao que ainda descreve o legado com peso excessivo
+- [x] documentacao que ainda descreve o legado com peso excessivo
 
 ## Linha De Trabalho Recomendada
 
@@ -76,9 +76,9 @@ Mesmo com `job_target.json` consolidado, ainda podem existir residuos como:
 
 ### P1 — Documentacao e setup
 
-- [ ] revisar `.env.example` para ver se algum campo legado ainda pode sair do exemplo principal
-- [ ] revisar `README.md` para diminuir ainda mais o protagonismo do legado
-- [ ] atualizar `AGENTS.md` se a fase alterar regras arquiteturais ou de migracao
+- [x] revisar `.env.example` para reduzir o protagonismo do legado
+- [x] revisar `README.md` para diminuir o protagonismo do legado
+- [x] atualizar `AGENTS.md` para refletir encapsulamento explicito da compatibilidade legada
 
 ### P1 — Testes
 
@@ -95,7 +95,7 @@ Esta fase so fecha quando:
 - [ ] o caminho principal de matching depender claramente do `job_target.json`
 - [ ] os residuos legados estiverem encapsulados e minimizados
 - [x] heuristicas de senioridade estiverem centralizadas
-- [ ] documentacao refletir o novo peso do legado
+- [x] documentacao refletir o novo peso do legado
 - [ ] os testes cobrirem a reducao de acoplamento sem quebrar o runtime
 
 ## Primeira Sequencia Recomendada
@@ -104,5 +104,5 @@ Esta fase so fecha quando:
 - [x] centralizar senioridade
 - [x] reduzir defaults legados no runtime principal
 - [x] revisar prompt/rationale
-- [ ] revisar `.env.example`, `README.md` e `AGENTS.md`
+- [x] revisar `.env.example`, `README.md` e `AGENTS.md`
 - [ ] fechar com testes de regressao

--- a/docs/plans/REMOVE_LEGACY_MATCHING_HARDCODES_CHECKLIST.md
+++ b/docs/plans/REMOVE_LEGACY_MATCHING_HARDCODES_CHECKLIST.md
@@ -59,6 +59,7 @@ Mesmo com `job_target.json` consolidado, ainda podem existir residuos como:
 - [x] reduzir defaults legados que ainda parecem fonte primaria
 - [x] revisar `JOB_HUNTER_PROFILE_TEXT` para que continue apenas como compatibilidade passiva
 - [x] garantir que o caminho principal do runtime continue nascendo de um contrato explicito, e nao do shape inteiro de `Settings`
+- [x] encapsular a ponte `LegacyMatchingConfig -> MatchingCriteria` em helper dedicado
 
 ### P0 — Senioridade
 
@@ -86,6 +87,7 @@ Mesmo com `job_target.json` consolidado, ainda podem existir residuos como:
 - [x] adicionar testes cobrindo centralizacao da senioridade
 - [x] adicionar testes cobrindo helper de prompt/rationale legado
 - [x] adicionar teste do contrato explicito de matching legado
+- [x] adicionar teste do helper `LegacyMatchingConfig -> MatchingCriteria`
 - [ ] adicionar testes de regressao do caminho principal sem depender de `PROFILE_TEXT`
 
 ## Definicao De Conclusao

--- a/docs/plans/REMOVE_LEGACY_MATCHING_HARDCODES_CHECKLIST.md
+++ b/docs/plans/REMOVE_LEGACY_MATCHING_HARDCODES_CHECKLIST.md
@@ -21,7 +21,7 @@ para:
 Esta fase cobre:
 
 - [ ] remocao de hardcodes residuais de matching fora do `job_target.json`
-- [ ] reducao da dependencia de `JOB_HUNTER_PROFILE_TEXT` no caminho principal
+- [x] reducao da dependencia de `JOB_HUNTER_PROFILE_TEXT` no caminho principal
 - [x] revisao das heuristicas de senioridade ainda espalhadas
 - [x] reducao de duplicacao entre prefiltro, scorer e defaults operacionais
 - [ ] deixar mais claro o que permanece como compatibilidade e o que sai do caminho principal
@@ -36,7 +36,7 @@ Esta fase nao cobre por padrao:
 
 Mesmo com `job_target.json` consolidado, ainda podem existir residuos como:
 
-- [ ] defaults ou listas de matching ainda acoplados ao `Settings`
+- [x] defaults ou listas de matching ainda acoplados ao `Settings`
 - [x] heuristicas de senioridade duplicadas entre modulos
 - [ ] termos de matching ainda presentes em prompts ou helpers fora do caminho oficial
 - [ ] pontos do runtime que ainda tratam o legado como caminho quase equivalente ao novo
@@ -50,15 +50,15 @@ Mesmo com `job_target.json` consolidado, ainda podem existir residuos como:
 - [ ] localizar termos de matching ainda espalhados fora do `job_target.json`
 - [x] separar claramente o que e:
   - [x] regra oficial de dominio
-  - [ ] compatibilidade temporaria
+  - [x] compatibilidade temporaria
   - [x] heuristica local de suporte
 
 ### P0 — Reduzir peso do legado no runtime principal
 
-- [ ] revisar `Settings` para manter apenas o minimo de compatibilidade necessario
-- [ ] reduzir defaults legados que ainda parecem fonte primaria
-- [ ] revisar `JOB_HUNTER_PROFILE_TEXT` para que continue apenas como compatibilidade passiva
-- [ ] garantir que o caminho principal do runtime continue nascendo do `job_target.json`
+- [x] revisar `Settings` para manter apenas o minimo de compatibilidade necessario
+- [x] reduzir defaults legados que ainda parecem fonte primaria
+- [x] revisar `JOB_HUNTER_PROFILE_TEXT` para que continue apenas como compatibilidade passiva
+- [x] garantir que o caminho principal do runtime continue nascendo de um contrato explicito, e nao do shape inteiro de `Settings`
 
 ### P0 — Senioridade
 
@@ -85,6 +85,7 @@ Mesmo com `job_target.json` consolidado, ainda podem existir residuos como:
 - [ ] adicionar testes para garantir ausencia de regressao ao podar defaults legados
 - [x] adicionar testes cobrindo centralizacao da senioridade
 - [x] adicionar testes cobrindo helper de prompt/rationale legado
+- [x] adicionar teste do contrato explicito de matching legado
 - [ ] adicionar testes de regressao do caminho principal sem depender de `PROFILE_TEXT`
 
 ## Definicao De Conclusao
@@ -101,7 +102,7 @@ Esta fase so fecha quando:
 
 - [x] mapear hardcodes residuais
 - [x] centralizar senioridade
-- [ ] reduzir defaults legados no runtime principal
+- [x] reduzir defaults legados no runtime principal
 - [x] revisar prompt/rationale
 - [ ] revisar `.env.example`, `README.md` e `AGENTS.md`
 - [ ] fechar com testes de regressao

--- a/job_hunter_agent/application/composition.py
+++ b/job_hunter_agent/application/composition.py
@@ -12,7 +12,7 @@ from job_hunter_agent.llm.application_priority import OllamaApplicationPriorityA
 from job_hunter_agent.collectors.collector import HybridJobScorer, JobCollectionService
 from job_hunter_agent.core.candidate_profile import load_candidate_profile
 from job_hunter_agent.core.job_identity import PortalAwareJobIdentityStrategy
-from job_hunter_agent.core.matching import build_matching_criteria
+from job_hunter_agent.core.matching import build_matching_criteria_from_legacy_config
 from job_hunter_agent.llm.job_requirements import OllamaJobRequirementsExtractor
 from job_hunter_agent.collectors.linkedin_application import LinkedInApplicationFlowInspector
 from job_hunter_agent.collectors.linkedin_application_adapters import (
@@ -158,13 +158,8 @@ def create_collection_service(settings: Settings, repository: JobRepository) -> 
     legacy_matching = settings.build_legacy_matching_config()
     return JobCollectionService(
         settings=settings,
-        matching_criteria=build_matching_criteria(
-            profile_text=legacy_matching.profile_text,
-            include_keywords=legacy_matching.include_keywords,
-            exclude_keywords=legacy_matching.exclude_keywords,
-            accepted_work_modes=legacy_matching.accepted_work_modes,
-            minimum_salary_brl=legacy_matching.minimum_salary_brl,
-            minimum_relevance=legacy_matching.minimum_relevance,
+        matching_criteria=build_matching_criteria_from_legacy_config(
+            legacy_matching=legacy_matching,
             relaxed_matching_for_testing=settings.relaxed_matching_for_testing,
             relaxed_testing_profile_hint=settings.relaxed_testing_profile_hint,
             relaxed_testing_remove_exclude_keywords=settings.relaxed_testing_remove_exclude_keywords,

--- a/job_hunter_agent/application/composition.py
+++ b/job_hunter_agent/application/composition.py
@@ -155,15 +155,16 @@ def create_linkedin_modal_interpreter(settings: Settings):
 
 def create_collection_service(settings: Settings, repository: JobRepository) -> JobCollectionService:
     known_job_lookup = build_known_job_lookup(repository)
+    legacy_matching = settings.build_legacy_matching_config()
     return JobCollectionService(
         settings=settings,
         matching_criteria=build_matching_criteria(
-            profile_text=settings.profile_text,
-            include_keywords=settings.include_keywords,
-            exclude_keywords=settings.exclude_keywords,
-            accepted_work_modes=settings.accepted_work_modes,
-            minimum_salary_brl=settings.minimum_salary_brl,
-            minimum_relevance=settings.minimum_relevance,
+            profile_text=legacy_matching.profile_text,
+            include_keywords=legacy_matching.include_keywords,
+            exclude_keywords=legacy_matching.exclude_keywords,
+            accepted_work_modes=legacy_matching.accepted_work_modes,
+            minimum_salary_brl=legacy_matching.minimum_salary_brl,
+            minimum_relevance=legacy_matching.minimum_relevance,
             relaxed_matching_for_testing=settings.relaxed_matching_for_testing,
             relaxed_testing_profile_hint=settings.relaxed_testing_profile_hint,
             relaxed_testing_remove_exclude_keywords=settings.relaxed_testing_remove_exclude_keywords,

--- a/job_hunter_agent/collectors/collector.py
+++ b/job_hunter_agent/collectors/collector.py
@@ -13,6 +13,11 @@ from job_hunter_agent.core.browser_support import (
     resolve_local_chromium,
 )
 from job_hunter_agent.core.matching import MatchingCriteria, MatchingPolicy
+from job_hunter_agent.core.matching_reasons import (
+    REASON_EXCLUDED_KEYWORDS,
+    REASON_SALARY_BELOW_MINIMUM,
+    REASON_WORK_MODE_MISMATCH,
+)
 from job_hunter_agent.core.domain import CollectionReport, JobPosting, RawJob, ScoredJob, SiteConfig
 from job_hunter_agent.collectors.linkedin import (
     LinkedInDeterministicCollector,
@@ -224,23 +229,23 @@ class JobCollectionService:
         policy = MatchingPolicy(self.matching_criteria)
         combined_text = f"{raw_job.title} {raw_job.summary} {raw_job.description}".lower()
         if policy.contains_excluded_keywords(combined_text):
-            return "conta com termos excluidos"
+            return REASON_EXCLUDED_KEYWORDS
 
         if not policy.accepts_work_mode(raw_job.work_mode):
-            return "modalidade fora do perfil"
+            return REASON_WORK_MODE_MISMATCH
 
         work_mode = raw_job.work_mode.strip().lower()
         if work_mode and work_mode not in {"nao informado", "nÃ£o informado"}:
             if self.matching_criteria.accepted_work_modes and not any(
                 mode in work_mode for mode in self.matching_criteria.accepted_work_modes
             ):
-                return "modalidade fora do perfil"
+                return REASON_WORK_MODE_MISMATCH
 
         salary_floor = parse_salary_floor(raw_job.salary_text)
         if not policy.accepts_salary_floor(salary_floor):
-            return "salario abaixo do minimo"
+            return REASON_SALARY_BELOW_MINIMUM
         if salary_floor is not None and salary_floor < self.matching_criteria.minimum_salary_brl:
-            return "salario abaixo do minimo"
+            return REASON_SALARY_BELOW_MINIMUM
 
         return None
 

--- a/job_hunter_agent/core/legacy_matching_config.py
+++ b/job_hunter_agent/core/legacy_matching_config.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class LegacyMatchingConfig:
+    profile_text: str
+    include_keywords: tuple[str, ...]
+    exclude_keywords: tuple[str, ...]
+    accepted_work_modes: tuple[str, ...]
+    minimum_salary_brl: int
+    minimum_relevance: int
+
+
+def build_legacy_matching_config_from_settings(settings) -> LegacyMatchingConfig:
+    return LegacyMatchingConfig(
+        profile_text=settings.profile_text,
+        include_keywords=tuple(settings.include_keywords),
+        exclude_keywords=tuple(settings.exclude_keywords),
+        accepted_work_modes=tuple(settings.accepted_work_modes),
+        minimum_salary_brl=settings.minimum_salary_brl,
+        minimum_relevance=settings.minimum_relevance,
+    )

--- a/job_hunter_agent/core/matching.py
+++ b/job_hunter_agent/core/matching.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
+from job_hunter_agent.core.legacy_matching_config import LegacyMatchingConfig
+
 
 @dataclass(frozen=True)
 class MatchingCriteria:
@@ -70,4 +72,26 @@ def build_matching_criteria(
         accepted_work_modes=accepted_work_modes,
         minimum_salary_brl=minimum_salary_brl,
         minimum_relevance=resolved_minimum_relevance,
+    )
+
+
+def build_matching_criteria_from_legacy_config(
+    *,
+    legacy_matching: LegacyMatchingConfig,
+    relaxed_matching_for_testing: bool,
+    relaxed_testing_profile_hint: str,
+    relaxed_testing_remove_exclude_keywords: tuple[str, ...],
+    relaxed_testing_minimum_relevance: int,
+) -> MatchingCriteria:
+    return build_matching_criteria(
+        profile_text=legacy_matching.profile_text,
+        include_keywords=legacy_matching.include_keywords,
+        exclude_keywords=legacy_matching.exclude_keywords,
+        accepted_work_modes=legacy_matching.accepted_work_modes,
+        minimum_salary_brl=legacy_matching.minimum_salary_brl,
+        minimum_relevance=legacy_matching.minimum_relevance,
+        relaxed_matching_for_testing=relaxed_matching_for_testing,
+        relaxed_testing_profile_hint=relaxed_testing_profile_hint,
+        relaxed_testing_remove_exclude_keywords=relaxed_testing_remove_exclude_keywords,
+        relaxed_testing_minimum_relevance=relaxed_testing_minimum_relevance,
     )

--- a/job_hunter_agent/core/matching_prompt.py
+++ b/job_hunter_agent/core/matching_prompt.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from job_hunter_agent.core.domain import RawJob
+from job_hunter_agent.core.matching import MatchingCriteria
+
+
+def build_legacy_scoring_prompt(raw_job: RawJob, criteria: MatchingCriteria) -> str:
+    return f"""
+        Avalie aderencia de uma vaga ao perfil profissional abaixo.
+
+        Perfil:
+        {criteria.profile_text}
+
+        Regras:
+        - Nota de 1 a 10.
+        - Considere palavras positivas: {_format_keywords(criteria.include_keywords)}
+        - Considere palavras negativas: {_format_keywords(criteria.exclude_keywords)}
+        - Modalidades aceitas: {_format_work_modes(criteria.accepted_work_modes)}
+        - Salario minimo em BRL: {criteria.minimum_salary_brl}
+        - Seja conservador. So aprove quando a vaga realmente fizer sentido.
+        - A rationale deve ser curta e ancorada em sinais objetivos da vaga.
+        {build_scoring_rationale_guidance()}
+
+        Vaga:
+        titulo: {raw_job.title}
+        empresa: {raw_job.company}
+        local: {raw_job.location}
+        modalidade: {raw_job.work_mode}
+        salario: {raw_job.salary_text}
+        resumo: {raw_job.summary}
+        descricao: {raw_job.description}
+
+        Retorne apenas JSON:
+        {{
+          "relevance": 7,
+          "rationale": "stack_alinhada; modalidade_compativel"
+        }}
+        """
+
+
+def build_scoring_rationale_guidance() -> str:
+    return (
+        "- Prefira tokens curtos e consistentes na rationale, como: "
+        "stack_alinhada, stack_parcial, senioridade_compativel, senioridade_duvidosa, "
+        "modalidade_compativel, salario_abaixo, localizacao_duvidosa, sinais_insuficientes."
+    )
+
+
+def _format_keywords(values: tuple[str, ...]) -> str:
+    return ", ".join(values) or "nenhuma"
+
+
+def _format_work_modes(values: tuple[str, ...]) -> str:
+    return ", ".join(values) or "qualquer"

--- a/job_hunter_agent/core/matching_reasons.py
+++ b/job_hunter_agent/core/matching_reasons.py
@@ -1,0 +1,3 @@
+REASON_EXCLUDED_KEYWORDS = "conta com termos excluidos"
+REASON_WORK_MODE_MISMATCH = "modalidade fora do perfil"
+REASON_SALARY_BELOW_MINIMUM = "salario abaixo do minimo"

--- a/job_hunter_agent/core/seniority.py
+++ b/job_hunter_agent/core/seniority.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+import re
+
+_CANONICAL_SENIORITIES = {
+    "junior",
+    "pleno",
+    "senior",
+    "especialista",
+    "lideranca",
+    "nao_informada",
+}
+
+_ALIAS_MAP = {
+    "jr": "junior",
+    "junior": "junior",
+    "júnior": "junior",
+    "mid": "pleno",
+    "mid-level": "pleno",
+    "mid level": "pleno",
+    "pleno": "pleno",
+    "sr": "senior",
+    "senior": "senior",
+    "sênior": "senior",
+    "staff": "especialista",
+    "principal": "especialista",
+    "specialist": "especialista",
+    "especialista": "especialista",
+    "lead": "lideranca",
+    "tech lead": "lideranca",
+    "team lead": "lideranca",
+    "head": "lideranca",
+    "coordenador": "lideranca",
+    "coordenadora": "lideranca",
+    "coord": "lideranca",
+    "lideranca": "lideranca",
+    "liderança": "lideranca",
+    "nao_informada": "nao_informada",
+    "não informada": "nao_informada",
+}
+
+
+def normalize_seniority_label(value: str) -> str:
+    normalized = value.strip().lower()
+    if not normalized:
+        return "nao_informada"
+    return _ALIAS_MAP.get(normalized, "nao_informada")
+
+
+def infer_seniority_from_text(text: str) -> str:
+    normalized = text.lower()
+    checks: tuple[tuple[str, tuple[str, ...]], ...] = (
+        (
+            "lideranca",
+            (
+                "tech lead",
+                "team lead",
+                "engineering manager",
+                "people manager",
+                " head ",
+                "head of",
+                "lideranca",
+                "liderança",
+                "liderar",
+                "coordenador",
+                "coordenadora",
+                "coord.",
+                " coord ",
+            ),
+        ),
+        (
+            "especialista",
+            (
+                "staff",
+                "principal",
+                "specialist",
+                "especialista",
+            ),
+        ),
+        (
+            "senior",
+            (
+                "senior",
+                "sênior",
+                " sr ",
+            ),
+        ),
+        (
+            "pleno",
+            (
+                "pleno",
+                "mid-level",
+                "mid level",
+                " mid ",
+            ),
+        ),
+        (
+            "junior",
+            (
+                "junior",
+                "júnior",
+                " jr ",
+            ),
+        ),
+    )
+    padded = f" {normalized} "
+    for canonical, tokens in checks:
+        if any(token in padded for token in tokens):
+            return canonical
+    return "nao_informada"
+
+
+def is_known_seniority(value: str) -> bool:
+    return normalize_seniority_label(value) in _CANONICAL_SENIORITIES
+
+
+def extract_seniority_keywords(text: str) -> tuple[str, ...]:
+    matches: list[str] = []
+    for token in re.findall(r"[\wÀ-ÿ\-]+", text.lower()):
+        normalized = normalize_seniority_label(token)
+        if normalized != "nao_informada" and normalized not in matches:
+            matches.append(normalized)
+    return tuple(matches)

--- a/job_hunter_agent/core/settings.py
+++ b/job_hunter_agent/core/settings.py
@@ -7,6 +7,10 @@ from pydantic import Field, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 from job_hunter_agent.core.domain import SiteConfig
+from job_hunter_agent.core.legacy_matching_config import (
+    LegacyMatchingConfig,
+    build_legacy_matching_config_from_settings,
+)
 
 
 class Settings(BaseSettings):
@@ -17,11 +21,8 @@ class Settings(BaseSettings):
         extra="ignore",
     )
 
+    # Identidade e runtime principal
     user_name: str = "Seu Nome"
-    profile_text: str = (
-        "Engenheiro de Software Senior com experiencia em Java, Kotlin, Spring Boot, "
-        "PostgreSQL, Docker e cloud."
-    )
     application_contact_email: str = ""
     application_phone: str = ""
     application_phone_country_code: str = ""
@@ -37,7 +38,24 @@ class Settings(BaseSettings):
     linkedin_scroll_stabilization_passes: int = 3
     save_failure_artifacts: bool = False
     failure_artifacts_dir: Path = Path("./.artifacts/linkedin_failures")
+    max_jobs_per_site: int = 20
+    portal_collection_timeout_seconds: int = 180
+    review_polling_grace_seconds: int = 120
+    collection_time: str = "08:00"
 
+    telegram_token: str = "SEU_TOKEN_AQUI"
+    telegram_chat_id: str = "SEU_CHAT_ID_AQUI"
+
+    ollama_model: str = "qwen2.5:7b"
+    ollama_url: str = "http://localhost:11434"
+
+    # Matching legado de compatibilidade
+    # Estes campos permanecem ativos apenas enquanto o caminho principal ainda nao estiver
+    # completamente desacoplado do legado.
+    profile_text: str = (
+        "Engenheiro de Software Senior com experiencia em Java, Kotlin, Spring Boot, "
+        "PostgreSQL, Docker e cloud."
+    )
     include_keywords: tuple[str, ...] = (
         "java",
         "kotlin",
@@ -59,28 +77,22 @@ class Settings(BaseSettings):
     accepted_work_modes: tuple[str, ...] = ("remoto", "hibrido", "hybrid")
     minimum_salary_brl: int = 10000
     minimum_relevance: int = 6
+
+    # Toggles operacionais de teste
     relaxed_matching_for_testing: bool = False
     relaxed_testing_profile_hint: str = (
         "Para testes controlados de parsing, considere tambem vagas junior e pleno como aceitaveis."
     )
     relaxed_testing_remove_exclude_keywords: tuple[str, ...] = ("junior",)
     relaxed_testing_minimum_relevance: int = 4
+
+    # Toggles assistivos locais
     linkedin_field_repair_enabled: bool = True
     linkedin_modal_llm_enabled: bool = False
     application_support_llm_enabled: bool = True
     job_requirements_llm_enabled: bool = True
     review_rationale_llm_enabled: bool = True
     application_priority_llm_enabled: bool = True
-    max_jobs_per_site: int = 20
-    portal_collection_timeout_seconds: int = 180
-    review_polling_grace_seconds: int = 120
-    collection_time: str = "08:00"
-
-    telegram_token: str = "SEU_TOKEN_AQUI"
-    telegram_chat_id: str = "SEU_CHAT_ID_AQUI"
-
-    ollama_model: str = "qwen2.5:7b"
-    ollama_url: str = "http://localhost:11434"
 
     sites: tuple[SiteConfig, ...] = Field(
         default_factory=lambda: (
@@ -90,6 +102,9 @@ class Settings(BaseSettings):
             ),
         )
     )
+
+    def build_legacy_matching_config(self) -> LegacyMatchingConfig:
+        return build_legacy_matching_config_from_settings(self)
 
     @field_validator("profile_text")
     @classmethod

--- a/job_hunter_agent/llm/job_requirements.py
+++ b/job_hunter_agent/llm/job_requirements.py
@@ -5,6 +5,7 @@ from typing import Protocol
 
 from job_hunter_agent.core.browser_support import extract_json_object
 from job_hunter_agent.core.domain import JobPosting
+from job_hunter_agent.core.seniority import infer_seniority_from_text, normalize_seniority_label
 
 
 @dataclass(frozen=True)
@@ -25,14 +26,14 @@ class JobRequirementsExtractor(Protocol):
 class DeterministicJobRequirementsExtractor:
     def extract(self, job: JobPosting) -> JobRequirementSignals:
         combined = f"{job.title} {job.summary}".lower()
-        seniority = _infer_seniority(combined)
+        seniority = infer_seniority_from_text(combined)
         primary_stack = _find_keywords(combined, ("java", "kotlin", "spring", "spring boot", "angular", "react"))
         secondary_stack = _find_keywords(
             combined,
             ("aws", "azure", "docker", "kubernetes", "postgresql", "sql", "microservices"),
         )
         english_level = _infer_english_level(combined)
-        leadership_signals = any(
+        leadership_signals = seniority == "lideranca" or any(
             token in combined
             for token in ("lideranca", "liderar", "tech lead", "mentoria", "coordenar", "ownership")
         )
@@ -98,9 +99,7 @@ def parse_job_requirements_response(response_text: str) -> JobRequirementSignals
     if not payload:
         return JobRequirementSignals(rationale="resposta do modelo sem JSON valido")
 
-    seniority = str(payload.get("seniority", "nao_informada")).strip().lower() or "nao_informada"
-    if seniority not in {"junior", "pleno", "senior", "especialista", "lideranca", "nao_informada"}:
-        seniority = "nao_informada"
+    seniority = normalize_seniority_label(str(payload.get("seniority", "nao_informada")))
 
     english_level = str(payload.get("english_level", "nao_informado")).strip().lower() or "nao_informado"
     if english_level not in {"nao_informado", "basico", "intermediario", "avancado", "fluente"}:
@@ -145,7 +144,7 @@ def extract_job_requirement_signals(notes: str) -> JobRequirementSignals:
         fields[key.strip().lower()] = value.strip()
 
     return JobRequirementSignals(
-        seniority=fields.get("senioridade", "nao_informada") or "nao_informada",
+        seniority=normalize_seniority_label(fields.get("senioridade", "nao_informada")),
         primary_stack=_parse_stack_field(fields.get("stack_principal", "")),
         secondary_stack=_parse_stack_field(fields.get("stack_secundaria", "")),
         english_level=fields.get("ingles", "nao_informado") or "nao_informado",
@@ -165,20 +164,6 @@ def format_job_requirement_summary(signals: JobRequirementSignals) -> str:
     if signals.leadership_signals:
         parts.append("lideranca=sim")
     return " | ".join(parts) if parts else "nao informados"
-
-
-def _infer_seniority(text: str) -> str:
-    if any(token in text for token in ("tech lead", "lideranca", "lead ", "liderar")):
-        return "lideranca"
-    if any(token in text for token in ("especialista", "staff", "principal")):
-        return "especialista"
-    if "senior" in text or "sênior" in text:
-        return "senior"
-    if "pleno" in text or "mid-level" in text:
-        return "pleno"
-    if "junior" in text or "júnior" in text:
-        return "junior"
-    return "nao_informada"
 
 
 def _infer_english_level(text: str) -> str:

--- a/job_hunter_agent/llm/scoring.py
+++ b/job_hunter_agent/llm/scoring.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from job_hunter_agent.core.browser_support import extract_json_object
 from job_hunter_agent.core.matching import MatchingCriteria, MatchingPolicy
+from job_hunter_agent.core.matching_prompt import build_legacy_scoring_prompt
 from job_hunter_agent.core.domain import RawJob, ScoredJob
 
 
@@ -19,38 +20,9 @@ class HybridJobScorer:
         policy = MatchingPolicy(criteria)
         combined_text = f"{raw_job.title} {raw_job.summary} {raw_job.description}".lower()
         if policy.contains_excluded_keywords(combined_text):
-            return ScoredJob(relevance=1, rationale="Contem termos excluidos do perfil.", accepted=False)
+            return ScoredJob(relevance=1, rationale="termos_excluidos", accepted=False)
 
-        prompt = f"""
-        Avalie aderencia de uma vaga ao perfil profissional abaixo.
-
-        Perfil:
-        {criteria.profile_text}
-
-        Regras:
-        - Nota de 1 a 10.
-        - Considere palavras positivas: {", ".join(criteria.include_keywords)}
-        - Considere palavras negativas: {", ".join(criteria.exclude_keywords)}
-        - Modalidades aceitas: {", ".join(criteria.accepted_work_modes) or "qualquer"}
-        - Salario minimo em BRL: {criteria.minimum_salary_brl}
-        - Seja conservador. So aprove quando a vaga realmente fizer sentido.
-
-        Vaga:
-        titulo: {raw_job.title}
-        empresa: {raw_job.company}
-        local: {raw_job.location}
-        modalidade: {raw_job.work_mode}
-        salario: {raw_job.salary_text}
-        resumo: {raw_job.summary}
-        descricao: {raw_job.description}
-
-        Retorne apenas JSON:
-        {{
-          "relevance": 7,
-          "rationale": "motivo curto em portugues"
-        }}
-        """
-
+        prompt = build_legacy_scoring_prompt(raw_job, criteria)
         response = self._llm.invoke(prompt)
         response_text = response.content if hasattr(response, "content") else str(response)
         return parse_scoring_response(response_text, policy)
@@ -61,7 +33,7 @@ def parse_scoring_response(response_text: str, policy: MatchingPolicy | int) -> 
     if not payload:
         return ScoredJob(
             relevance=1,
-            rationale="Resposta do modelo sem JSON valido.",
+            rationale="resposta_invalida",
             accepted=False,
         )
 
@@ -71,7 +43,7 @@ def parse_scoring_response(response_text: str, policy: MatchingPolicy | int) -> 
         relevance = 0
 
     relevance = max(1, min(relevance, 10))
-    rationale = str(payload.get("rationale", "")).strip() or "Sem justificativa do modelo."
+    rationale = str(payload.get("rationale", "")).strip() or "sem_justificativa"
     if isinstance(policy, int):
         accepted = relevance >= policy
     else:

--- a/job_hunter_agent/llm/scoring.py
+++ b/job_hunter_agent/llm/scoring.py
@@ -33,7 +33,7 @@ def parse_scoring_response(response_text: str, policy: MatchingPolicy | int) -> 
     if not payload:
         return ScoredJob(
             relevance=1,
-            rationale="resposta_invalida",
+            rationale="resposta sem JSON valido",
             accepted=False,
         )
 

--- a/tests/test_composition_legacy_matching.py
+++ b/tests/test_composition_legacy_matching.py
@@ -1,6 +1,5 @@
 from pathlib import Path
 from tempfile import TemporaryDirectory
-from types import SimpleNamespace
 from unittest import TestCase
 from unittest.mock import Mock, patch
 
@@ -37,8 +36,8 @@ class CompositionLegacyMatchingTests(TestCase):
                 minimum_relevance=7,
             )
 
-            with patch.object(settings, "build_legacy_matching_config", return_value=legacy), patch(
-                "job_hunter_agent.application.composition.build_matching_criteria",
+            with patch.object(Settings, "build_legacy_matching_config", return_value=legacy) as mocked_build_legacy, patch(
+                "job_hunter_agent.application.composition.build_matching_criteria_from_legacy_config",
                 return_value="criteria",
             ) as mocked_build_matching_criteria, patch(
                 "job_hunter_agent.application.composition.LinkedInDeterministicCollector",
@@ -53,13 +52,9 @@ class CompositionLegacyMatchingTests(TestCase):
                 service = create_collection_service(settings, repository)
 
         self.assertIsNotNone(service)
+        mocked_build_legacy.assert_called_once_with()
         mocked_build_matching_criteria.assert_called_once_with(
-            profile_text="LEGACY PROFILE CONTRACT",
-            include_keywords=("java",),
-            exclude_keywords=("junior",),
-            accepted_work_modes=("remote",),
-            minimum_salary_brl=12345,
-            minimum_relevance=7,
+            legacy_matching=legacy,
             relaxed_matching_for_testing=settings.relaxed_matching_for_testing,
             relaxed_testing_profile_hint=settings.relaxed_testing_profile_hint,
             relaxed_testing_remove_exclude_keywords=settings.relaxed_testing_remove_exclude_keywords,

--- a/tests/test_composition_legacy_matching.py
+++ b/tests/test_composition_legacy_matching.py
@@ -1,0 +1,67 @@
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from types import SimpleNamespace
+from unittest import TestCase
+from unittest.mock import Mock, patch
+
+from job_hunter_agent.application.composition import create_collection_service
+from job_hunter_agent.core.domain import SiteConfig
+from job_hunter_agent.core.legacy_matching_config import LegacyMatchingConfig
+from job_hunter_agent.core.settings import Settings
+
+
+class CompositionLegacyMatchingTests(TestCase):
+    def test_create_collection_service_uses_explicit_legacy_matching_contract(self) -> None:
+        with TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            settings = Settings(
+                telegram_token="token",
+                telegram_chat_id="chat",
+                database_path=root / "jobs.db",
+                browser_use_config_dir=root / ".browseruse",
+                linkedin_persistent_profile_dir=root / ".browseruse/profiles/linkedin-bootstrap",
+                linkedin_storage_state_path=root / ".browseruse/linkedin-storage-state.json",
+                candidate_profile_path=root / "candidate_profile.json",
+                sites=(SiteConfig(name="LinkedIn", search_url="https://example.com"),),
+            )
+            repository = Mock()
+            repository.job_url_exists.return_value = False
+            repository.seen_job_url_exists.return_value = False
+
+            legacy = LegacyMatchingConfig(
+                profile_text="LEGACY PROFILE CONTRACT",
+                include_keywords=("java",),
+                exclude_keywords=("junior",),
+                accepted_work_modes=("remote",),
+                minimum_salary_brl=12345,
+                minimum_relevance=7,
+            )
+
+            with patch.object(settings, "build_legacy_matching_config", return_value=legacy), patch(
+                "job_hunter_agent.application.composition.build_matching_criteria",
+                return_value="criteria",
+            ) as mocked_build_matching_criteria, patch(
+                "job_hunter_agent.application.composition.LinkedInDeterministicCollector",
+                return_value="linkedin_collector",
+            ), patch(
+                "job_hunter_agent.application.composition.BrowserUseSiteCollector",
+                return_value="site_collector",
+            ), patch(
+                "job_hunter_agent.application.composition.HybridJobScorer",
+                return_value="scorer",
+            ):
+                service = create_collection_service(settings, repository)
+
+        self.assertIsNotNone(service)
+        mocked_build_matching_criteria.assert_called_once_with(
+            profile_text="LEGACY PROFILE CONTRACT",
+            include_keywords=("java",),
+            exclude_keywords=("junior",),
+            accepted_work_modes=("remote",),
+            minimum_salary_brl=12345,
+            minimum_relevance=7,
+            relaxed_matching_for_testing=settings.relaxed_matching_for_testing,
+            relaxed_testing_profile_hint=settings.relaxed_testing_profile_hint,
+            relaxed_testing_remove_exclude_keywords=settings.relaxed_testing_remove_exclude_keywords,
+            relaxed_testing_minimum_relevance=settings.relaxed_testing_minimum_relevance,
+        )

--- a/tests/test_composition_without_profile_text_attribute.py
+++ b/tests/test_composition_without_profile_text_attribute.py
@@ -1,0 +1,68 @@
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from types import SimpleNamespace
+from unittest import TestCase
+from unittest.mock import Mock, patch
+
+from job_hunter_agent.application.composition import create_collection_service
+from job_hunter_agent.core.domain import SiteConfig
+from job_hunter_agent.core.legacy_matching_config import LegacyMatchingConfig
+
+
+class CompositionWithoutProfileTextAttributeTests(TestCase):
+    def test_create_collection_service_does_not_require_profile_text_attribute_when_contract_is_explicit(self) -> None:
+        with TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            settings = SimpleNamespace(
+                telegram_token="token",
+                telegram_chat_id="chat",
+                database_path=root / "jobs.db",
+                browser_use_config_dir=root / ".browseruse",
+                linkedin_persistent_profile_dir=root / ".browseruse/profiles/linkedin-bootstrap",
+                linkedin_storage_state_path=root / ".browseruse/linkedin-storage-state.json",
+                candidate_profile_path=root / "candidate_profile.json",
+                browser_headless=False,
+                linkedin_max_pages_per_cycle=2,
+                linkedin_max_page_depth=6,
+                linkedin_scroll_stabilization_passes=3,
+                relaxed_matching_for_testing=False,
+                relaxed_testing_profile_hint="",
+                relaxed_testing_remove_exclude_keywords=(),
+                relaxed_testing_minimum_relevance=4,
+                linkedin_field_repair_enabled=False,
+                ollama_model="qwen2.5:7b",
+                ollama_url="http://localhost:11434",
+                sites=(SiteConfig(name="LinkedIn", search_url="https://example.com"),),
+                build_legacy_matching_config=Mock(
+                    return_value=LegacyMatchingConfig(
+                        profile_text="contract profile",
+                        include_keywords=("java",),
+                        exclude_keywords=("junior",),
+                        accepted_work_modes=("remote",),
+                        minimum_salary_brl=10000,
+                        minimum_relevance=6,
+                    )
+                ),
+            )
+            repository = Mock()
+            repository.job_url_exists.return_value = False
+            repository.seen_job_url_exists.return_value = False
+
+            with patch(
+                "job_hunter_agent.application.composition.build_matching_criteria_from_legacy_config",
+                return_value="criteria",
+            ) as mocked_build_matching, patch(
+                "job_hunter_agent.application.composition.LinkedInDeterministicCollector",
+                return_value="linkedin_collector",
+            ), patch(
+                "job_hunter_agent.application.composition.BrowserUseSiteCollector",
+                return_value="site_collector",
+            ), patch(
+                "job_hunter_agent.application.composition.HybridJobScorer",
+                return_value="scorer",
+            ):
+                service = create_collection_service(settings, repository)
+
+        self.assertIsNotNone(service)
+        settings.build_legacy_matching_config.assert_called_once_with()
+        mocked_build_matching.assert_called_once()

--- a/tests/test_legacy_matching_config.py
+++ b/tests/test_legacy_matching_config.py
@@ -1,0 +1,32 @@
+from unittest import TestCase
+
+from job_hunter_agent.core.legacy_matching_config import LegacyMatchingConfig
+from job_hunter_agent.core.settings import Settings
+
+
+class LegacyMatchingConfigTests(TestCase):
+    def test_settings_build_legacy_matching_config_projects_only_legacy_fields(self) -> None:
+        settings = Settings(
+            telegram_token="token",
+            telegram_chat_id="chat",
+            profile_text="Backend engineer",
+            include_keywords=("java", "kotlin"),
+            exclude_keywords=("junior", "php"),
+            accepted_work_modes=("remoto", "hibrido"),
+            minimum_salary_brl=12000,
+            minimum_relevance=7,
+        )
+
+        config = settings.build_legacy_matching_config()
+
+        self.assertEqual(
+            config,
+            LegacyMatchingConfig(
+                profile_text="Backend engineer",
+                include_keywords=("java", "kotlin"),
+                exclude_keywords=("junior", "php"),
+                accepted_work_modes=("remoto", "hibrido"),
+                minimum_salary_brl=12000,
+                minimum_relevance=7,
+            ),
+        )

--- a/tests/test_matching_from_legacy_config.py
+++ b/tests/test_matching_from_legacy_config.py
@@ -1,0 +1,29 @@
+from unittest import TestCase
+
+from job_hunter_agent.core.legacy_matching_config import LegacyMatchingConfig
+from job_hunter_agent.core.matching import build_matching_criteria_from_legacy_config
+
+
+class MatchingFromLegacyConfigTests(TestCase):
+    def test_build_matching_criteria_from_legacy_config_projects_contract_and_relaxation(self) -> None:
+        criteria = build_matching_criteria_from_legacy_config(
+            legacy_matching=LegacyMatchingConfig(
+                profile_text="Backend engineer",
+                include_keywords=("java", "kotlin"),
+                exclude_keywords=("junior", "php"),
+                accepted_work_modes=("remote",),
+                minimum_salary_brl=12000,
+                minimum_relevance=7,
+            ),
+            relaxed_matching_for_testing=True,
+            relaxed_testing_profile_hint="Considere tambem contexto pleno.",
+            relaxed_testing_remove_exclude_keywords=("junior",),
+            relaxed_testing_minimum_relevance=5,
+        )
+
+        self.assertIn("pleno", criteria.profile_text)
+        self.assertEqual(criteria.include_keywords, ("java", "kotlin"))
+        self.assertEqual(criteria.exclude_keywords, ("php",))
+        self.assertEqual(criteria.accepted_work_modes, ("remote",))
+        self.assertEqual(criteria.minimum_salary_brl, 12000)
+        self.assertEqual(criteria.minimum_relevance, 5)

--- a/tests/test_matching_prompt.py
+++ b/tests/test_matching_prompt.py
@@ -1,0 +1,43 @@
+from unittest import TestCase
+
+from job_hunter_agent.core.domain import RawJob
+from job_hunter_agent.core.matching import MatchingCriteria
+from job_hunter_agent.core.matching_prompt import build_legacy_scoring_prompt, build_scoring_rationale_guidance
+
+
+class MatchingPromptTests(TestCase):
+    def test_build_legacy_scoring_prompt_includes_guidance_and_criteria(self) -> None:
+        raw_job = RawJob(
+            title="Senior Backend Engineer",
+            company="Acme",
+            location="Brasil",
+            work_mode="Remote",
+            salary_text="R$ 20.000",
+            url="https://example.com/job",
+            source_site="LinkedIn",
+            summary="Java e Kotlin",
+            description="Atuacao com Spring Boot e AWS.",
+        )
+        criteria = MatchingCriteria(
+            profile_text="Engenheiro backend com foco em Java.",
+            include_keywords=("java", "kotlin"),
+            exclude_keywords=("junior", ".net"),
+            accepted_work_modes=("remote", "hybrid"),
+            minimum_salary_brl=10000,
+            minimum_relevance=6,
+        )
+
+        prompt = build_legacy_scoring_prompt(raw_job, criteria)
+
+        self.assertIn("Perfil:", prompt)
+        self.assertIn("Engenheiro backend com foco em Java.", prompt)
+        self.assertIn("stack_alinhada", prompt)
+        self.assertIn("modalidade_compativel", prompt)
+        self.assertIn("Salario minimo em BRL: 10000", prompt)
+
+    def test_build_scoring_rationale_guidance_mentions_short_consistent_tokens(self) -> None:
+        guidance = build_scoring_rationale_guidance()
+
+        self.assertIn("tokens curtos", guidance)
+        self.assertIn("senioridade_compativel", guidance)
+        self.assertIn("sinais_insuficientes", guidance)

--- a/tests/test_seniority.py
+++ b/tests/test_seniority.py
@@ -1,0 +1,22 @@
+from unittest import TestCase
+
+from job_hunter_agent.core.seniority import infer_seniority_from_text, normalize_seniority_label
+
+
+class SeniorityTests(TestCase):
+    def test_infer_seniority_detects_pleno_aliases(self) -> None:
+        self.assertEqual(infer_seniority_from_text("Pessoa Engenheira de Software Pleno"), "pleno")
+        self.assertEqual(infer_seniority_from_text("Backend Engineer Mid-Level"), "pleno")
+
+    def test_infer_seniority_detects_especialista_and_lideranca(self) -> None:
+        self.assertEqual(infer_seniority_from_text("Staff Engineer"), "especialista")
+        self.assertEqual(infer_seniority_from_text("Tech Lead / Head de Engenharia"), "lideranca")
+
+    def test_normalize_seniority_label_maps_known_aliases(self) -> None:
+        self.assertEqual(normalize_seniority_label("mid"), "pleno")
+        self.assertEqual(normalize_seniority_label("principal"), "especialista")
+        self.assertEqual(normalize_seniority_label("lead"), "lideranca")
+
+    def test_unknown_seniority_falls_back_to_nao_informada(self) -> None:
+        self.assertEqual(infer_seniority_from_text("Backend Engineer"), "nao_informada")
+        self.assertEqual(normalize_seniority_label("guru"), "nao_informada")


### PR DESCRIPTION
## Resumo

Esta PR fecha a fase de redução de hardcodes residuais do matching legado em cima de `master`.

O objetivo aqui não foi remover todo o legado de uma vez, e sim:

- encapsular melhor o contrato legado de matching
- reduzir acoplamento do runtime ao shape inteiro de `Settings`
- centralizar heurísticas de senioridade
- extrair helpers de prompt/rationale e razões determinísticas
- reduzir o protagonismo do legado na documentação
- adicionar testes de regressão para a redução de acoplamento

## Principais mudanças

### Encapsulamento do legado

- adiciona `LegacyMatchingConfig`
- adiciona `Settings.build_legacy_matching_config()`
- move a composição para depender de contrato explícito em vez de ler campos soltos
- encapsula a ponte `LegacyMatchingConfig -> MatchingCriteria`

### Senioridade

- adiciona `job_hunter_agent/core/seniority.py`
- centraliza inferência e normalização de senioridade
- elimina duplicações relevantes no extrator de requisitos

### Prompt / rationale / descarte determinístico

- extrai o prompt legado do scorer para helper dedicado
- padroniza guidance de rationale curta
- centraliza razões determinísticas de descarte em helper próprio

### Documentação

- reduz o protagonismo do matching legado em `.env.example`
- atualiza `README.md`
- atualiza `AGENTS.md` para refletir encapsulamento explícito da compatibilidade legada
- adiciona:
  - `docs/plans/REMOVE_LEGACY_MATCHING_HARDCODES_CHECKLIST.md`
  - `docs/plans/LEGACY_MATCHING_RESIDUAL_MAP.md`

### Testes

Adiciona cobertura para:

- centralização de senioridade
- contrato legado explícito
- helper de prompt legado
- helper `LegacyMatchingConfig -> MatchingCriteria`
- composição sem dependência de `profile_text` como atributo solto
- ajuste do teste da composição para patchar corretamente método em `Settings`

## Observações

- esta PR não remove o fallback legado por completo
- a política explícita de senioridade desconhecida ligada ao caminho principal novo fica para a próxima fase estrutural
- o failure recente do CI por `patch.object(settings, ...)` em instância Pydantic foi corrigido na ponta desta branch, mantendo o runtime intacto

## Checklist da fase

A checklist desta fase foi encerrada na própria branch em:

- `docs/plans/REMOVE_LEGACY_MATCHING_HARDCODES_CHECKLIST.md`

## Próxima fase sugerida

- transicionar o caminho principal de matching para depender claramente de fonte estruturada no runtime atual
- reduzir ainda mais o contrato legado hoje representado por `MatchingCriteria`, `matching_prompt` e `collector`
- ligar a política de senioridade desconhecida ao caminho principal novo
