### PR TITLE
refactor: introduz fonte estruturada de matching no runtime

### DIFF
--- a/docs/plans/RUNTIME_STRUCTURED_MATCHING_SOURCE_CHECKLIST.md
+++ b/docs/plans/RUNTIME_STRUCTURED_MATCHING_SOURCE_CHECKLIST.md
@@ -20,17 +20,17 @@ para:
 
 Esta fase cobre:
 
-- [ ] introduzir no runtime principal uma fonte estruturada explícita de matching
+- [x] introduzir no runtime principal uma fonte estruturada explícita de matching
 - [ ] reduzir o papel central de `MatchingCriteria` legado
 - [ ] ligar a política de senioridade desconhecida ao caminho principal novo
 - [ ] reduzir ainda mais termos legados em `matching_prompt`, `collector` e `scoring`
-- [ ] preservar compatibilidade enquanto a transição estiver incompleta
+- [x] preservar compatibilidade enquanto a transição estiver incompleta
 
 Esta fase não cobre por padrão:
 
-- [ ] remoção imediata de todo fallback legado sem plano de migração
-- [ ] mudança de produto no fluxo principal de coleta/revisão
-- [ ] reescrita ampla do fluxo de candidatura
+- [x] remoção imediata de todo fallback legado sem plano de migração
+- [x] mudança de produto no fluxo principal de coleta/revisão
+- [x] reescrita ampla do fluxo de candidatura
 
 ## Problema Atual
 
@@ -47,10 +47,10 @@ O resultado é melhor do que antes, mas a fonte estruturada ainda não domina o 
 
 ### P0 — Fonte estruturada no runtime
 
-- [ ] definir o contrato estruturado mínimo que o runtime principal vai consumir
-- [ ] introduzir loader/bootstrap desse contrato no fluxo atual
-- [ ] fazer a composição depender desse contrato como caminho principal
-- [ ] manter fallback legado explícito e bem delimitado
+- [x] definir o contrato estruturado mínimo que o runtime principal vai consumir
+- [x] introduzir loader/bootstrap desse contrato no fluxo atual
+- [x] fazer a composição depender desse contrato como caminho principal
+- [x] manter fallback legado explícito e bem delimitado
 
 ### P0 — Senioridade como policy do caminho novo
 
@@ -73,8 +73,8 @@ O resultado é melhor do que antes, mas a fonte estruturada ainda não domina o 
 
 ### P1 — Testes
 
-- [ ] adicionar testes do runtime principal usando a fonte estruturada
-- [ ] preservar testes de compatibilidade do legado enquanto necessário
+- [x] adicionar testes do runtime principal usando a fonte estruturada
+- [x] preservar testes de compatibilidade do legado enquanto necessário
 - [ ] adicionar testes da policy de senioridade desconhecida no caminho novo
 
 ## Definição De Conclusão

--- a/docs/plans/RUNTIME_STRUCTURED_MATCHING_SOURCE_CHECKLIST.md
+++ b/docs/plans/RUNTIME_STRUCTURED_MATCHING_SOURCE_CHECKLIST.md
@@ -22,8 +22,8 @@ Esta fase cobre:
 
 - [x] introduzir no runtime principal uma fonte estruturada explícita de matching
 - [ ] reduzir o papel central de `MatchingCriteria` legado
-- [ ] ligar a política de senioridade desconhecida ao caminho principal novo
-- [ ] reduzir ainda mais termos legados em `matching_prompt`, `collector` e `scoring`
+- [x] ligar a política de senioridade desconhecida ao caminho principal novo
+- [x] reduzir ainda mais termos legados em `matching_prompt`, `collector` e `scoring`
 - [x] preservar compatibilidade enquanto a transição estiver incompleta
 
 Esta fase não cobre por padrão:
@@ -54,15 +54,15 @@ O resultado é melhor do que antes, mas a fonte estruturada ainda não domina o 
 
 ### P0 — Senioridade como policy do caminho novo
 
-- [ ] mover a política de senioridade desconhecida para o contrato estruturado
-- [ ] fazer prefiltro/scoring respeitarem a mesma policy sem `if` espalhado
-- [ ] revisar integração com `core/seniority.py`
+- [x] mover a política de senioridade desconhecida para o contrato estruturado
+- [x] fazer prefiltro/scoring respeitarem a mesma policy sem `if` espalhado
+- [x] revisar integração com `core/seniority.py`
 
 ### P1 — Coleta, prompt e scoring
 
-- [ ] reduzir dependência do shape legado em `collector.py`
-- [ ] reduzir dependência do shape legado em `matching_prompt.py`
-- [ ] reduzir dependência do shape legado em `scoring.py`
+- [x] reduzir dependência do shape legado em `collector.py`
+- [x] reduzir dependência do shape legado em `matching_prompt.py`
+- [x] reduzir dependência do shape legado em `scoring.py`
 - [ ] revisar rationale e descarte para o caminho principal novo
 
 ### P1 — Compatibilidade e documentação
@@ -75,7 +75,7 @@ O resultado é melhor do que antes, mas a fonte estruturada ainda não domina o 
 
 - [x] adicionar testes do runtime principal usando a fonte estruturada
 - [x] preservar testes de compatibilidade do legado enquanto necessário
-- [ ] adicionar testes da policy de senioridade desconhecida no caminho novo
+- [x] adicionar testes da policy de senioridade desconhecida no caminho novo
 
 ## Definição De Conclusão
 
@@ -83,5 +83,5 @@ Esta fase só fecha quando:
 
 - [ ] o runtime principal depender claramente da fonte estruturada
 - [ ] o legado estiver reduzido a compatibilidade marginal
-- [ ] senioridade desconhecida estiver modelada como policy do caminho novo
+- [x] senioridade desconhecida estiver modelada como policy do caminho novo
 - [ ] documentação e testes refletirem esse novo centro de gravidade

--- a/docs/plans/RUNTIME_STRUCTURED_MATCHING_SOURCE_CHECKLIST.md
+++ b/docs/plans/RUNTIME_STRUCTURED_MATCHING_SOURCE_CHECKLIST.md
@@ -1,0 +1,87 @@
+# Runtime Structured Matching Source
+
+## Papel Deste Documento
+
+- [x] Este arquivo abre a próxima fase estrutural após a redução de hardcodes do legado
+- [x] O objetivo aqui é fazer o runtime principal depender claramente de uma fonte estruturada de matching
+- [x] A branch desta fase foi aberta: `refactor/runtime-structured-matching-source`
+
+## Objetivo Da Fase
+
+Levar o projeto de:
+
+- runtime principal ainda baseado em contrato legado encapsulado
+
+para:
+
+- runtime principal baseado em fonte estruturada, com legado residual apenas como compatibilidade marginal
+
+## Escopo
+
+Esta fase cobre:
+
+- [ ] introduzir no runtime principal uma fonte estruturada explícita de matching
+- [ ] reduzir o papel central de `MatchingCriteria` legado
+- [ ] ligar a política de senioridade desconhecida ao caminho principal novo
+- [ ] reduzir ainda mais termos legados em `matching_prompt`, `collector` e `scoring`
+- [ ] preservar compatibilidade enquanto a transição estiver incompleta
+
+Esta fase não cobre por padrão:
+
+- [ ] remoção imediata de todo fallback legado sem plano de migração
+- [ ] mudança de produto no fluxo principal de coleta/revisão
+- [ ] reescrita ampla do fluxo de candidatura
+
+## Problema Atual
+
+Mesmo após a fase anterior, o runtime ainda opera principalmente com:
+
+- `LegacyMatchingConfig`
+- `MatchingCriteria`
+- `matching_prompt` legado
+- `collector` e `scoring` ainda orientados por contrato antigo
+
+O resultado é melhor do que antes, mas a fonte estruturada ainda não domina o runtime principal.
+
+## Linha De Trabalho Recomendada
+
+### P0 — Fonte estruturada no runtime
+
+- [ ] definir o contrato estruturado mínimo que o runtime principal vai consumir
+- [ ] introduzir loader/bootstrap desse contrato no fluxo atual
+- [ ] fazer a composição depender desse contrato como caminho principal
+- [ ] manter fallback legado explícito e bem delimitado
+
+### P0 — Senioridade como policy do caminho novo
+
+- [ ] mover a política de senioridade desconhecida para o contrato estruturado
+- [ ] fazer prefiltro/scoring respeitarem a mesma policy sem `if` espalhado
+- [ ] revisar integração com `core/seniority.py`
+
+### P1 — Coleta, prompt e scoring
+
+- [ ] reduzir dependência do shape legado em `collector.py`
+- [ ] reduzir dependência do shape legado em `matching_prompt.py`
+- [ ] reduzir dependência do shape legado em `scoring.py`
+- [ ] revisar rationale e descarte para o caminho principal novo
+
+### P1 — Compatibilidade e documentação
+
+- [ ] documentar claramente o caminho principal novo vs fallback legado
+- [ ] revisar `.env.example`, `README.md` e `AGENTS.md`
+- [ ] registrar critérios de desligamento futuro do legado
+
+### P1 — Testes
+
+- [ ] adicionar testes do runtime principal usando a fonte estruturada
+- [ ] preservar testes de compatibilidade do legado enquanto necessário
+- [ ] adicionar testes da policy de senioridade desconhecida no caminho novo
+
+## Definição De Conclusão
+
+Esta fase só fecha quando:
+
+- [ ] o runtime principal depender claramente da fonte estruturada
+- [ ] o legado estiver reduzido a compatibilidade marginal
+- [ ] senioridade desconhecida estiver modelada como policy do caminho novo
+- [ ] documentação e testes refletirem esse novo centro de gravidade

--- a/job_hunter_agent/application/composition.py
+++ b/job_hunter_agent/application/composition.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 from typing import Callable
 
 from job_hunter_agent.application.contracts import ArtifactCapturePort
@@ -12,7 +13,7 @@ from job_hunter_agent.llm.application_priority import OllamaApplicationPriorityA
 from job_hunter_agent.collectors.collector import HybridJobScorer, JobCollectionService
 from job_hunter_agent.core.candidate_profile import load_candidate_profile
 from job_hunter_agent.core.job_identity import PortalAwareJobIdentityStrategy
-from job_hunter_agent.core.matching import build_matching_criteria_from_legacy_config
+from job_hunter_agent.core.matching import build_matching_criteria_from_structured_config
 from job_hunter_agent.llm.job_requirements import OllamaJobRequirementsExtractor
 from job_hunter_agent.collectors.linkedin_application import LinkedInApplicationFlowInspector
 from job_hunter_agent.collectors.linkedin_application_adapters import (
@@ -35,7 +36,11 @@ from job_hunter_agent.infrastructure.repository import JobRepository, SqliteJobR
 from job_hunter_agent.llm.review_rationale import OllamaReviewRationaleFormatter
 from job_hunter_agent.core.runtime import RuntimeGuard
 from job_hunter_agent.core.settings import Settings
+from job_hunter_agent.core.structured_matching_config import resolve_structured_matching_source
 from job_hunter_agent.collectors.linkedin_application_artifacts import create_linkedin_failure_artifact_capture
+
+
+logger = logging.getLogger(__name__)
 
 
 def create_repository(settings: Settings) -> JobRepository:
@@ -155,11 +160,19 @@ def create_linkedin_modal_interpreter(settings: Settings):
 
 def create_collection_service(settings: Settings, repository: JobRepository) -> JobCollectionService:
     known_job_lookup = build_known_job_lookup(repository)
-    legacy_matching = settings.build_legacy_matching_config()
+    resolved_matching = resolve_structured_matching_source(
+        structured_matching_config_path=settings.structured_matching_config_path,
+        legacy_matching=settings.build_legacy_matching_config(),
+        legacy_fallback_enabled=settings.structured_matching_fallback_enabled,
+    )
+    if resolved_matching.used_legacy_fallback:
+        logger.warning(resolved_matching.describe_source())
+    else:
+        logger.info(resolved_matching.describe_source())
     return JobCollectionService(
         settings=settings,
-        matching_criteria=build_matching_criteria_from_legacy_config(
-            legacy_matching=legacy_matching,
+        matching_criteria=build_matching_criteria_from_structured_config(
+            structured_matching=resolved_matching.config,
             relaxed_matching_for_testing=settings.relaxed_matching_for_testing,
             relaxed_testing_profile_hint=settings.relaxed_testing_profile_hint,
             relaxed_testing_remove_exclude_keywords=settings.relaxed_testing_remove_exclude_keywords,

--- a/job_hunter_agent/collectors/collector.py
+++ b/job_hunter_agent/collectors/collector.py
@@ -16,6 +16,8 @@ from job_hunter_agent.core.matching import MatchingCriteria, MatchingPolicy
 from job_hunter_agent.core.matching_reasons import (
     REASON_EXCLUDED_KEYWORDS,
     REASON_SALARY_BELOW_MINIMUM,
+    REASON_SENIORITY_OUTSIDE_TARGET,
+    REASON_UNKNOWN_SENIORITY,
     REASON_WORK_MODE_MISMATCH,
 )
 from job_hunter_agent.core.domain import CollectionReport, JobPosting, RawJob, ScoredJob, SiteConfig
@@ -230,6 +232,10 @@ class JobCollectionService:
         combined_text = f"{raw_job.title} {raw_job.summary} {raw_job.description}".lower()
         if policy.contains_excluded_keywords(combined_text):
             return REASON_EXCLUDED_KEYWORDS
+
+        seniority_reason = policy.evaluate_seniority_reason(combined_text)
+        if seniority_reason is not None:
+            return seniority_reason
 
         if not policy.accepts_work_mode(raw_job.work_mode):
             return REASON_WORK_MODE_MISMATCH

--- a/job_hunter_agent/core/matching.py
+++ b/job_hunter_agent/core/matching.py
@@ -3,6 +3,11 @@ from __future__ import annotations
 from dataclasses import dataclass
 
 from job_hunter_agent.core.legacy_matching_config import LegacyMatchingConfig
+from job_hunter_agent.core.matching_reasons import (
+    REASON_SENIORITY_OUTSIDE_TARGET,
+    REASON_UNKNOWN_SENIORITY,
+)
+from job_hunter_agent.core.seniority import infer_seniority_from_text, normalize_seniority_label
 from job_hunter_agent.core.structured_matching_config import StructuredMatchingSource
 
 
@@ -14,6 +19,8 @@ class MatchingCriteria:
     accepted_work_modes: tuple[str, ...]
     minimum_salary_brl: int
     minimum_relevance: int
+    target_seniorities: tuple[str, ...] = ()
+    allow_unknown_seniority: bool = True
 
 
 @dataclass(frozen=True)
@@ -40,6 +47,15 @@ class MatchingPolicy:
     def accepts_relevance(self, relevance: int) -> bool:
         return relevance >= self.criteria.minimum_relevance
 
+    def evaluate_seniority_reason(self, text: str) -> str | None:
+        if not self.criteria.target_seniorities:
+            return None
+        detected = infer_seniority_from_text(text)
+        if detected == "nao_informada":
+            return None if self.criteria.allow_unknown_seniority else REASON_UNKNOWN_SENIORITY
+        accepted = {normalize_seniority_label(value) for value in self.criteria.target_seniorities}
+        return None if detected in accepted else REASON_SENIORITY_OUTSIDE_TARGET
+
 
 def build_matching_criteria(
     *,
@@ -53,6 +69,8 @@ def build_matching_criteria(
     relaxed_testing_profile_hint: str,
     relaxed_testing_remove_exclude_keywords: tuple[str, ...],
     relaxed_testing_minimum_relevance: int,
+    target_seniorities: tuple[str, ...] = (),
+    allow_unknown_seniority: bool = True,
 ) -> MatchingCriteria:
     resolved_profile_text = profile_text
     resolved_exclude_keywords = exclude_keywords
@@ -73,6 +91,8 @@ def build_matching_criteria(
         accepted_work_modes=accepted_work_modes,
         minimum_salary_brl=minimum_salary_brl,
         minimum_relevance=resolved_minimum_relevance,
+        target_seniorities=target_seniorities,
+        allow_unknown_seniority=allow_unknown_seniority,
     )
 
 
@@ -84,6 +104,8 @@ def build_matching_criteria_from_legacy_config(
     relaxed_testing_remove_exclude_keywords: tuple[str, ...],
     relaxed_testing_minimum_relevance: int,
 ) -> MatchingCriteria:
+    inferred = infer_seniority_from_text(legacy_matching.profile_text)
+    target_seniorities = () if inferred == "nao_informada" else (inferred,)
     return build_matching_criteria(
         profile_text=legacy_matching.profile_text,
         include_keywords=legacy_matching.include_keywords,
@@ -95,6 +117,8 @@ def build_matching_criteria_from_legacy_config(
         relaxed_testing_profile_hint=relaxed_testing_profile_hint,
         relaxed_testing_remove_exclude_keywords=relaxed_testing_remove_exclude_keywords,
         relaxed_testing_minimum_relevance=relaxed_testing_minimum_relevance,
+        target_seniorities=target_seniorities,
+        allow_unknown_seniority=True,
     )
 
 
@@ -117,4 +141,6 @@ def build_matching_criteria_from_structured_config(
         relaxed_testing_profile_hint=relaxed_testing_profile_hint,
         relaxed_testing_remove_exclude_keywords=relaxed_testing_remove_exclude_keywords,
         relaxed_testing_minimum_relevance=relaxed_testing_minimum_relevance,
+        target_seniorities=structured_matching.matching.target_seniorities,
+        allow_unknown_seniority=structured_matching.matching.allow_unknown_seniority,
     )

--- a/job_hunter_agent/core/matching.py
+++ b/job_hunter_agent/core/matching.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 
 from job_hunter_agent.core.legacy_matching_config import LegacyMatchingConfig
+from job_hunter_agent.core.structured_matching_config import StructuredMatchingSource
 
 
 @dataclass(frozen=True)
@@ -90,6 +91,28 @@ def build_matching_criteria_from_legacy_config(
         accepted_work_modes=legacy_matching.accepted_work_modes,
         minimum_salary_brl=legacy_matching.minimum_salary_brl,
         minimum_relevance=legacy_matching.minimum_relevance,
+        relaxed_matching_for_testing=relaxed_matching_for_testing,
+        relaxed_testing_profile_hint=relaxed_testing_profile_hint,
+        relaxed_testing_remove_exclude_keywords=relaxed_testing_remove_exclude_keywords,
+        relaxed_testing_minimum_relevance=relaxed_testing_minimum_relevance,
+    )
+
+
+def build_matching_criteria_from_structured_config(
+    *,
+    structured_matching: StructuredMatchingSource,
+    relaxed_matching_for_testing: bool,
+    relaxed_testing_profile_hint: str,
+    relaxed_testing_remove_exclude_keywords: tuple[str, ...],
+    relaxed_testing_minimum_relevance: int,
+) -> MatchingCriteria:
+    return build_matching_criteria(
+        profile_text=structured_matching.profile.summary,
+        include_keywords=structured_matching.matching.include_keywords,
+        exclude_keywords=structured_matching.matching.exclude_keywords,
+        accepted_work_modes=structured_matching.matching.accepted_work_modes,
+        minimum_salary_brl=structured_matching.matching.minimum_salary_brl,
+        minimum_relevance=structured_matching.matching.minimum_relevance,
         relaxed_matching_for_testing=relaxed_matching_for_testing,
         relaxed_testing_profile_hint=relaxed_testing_profile_hint,
         relaxed_testing_remove_exclude_keywords=relaxed_testing_remove_exclude_keywords,

--- a/job_hunter_agent/core/matching_prompt.py
+++ b/job_hunter_agent/core/matching_prompt.py
@@ -16,6 +16,8 @@ def build_legacy_scoring_prompt(raw_job: RawJob, criteria: MatchingCriteria) -> 
         - Considere palavras positivas: {_format_keywords(criteria.include_keywords)}
         - Considere palavras negativas: {_format_keywords(criteria.exclude_keywords)}
         - Modalidades aceitas: {_format_work_modes(criteria.accepted_work_modes)}
+        - Senioridades alvo: {_format_seniorities(criteria.target_seniorities)}
+        - Aceitar senioridade nao informada: {_format_bool(criteria.allow_unknown_seniority)}
         - Salario minimo em BRL: {criteria.minimum_salary_brl}
         - Seja conservador. So aprove quando a vaga realmente fizer sentido.
         - A rationale deve ser curta e ancorada em sinais objetivos da vaga.
@@ -42,7 +44,8 @@ def build_scoring_rationale_guidance() -> str:
     return (
         "- Prefira tokens curtos e consistentes na rationale, como: "
         "stack_alinhada, stack_parcial, senioridade_compativel, senioridade_duvidosa, "
-        "modalidade_compativel, salario_abaixo, localizacao_duvidosa, sinais_insuficientes."
+        "senioridade_fora_do_alvo, senioridade_nao_informada, modalidade_compativel, "
+        "salario_abaixo, localizacao_duvidosa, sinais_insuficientes."
     )
 
 
@@ -52,3 +55,11 @@ def _format_keywords(values: tuple[str, ...]) -> str:
 
 def _format_work_modes(values: tuple[str, ...]) -> str:
     return ", ".join(values) or "qualquer"
+
+
+def _format_seniorities(values: tuple[str, ...]) -> str:
+    return ", ".join(values) or "qualquer"
+
+
+def _format_bool(value: bool) -> str:
+    return "sim" if value else "nao"

--- a/job_hunter_agent/core/matching_reasons.py
+++ b/job_hunter_agent/core/matching_reasons.py
@@ -1,3 +1,5 @@
 REASON_EXCLUDED_KEYWORDS = "conta com termos excluidos"
 REASON_WORK_MODE_MISMATCH = "modalidade fora do perfil"
 REASON_SALARY_BELOW_MINIMUM = "salario abaixo do minimo"
+REASON_SENIORITY_OUTSIDE_TARGET = "senioridade fora do alvo"
+REASON_UNKNOWN_SENIORITY = "senioridade nao informada"

--- a/job_hunter_agent/core/settings.py
+++ b/job_hunter_agent/core/settings.py
@@ -28,6 +28,8 @@ class Settings(BaseSettings):
     application_phone_country_code: str = ""
     resume_path: Path = Path("./curriculo.pdf")
     candidate_profile_path: Path = Path("./candidate_profile.json")
+    structured_matching_config_path: Path = Path("./job_target.json")
+    structured_matching_fallback_enabled: bool = True
     database_path: Path = Path("./jobs.db")
     browser_use_config_dir: Path = Path("./.browseruse")
     linkedin_persistent_profile_dir: Path = Path("./.browseruse/profiles/linkedin-bootstrap")
@@ -50,8 +52,6 @@ class Settings(BaseSettings):
     ollama_url: str = "http://localhost:11434"
 
     # Matching legado de compatibilidade
-    # Estes campos permanecem ativos apenas enquanto o caminho principal ainda nao estiver
-    # completamente desacoplado do legado.
     profile_text: str = (
         "Engenheiro de Software Senior com experiencia em Java, Kotlin, Spring Boot, "
         "PostgreSQL, Docker e cloud."
@@ -151,7 +151,7 @@ class Settings(BaseSettings):
             )
         return normalized
 
-    @field_validator("resume_path", "linkedin_storage_state_path")
+    @field_validator("resume_path", "linkedin_storage_state_path", "structured_matching_config_path")
     @classmethod
     def validate_runtime_paths(cls, value: Path, info) -> Path:
         path = Path(value)

--- a/job_hunter_agent/core/structured_matching_config.py
+++ b/job_hunter_agent/core/structured_matching_config.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from typing import Any
 
 from job_hunter_agent.core.legacy_matching_config import LegacyMatchingConfig
+from job_hunter_agent.core.seniority import normalize_seniority_label
 
 
 @dataclass(frozen=True)
@@ -20,6 +21,7 @@ class StructuredMatchingConfig:
     accepted_work_modes: tuple[str, ...]
     minimum_salary_brl: int
     minimum_relevance: int
+    target_seniorities: tuple[str, ...] = ()
     allow_unknown_seniority: bool = True
 
 
@@ -83,6 +85,7 @@ def parse_structured_matching_source(payload: dict[str, Any]) -> StructuredMatch
                 minimum=1,
                 maximum=10,
             ),
+            target_seniorities=_optional_seniority_list(matching_payload, "target_seniorities"),
             allow_unknown_seniority=_optional_bool(
                 matching_payload,
                 "allow_unknown_seniority",
@@ -96,6 +99,10 @@ def parse_structured_matching_source(payload: dict[str, Any]) -> StructuredMatch
 def build_structured_matching_source_from_legacy(
     legacy_matching: LegacyMatchingConfig,
 ) -> StructuredMatchingSource:
+    from job_hunter_agent.core.seniority import infer_seniority_from_text
+
+    inferred = infer_seniority_from_text(legacy_matching.profile_text)
+    target_seniorities = () if inferred == "nao_informada" else (inferred,)
     return StructuredMatchingSource(
         profile=StructuredCandidateProfile(summary=legacy_matching.profile_text),
         matching=StructuredMatchingConfig(
@@ -104,6 +111,7 @@ def build_structured_matching_source_from_legacy(
             accepted_work_modes=legacy_matching.accepted_work_modes,
             minimum_salary_brl=legacy_matching.minimum_salary_brl,
             minimum_relevance=legacy_matching.minimum_relevance,
+            target_seniorities=target_seniorities,
             allow_unknown_seniority=True,
         ),
     )
@@ -170,6 +178,20 @@ def _optional_string_list(payload: dict[str, Any], key: str) -> tuple[str, ...]:
             raise ValueError("Arquivo de matching estruturado invalido: listas devem conter apenas strings.")
         token = item.strip().lower()
         if token and token not in normalized:
+            normalized.append(token)
+    return tuple(normalized)
+
+
+def _optional_seniority_list(payload: dict[str, Any], key: str) -> tuple[str, ...]:
+    raw_values = _optional_string_list(payload, key)
+    normalized: list[str] = []
+    for value in raw_values:
+        token = normalize_seniority_label(value)
+        if token == "nao_informada":
+            raise ValueError(
+                f"Arquivo de matching estruturado invalido: campo '{key}' contem senioridade invalida: {value}."
+            )
+        if token not in normalized:
             normalized.append(token)
     return tuple(normalized)
 

--- a/job_hunter_agent/core/structured_matching_config.py
+++ b/job_hunter_agent/core/structured_matching_config.py
@@ -1,0 +1,208 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+import json
+from pathlib import Path
+from typing import Any
+
+from job_hunter_agent.core.legacy_matching_config import LegacyMatchingConfig
+
+
+@dataclass(frozen=True)
+class StructuredCandidateProfile:
+    summary: str
+
+
+@dataclass(frozen=True)
+class StructuredMatchingConfig:
+    include_keywords: tuple[str, ...]
+    exclude_keywords: tuple[str, ...]
+    accepted_work_modes: tuple[str, ...]
+    minimum_salary_brl: int
+    minimum_relevance: int
+    allow_unknown_seniority: bool = True
+
+
+@dataclass(frozen=True)
+class StructuredMatchingSource:
+    profile: StructuredCandidateProfile
+    matching: StructuredMatchingConfig
+
+
+@dataclass(frozen=True)
+class ResolvedStructuredMatchingSource:
+    config: StructuredMatchingSource
+    source: str
+    path: Path | None = None
+
+    @property
+    def used_legacy_fallback(self) -> bool:
+        return self.source == "legacy_fallback"
+
+    def describe_source(self) -> str:
+        if self.source == "structured_file":
+            return f"matching estruturado carregado de arquivo: {self.path}"
+        if self.source == "legacy_fallback":
+            return f"matching estruturado ausente em {self.path}; usando fallback legado"
+        return f"matching estruturado resolvido de fonte desconhecida: {self.source}"
+
+
+def load_structured_matching_source(path: str | Path) -> StructuredMatchingSource:
+    config_path = Path(path)
+    try:
+        payload = json.loads(config_path.read_text(encoding="utf-8"))
+    except FileNotFoundError as exc:
+        raise ValueError(f"Arquivo de matching estruturado nao encontrado: {config_path}") from exc
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"Arquivo de matching estruturado invalido: JSON malformado em {config_path}") from exc
+    if not isinstance(payload, dict):
+        raise ValueError("Arquivo de matching estruturado invalido: raiz deve ser um objeto JSON.")
+    return parse_structured_matching_source(payload)
+
+
+def parse_structured_matching_source(payload: dict[str, Any]) -> StructuredMatchingSource:
+    profile_payload = _require_dict(payload, "profile")
+    matching_payload = _require_dict(payload, "matching")
+    return StructuredMatchingSource(
+        profile=StructuredCandidateProfile(
+            summary=_require_non_empty_string(profile_payload, "summary", section="profile"),
+        ),
+        matching=StructuredMatchingConfig(
+            include_keywords=_require_string_list(matching_payload, "include_keywords", section="matching"),
+            exclude_keywords=_optional_string_list(matching_payload, "exclude_keywords"),
+            accepted_work_modes=_optional_string_list(matching_payload, "accepted_work_modes"),
+            minimum_salary_brl=_require_non_negative_int(
+                matching_payload,
+                "minimum_salary_brl",
+                section="matching",
+            ),
+            minimum_relevance=_require_int_in_range(
+                matching_payload,
+                "minimum_relevance",
+                section="matching",
+                minimum=1,
+                maximum=10,
+            ),
+            allow_unknown_seniority=_optional_bool(
+                matching_payload,
+                "allow_unknown_seniority",
+                default=True,
+                section="matching",
+            ),
+        ),
+    )
+
+
+def build_structured_matching_source_from_legacy(
+    legacy_matching: LegacyMatchingConfig,
+) -> StructuredMatchingSource:
+    return StructuredMatchingSource(
+        profile=StructuredCandidateProfile(summary=legacy_matching.profile_text),
+        matching=StructuredMatchingConfig(
+            include_keywords=legacy_matching.include_keywords,
+            exclude_keywords=legacy_matching.exclude_keywords,
+            accepted_work_modes=legacy_matching.accepted_work_modes,
+            minimum_salary_brl=legacy_matching.minimum_salary_brl,
+            minimum_relevance=legacy_matching.minimum_relevance,
+            allow_unknown_seniority=True,
+        ),
+    )
+
+
+def resolve_structured_matching_source(
+    *,
+    structured_matching_config_path: str | Path,
+    legacy_matching: LegacyMatchingConfig,
+    legacy_fallback_enabled: bool,
+) -> ResolvedStructuredMatchingSource:
+    config_path = Path(structured_matching_config_path)
+    if config_path.exists():
+        return ResolvedStructuredMatchingSource(
+            config=load_structured_matching_source(config_path),
+            source="structured_file",
+            path=config_path,
+        )
+    if not legacy_fallback_enabled:
+        raise ValueError(
+            f"Arquivo de matching estruturado nao encontrado em {config_path} e o fallback legado esta desabilitado."
+        )
+    return ResolvedStructuredMatchingSource(
+        config=build_structured_matching_source_from_legacy(legacy_matching),
+        source="legacy_fallback",
+        path=config_path,
+    )
+
+
+def _require_dict(payload: dict[str, Any], key: str) -> dict[str, Any]:
+    value = payload.get(key)
+    if not isinstance(value, dict):
+        raise ValueError(f"Arquivo de matching estruturado invalido: secao '{key}' ausente ou invalida.")
+    return value
+
+
+def _require_non_empty_string(payload: dict[str, Any], key: str, *, section: str) -> str:
+    value = payload.get(key)
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(
+            f"Arquivo de matching estruturado invalido: campo '{section}.{key}' deve ser texto nao vazio."
+        )
+    return value.strip()
+
+
+def _require_string_list(payload: dict[str, Any], key: str, *, section: str) -> tuple[str, ...]:
+    values = _optional_string_list(payload, key)
+    if not values:
+        raise ValueError(
+            f"Arquivo de matching estruturado invalido: campo '{section}.{key}' deve conter ao menos um item."
+        )
+    return values
+
+
+def _optional_string_list(payload: dict[str, Any], key: str) -> tuple[str, ...]:
+    raw_value = payload.get(key, [])
+    if raw_value is None:
+        return ()
+    if not isinstance(raw_value, list):
+        raise ValueError(f"Arquivo de matching estruturado invalido: campo '{key}' deve ser lista.")
+    normalized: list[str] = []
+    for item in raw_value:
+        if not isinstance(item, str):
+            raise ValueError("Arquivo de matching estruturado invalido: listas devem conter apenas strings.")
+        token = item.strip().lower()
+        if token and token not in normalized:
+            normalized.append(token)
+    return tuple(normalized)
+
+
+def _require_non_negative_int(payload: dict[str, Any], key: str, *, section: str) -> int:
+    value = payload.get(key)
+    if not isinstance(value, int) or value < 0:
+        raise ValueError(
+            f"Arquivo de matching estruturado invalido: campo '{section}.{key}' deve ser inteiro >= 0."
+        )
+    return value
+
+
+def _require_int_in_range(
+    payload: dict[str, Any],
+    key: str,
+    *,
+    section: str,
+    minimum: int,
+    maximum: int,
+) -> int:
+    value = payload.get(key)
+    if not isinstance(value, int) or not (minimum <= value <= maximum):
+        raise ValueError(
+            f"Arquivo de matching estruturado invalido: campo '{section}.{key}' deve estar entre {minimum} e {maximum}."
+        )
+    return value
+
+
+def _optional_bool(payload: dict[str, Any], key: str, *, default: bool, section: str) -> bool:
+    value = payload.get(key, default)
+    if not isinstance(value, bool):
+        raise ValueError(
+            f"Arquivo de matching estruturado invalido: campo '{section}.{key}' deve ser booleano."
+        )
+    return value

--- a/job_hunter_agent/llm/scoring.py
+++ b/job_hunter_agent/llm/scoring.py
@@ -21,6 +21,14 @@ class HybridJobScorer:
         combined_text = f"{raw_job.title} {raw_job.summary} {raw_job.description}".lower()
         if policy.contains_excluded_keywords(combined_text):
             return ScoredJob(relevance=1, rationale="termos_excluidos", accepted=False)
+        seniority_reason = policy.evaluate_seniority_reason(combined_text)
+        if seniority_reason is not None:
+            token = (
+                "senioridade_nao_informada"
+                if "nao informada" in seniority_reason
+                else "senioridade_fora_do_alvo"
+            )
+            return ScoredJob(relevance=1, rationale=token, accepted=False)
 
         prompt = build_legacy_scoring_prompt(raw_job, criteria)
         response = self._llm.invoke(prompt)

--- a/job_target.example.json
+++ b/job_target.example.json
@@ -1,0 +1,30 @@
+{
+  "profile": {
+    "summary": "Engenheiro de software com experiencia em Java, Kotlin, Spring Boot e cloud."
+  },
+  "matching": {
+    "include_keywords": [
+      "java",
+      "kotlin",
+      "spring",
+      "backend",
+      "software engineer"
+    ],
+    "exclude_keywords": [
+      "estagio",
+      "junior",
+      "trainee",
+      ".net",
+      "c#",
+      "php",
+      "ruby"
+    ],
+    "accepted_work_modes": [
+      "remote",
+      "hybrid"
+    ],
+    "minimum_salary_brl": 10000,
+    "minimum_relevance": 6,
+    "allow_unknown_seniority": true
+  }
+}

--- a/job_target.example.json
+++ b/job_target.example.json
@@ -25,6 +25,9 @@
     ],
     "minimum_salary_brl": 10000,
     "minimum_relevance": 6,
+    "target_seniorities": [
+      "senior"
+    ],
     "allow_unknown_seniority": true
   }
 }

--- a/tests/test_composition_structured_matching.py
+++ b/tests/test_composition_structured_matching.py
@@ -1,0 +1,68 @@
+import json
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest import TestCase
+from unittest.mock import Mock, patch
+
+from job_hunter_agent.application.composition import create_collection_service
+from job_hunter_agent.core.domain import SiteConfig
+from job_hunter_agent.core.settings import Settings
+
+
+class CompositionStructuredMatchingTests(TestCase):
+    def test_create_collection_service_prefers_structured_matching_file_when_present(self) -> None:
+        with TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            structured_path = root / "job_target.json"
+            structured_path.write_text(
+                json.dumps(
+                    {
+                        "profile": {"summary": "Structured profile"},
+                        "matching": {
+                            "include_keywords": ["java"],
+                            "exclude_keywords": ["junior"],
+                            "accepted_work_modes": ["remote"],
+                            "minimum_salary_brl": 15000,
+                            "minimum_relevance": 8,
+                            "allow_unknown_seniority": True,
+                        },
+                    }
+                ),
+                encoding="utf-8",
+            )
+            settings = Settings(
+                telegram_token="token",
+                telegram_chat_id="chat",
+                database_path=root / "jobs.db",
+                browser_use_config_dir=root / ".browseruse",
+                linkedin_persistent_profile_dir=root / ".browseruse/profiles/linkedin-bootstrap",
+                linkedin_storage_state_path=root / ".browseruse/linkedin-storage-state.json",
+                candidate_profile_path=root / "candidate_profile.json",
+                structured_matching_config_path=structured_path,
+                sites=(SiteConfig(name="LinkedIn", search_url="https://example.com"),),
+            )
+            repository = Mock()
+            repository.job_url_exists.return_value = False
+            repository.seen_job_url_exists.return_value = False
+
+            with patch(
+                "job_hunter_agent.application.composition.build_matching_criteria_from_structured_config",
+                return_value="criteria",
+            ) as mocked_build_matching, patch(
+                "job_hunter_agent.application.composition.LinkedInDeterministicCollector",
+                return_value="linkedin_collector",
+            ), patch(
+                "job_hunter_agent.application.composition.BrowserUseSiteCollector",
+                return_value="site_collector",
+            ), patch(
+                "job_hunter_agent.application.composition.HybridJobScorer",
+                return_value="scorer",
+            ):
+                service = create_collection_service(settings, repository)
+
+        self.assertIsNotNone(service)
+        mocked_build_matching.assert_called_once()
+        structured_matching = mocked_build_matching.call_args.kwargs["structured_matching"]
+        self.assertEqual(structured_matching.profile.summary, "Structured profile")
+        self.assertEqual(structured_matching.matching.minimum_salary_brl, 15000)
+        self.assertEqual(structured_matching.matching.minimum_relevance, 8)

--- a/tests/test_matching_prompt_structured_seniority.py
+++ b/tests/test_matching_prompt_structured_seniority.py
@@ -1,0 +1,37 @@
+from unittest import TestCase
+
+from job_hunter_agent.core.domain import RawJob
+from job_hunter_agent.core.matching import MatchingCriteria
+from job_hunter_agent.core.matching_prompt import build_legacy_scoring_prompt
+
+
+class MatchingPromptStructuredSeniorityTests(TestCase):
+    def test_prompt_mentions_target_seniorities_and_unknown_seniority_policy(self) -> None:
+        prompt = build_legacy_scoring_prompt(
+            RawJob(
+                title="Senior Backend Engineer",
+                company="Acme",
+                location="Brasil",
+                work_mode="Remote",
+                salary_text="R$ 20.000",
+                url="https://example.com/job",
+                source_site="LinkedIn",
+                summary="Java e Kotlin",
+                description="Atuacao com Spring Boot e AWS.",
+            ),
+            MatchingCriteria(
+                profile_text="Engenheiro backend com foco em Java.",
+                include_keywords=("java", "kotlin"),
+                exclude_keywords=("junior", ".net"),
+                accepted_work_modes=("remote", "hybrid"),
+                minimum_salary_brl=10000,
+                minimum_relevance=6,
+                target_seniorities=("senior", "especialista"),
+                allow_unknown_seniority=False,
+            ),
+        )
+
+        self.assertIn("Senioridades alvo: senior, especialista", prompt)
+        self.assertIn("Aceitar senioridade nao informada: nao", prompt)
+        self.assertIn("senioridade_fora_do_alvo", prompt)
+        self.assertIn("senioridade_nao_informada", prompt)

--- a/tests/test_matching_seniority_policy.py
+++ b/tests/test_matching_seniority_policy.py
@@ -1,0 +1,63 @@
+from unittest import TestCase
+
+from job_hunter_agent.core.matching import MatchingCriteria, MatchingPolicy
+from job_hunter_agent.core.matching_reasons import (
+    REASON_SENIORITY_OUTSIDE_TARGET,
+    REASON_UNKNOWN_SENIORITY,
+)
+
+
+class MatchingSeniorityPolicyTests(TestCase):
+    def test_policy_rejects_job_outside_target_seniority(self) -> None:
+        policy = MatchingPolicy(
+            MatchingCriteria(
+                profile_text="Backend engineer",
+                include_keywords=("java",),
+                exclude_keywords=(),
+                accepted_work_modes=("remote",),
+                minimum_salary_brl=10000,
+                minimum_relevance=6,
+                target_seniorities=("senior",),
+                allow_unknown_seniority=True,
+            )
+        )
+
+        reason = policy.evaluate_seniority_reason("junior backend engineer java kotlin")
+
+        self.assertEqual(reason, REASON_SENIORITY_OUTSIDE_TARGET)
+
+    def test_policy_rejects_unknown_seniority_when_not_allowed(self) -> None:
+        policy = MatchingPolicy(
+            MatchingCriteria(
+                profile_text="Backend engineer",
+                include_keywords=("java",),
+                exclude_keywords=(),
+                accepted_work_modes=("remote",),
+                minimum_salary_brl=10000,
+                minimum_relevance=6,
+                target_seniorities=("senior",),
+                allow_unknown_seniority=False,
+            )
+        )
+
+        reason = policy.evaluate_seniority_reason("backend engineer java kotlin")
+
+        self.assertEqual(reason, REASON_UNKNOWN_SENIORITY)
+
+    def test_policy_accepts_unknown_seniority_when_allowed(self) -> None:
+        policy = MatchingPolicy(
+            MatchingCriteria(
+                profile_text="Backend engineer",
+                include_keywords=("java",),
+                exclude_keywords=(),
+                accepted_work_modes=("remote",),
+                minimum_salary_brl=10000,
+                minimum_relevance=6,
+                target_seniorities=("senior",),
+                allow_unknown_seniority=True,
+            )
+        )
+
+        reason = policy.evaluate_seniority_reason("backend engineer java kotlin")
+
+        self.assertIsNone(reason)

--- a/tests/test_structured_matching_config.py
+++ b/tests/test_structured_matching_config.py
@@ -1,0 +1,81 @@
+import json
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest import TestCase
+
+from job_hunter_agent.core.legacy_matching_config import LegacyMatchingConfig
+from job_hunter_agent.core.structured_matching_config import (
+    StructuredMatchingSource,
+    load_structured_matching_source,
+    resolve_structured_matching_source,
+)
+
+
+class StructuredMatchingConfigTests(TestCase):
+    def test_load_structured_matching_source_reads_valid_file(self) -> None:
+        with TemporaryDirectory() as temp_dir:
+            config_path = Path(temp_dir) / "job_target.json"
+            config_path.write_text(
+                json.dumps(
+                    {
+                        "profile": {"summary": "Backend engineer com foco em Java."},
+                        "matching": {
+                            "include_keywords": ["java", "kotlin"],
+                            "exclude_keywords": ["junior"],
+                            "accepted_work_modes": ["remote"],
+                            "minimum_salary_brl": 10000,
+                            "minimum_relevance": 6,
+                            "allow_unknown_seniority": False,
+                        },
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            config = load_structured_matching_source(config_path)
+
+        self.assertIsInstance(config, StructuredMatchingSource)
+        self.assertEqual(config.profile.summary, "Backend engineer com foco em Java.")
+        self.assertEqual(config.matching.include_keywords, ("java", "kotlin"))
+        self.assertEqual(config.matching.exclude_keywords, ("junior",))
+        self.assertEqual(config.matching.accepted_work_modes, ("remote",))
+        self.assertEqual(config.matching.minimum_salary_brl, 10000)
+        self.assertEqual(config.matching.minimum_relevance, 6)
+        self.assertFalse(config.matching.allow_unknown_seniority)
+
+    def test_resolve_structured_matching_source_falls_back_to_legacy_when_file_is_missing(self) -> None:
+        legacy = LegacyMatchingConfig(
+            profile_text="Legacy profile",
+            include_keywords=("java",),
+            exclude_keywords=("junior",),
+            accepted_work_modes=("remote",),
+            minimum_salary_brl=9000,
+            minimum_relevance=5,
+        )
+
+        resolved = resolve_structured_matching_source(
+            structured_matching_config_path="./missing-job-target.json",
+            legacy_matching=legacy,
+            legacy_fallback_enabled=True,
+        )
+
+        self.assertTrue(resolved.used_legacy_fallback)
+        self.assertEqual(resolved.config.profile.summary, "Legacy profile")
+        self.assertEqual(resolved.config.matching.include_keywords, ("java",))
+
+    def test_resolve_structured_matching_source_fails_fast_when_fallback_is_disabled(self) -> None:
+        legacy = LegacyMatchingConfig(
+            profile_text="Legacy profile",
+            include_keywords=("java",),
+            exclude_keywords=("junior",),
+            accepted_work_modes=("remote",),
+            minimum_salary_brl=9000,
+            minimum_relevance=5,
+        )
+
+        with self.assertRaises(ValueError):
+            resolve_structured_matching_source(
+                structured_matching_config_path="./missing-job-target.json",
+                legacy_matching=legacy,
+                legacy_fallback_enabled=False,
+            )

--- a/tests/test_structured_matching_seniority.py
+++ b/tests/test_structured_matching_seniority.py
@@ -1,0 +1,53 @@
+import json
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest import TestCase
+
+from job_hunter_agent.core.legacy_matching_config import LegacyMatchingConfig
+from job_hunter_agent.core.structured_matching_config import (
+    load_structured_matching_source,
+    resolve_structured_matching_source,
+)
+
+
+class StructuredMatchingSeniorityTests(TestCase):
+    def test_load_structured_matching_source_reads_target_seniorities(self) -> None:
+        with TemporaryDirectory() as temp_dir:
+            config_path = Path(temp_dir) / "job_target.json"
+            config_path.write_text(
+                json.dumps(
+                    {
+                        "profile": {"summary": "Backend engineer com foco em Java."},
+                        "matching": {
+                            "include_keywords": ["java"],
+                            "minimum_salary_brl": 10000,
+                            "minimum_relevance": 6,
+                            "target_seniorities": ["senior", "principal"],
+                            "allow_unknown_seniority": False,
+                        },
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            config = load_structured_matching_source(config_path)
+
+        self.assertEqual(config.matching.target_seniorities, ("senior", "especialista"))
+        self.assertFalse(config.matching.allow_unknown_seniority)
+
+    def test_resolve_structured_matching_source_infers_target_seniority_from_legacy_profile(self) -> None:
+        resolved = resolve_structured_matching_source(
+            structured_matching_config_path="./missing-job-target.json",
+            legacy_matching=LegacyMatchingConfig(
+                profile_text="Engenheiro de Software Senior com foco em Java.",
+                include_keywords=("java",),
+                exclude_keywords=("junior",),
+                accepted_work_modes=("remote",),
+                minimum_salary_brl=10000,
+                minimum_relevance=6,
+            ),
+            legacy_fallback_enabled=True,
+        )
+
+        self.assertEqual(resolved.config.matching.target_seniorities, ("senior",))
+        self.assertTrue(resolved.config.matching.allow_unknown_seniority)


### PR DESCRIPTION
## Resumo

Esta PR inicia a transição do runtime principal para uma fonte estruturada de matching.

Nesta etapa entram:

- contrato estruturado mínimo de matching
- loader/validação de arquivo estruturado
- fallback legado explícito e controlável
- composição preferindo o caminho estruturado quando o arquivo existir
- política de senioridade desconhecida ligada ao caminho principal novo
- prefiltro e scorer respeitando a mesma policy
- exemplo versionado e testes focados no runtime estruturado

## Principais mudanças

### Fonte estruturada

- adiciona `job_hunter_agent/core/structured_matching_config.py`
- adiciona `StructuredMatchingSource` e bootstrap com fallback legado
- adiciona `job_target.example.json`

### Runtime principal

- `Settings` passa a conhecer:
  - `structured_matching_config_path`
  - `structured_matching_fallback_enabled`
- `create_collection_service(...)` passa a preferir a fonte estruturada

### Senioridade no caminho novo

- `MatchingCriteria` ganha:
  - `target_seniorities`
  - `allow_unknown_seniority`
- `MatchingPolicy` passa a avaliar senioridade fora do alvo e senioridade não informada
- `collector.py` aplica essa policy no prefiltro
- `matching_prompt.py` e `scoring.py` refletem a policy no caminho assistivo

### Testes

- loader e fallback da fonte estruturada
- composição preferindo arquivo estruturado
- leitura de `target_seniorities`
- policy de senioridade desconhecida no caminho novo
- prompt refletindo senioridades alvo e policy

## Observações

- esta PR não conclui a remoção do legado
- ela muda o centro de gravidade do runtime para preferir a fonte estruturada
- o legado continua como fallback explícito enquanto a transição estiver incompleta
