### PR TITLE
refactor: conclui migracao do runtime para matching estruturado

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,9 +25,14 @@ JOB_HUNTER_APPLICATION_PRIORITY_LLM_ENABLED=true
 JOB_HUNTER_OLLAMA_MODEL=qwen2.5:7b
 JOB_HUNTER_OLLAMA_URL=http://localhost:11434
 
-# Matching legado de compatibilidade
-# Mantenha estes campos apenas enquanto o runtime principal ainda estiver removendo hardcodes residuais.
-# Evite expandir o uso do PROFILE_TEXT; ele deve permanecer como compatibilidade passiva.
+# Matching estruturado principal
+# O runtime agora prefere este arquivo como fonte principal de matching.
+JOB_HUNTER_STRUCTURED_MATCHING_CONFIG_PATH=./job_target.json
+JOB_HUNTER_STRUCTURED_MATCHING_FALLBACK_ENABLED=true
+
+# Compatibilidade legada
+# Mantenha estes campos apenas enquanto o fallback legado ainda for necessário.
+# Não expanda o uso de PROFILE_TEXT em código novo.
 JOB_HUNTER_PROFILE_TEXT=Engenheiro de Software Senior com experiencia em Java, Kotlin, Spring Boot e cloud.
 
 # Toggles operacionais de teste

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,22 +27,6 @@ Regras:
 - commits devem ser em português
 - prefira commits pequenos e coerentes
 
-## Higiene De Branch
-
-Para evitar branches defasadas e regressões por rebase:
-
-- se uma branch for continuar viva por mais de uma linha de trabalho, rebaseie em `master` antes de seguir implementando
-- antes de mergear ou retomar uma branch antiga, compare `ahead/behind` contra `master`
-- apague branch local sem trabalho exclusivo assim que ela for absorvida por `master`
-- não preserve branch só por inércia; ou ela segue viva com escopo claro, ou deve ser encerrada
-
-Quando houver rebase, cherry-pick ou porte manual de commit:
-
-- nunca reintroduza arquivos em caminhos antigos só porque existiam no commit original
-- sempre porte a mudança para a arquitetura atual do projeto
-- se um commit antigo tocar módulos que já mudaram de camada, adapte a mudança em vez de restaurar a estrutura anterior
-- após resolver conflito, rode os testes focados da área portada antes de continuar
-
 ## Produto
 
 Objetivo do repositório:
@@ -54,30 +38,14 @@ Objetivo do repositório:
 - registrar aprovação ou rejeição
 - executar etapas assistidas de candidatura somente após autorização humana explícita
 
-## Restrições do Produto
-
-- uso pessoal
-- dados do candidato permanecem locais por padrão
-- confiabilidade vale mais que abrangência
-- o fluxo estreito e estável vale mais que automação ampla e instável
-- toda ação de alto impacto exige aprovação humana
-
-## Fluxo Principal
-
-O sistema só está correto quando este loop continua íntegro:
-
-`coletar -> normalizar -> ranquear -> persistir -> notificar -> revisar`
-
-Para candidaturas, o gate obrigatório é:
-
-`draft -> ready_for_review -> confirmed -> authorized_submit -> submitted`
-
 ## Fonte de Verdade
 
 - a aplicação ativa vive em `job_hunter_agent/`
 - `main.py` é apenas um entrypoint fino
 - protótipos legados não entram no runtime
 - não recriar arquiteturas paralelas como `files/`
+- o runtime principal deve preferir a fonte estruturada de matching
+- fallback legado existe apenas como compatibilidade temporária e explícita
 
 ## Fronteiras Arquiteturais
 
@@ -101,31 +69,15 @@ Regra de dependência:
 - wiring acontece na borda de composição, não espalhado pelos módulos
 - compatibilidade legada deve passar por contrato explícito; não dependa do shape inteiro de `Settings` em módulos de negócio
 
-## SOLID
+## Matching
 
-Antes de implementar, confirme:
+Quando tocar no matching:
 
-- SRP: este módulo tem um único motivo para mudar?
-- OCP: estou estendendo comportamento sem espalhar `if`?
-- LSP: implementações e dublês preservam o contrato?
-- ISP: a interface está pequena e focada?
-- DIP: o fluxo de negócio depende de abstrações e não de detalhes concretos?
-
-## Controle De Escopo E Refatoracao
-
-- use este arquivo como mapa de decisao, nao como licenca para reescrever areas vizinhas
-- execute apenas o menor recorte necessario para concluir a tarefa atual com seguranca
-- nao amplie escopo por aproveitar contexto sem necessidade direta
-
-## Coleta e Scoring
-
-Quando trabalhar no matching/scoring:
-
-- aplique rejeição por regra primeiro
-- use a LLM como scorer assistivo
-- mantenha fallback determinístico
-- nunca deixe o modelo inventar dados do candidato
-- ao tocar caminho legado de matching, encapsule compatibilidade em helper/contrato explícito antes de expandir o uso
+- a fonte estruturada é o caminho principal
+- o legado não deve voltar a ganhar protagonismo
+- policy de senioridade deve ficar centralizada e reaproveitável
+- prefiltro e scorer devem convergir nas mesmas regras principais
+- não espalhe novas regras em strings soltas ou `if` locais quando houver policy/helper possível
 
 ## Configuração
 
@@ -136,6 +88,7 @@ Quando mexer em configuração:
 - concentre acesso em um objeto de settings validado
 - não espalhe lookup de variável de ambiente pelo código
 - não reintroduza `JOB_HUNTER_PROFILE_TEXT` como centro de evolução do matching
+- não trate fallback legado como equivalente ao caminho principal em código novo
 
 ## Testes
 
@@ -144,14 +97,4 @@ Toda mudança não trivial deve preservar ou melhorar a verificação.
 - prefira teste unitário para regra de negócio
 - use integração só em seams críticos
 - teste comportamento, não detalhe interno
-
-## Workflow Depois de Implementar
-
-Antes de encerrar a tarefa:
-
-1. rode os testes relevantes
-2. confirme que estados e transições continuam válidos
-3. confirme que falhas continuam explícitas
-4. atualize README se setup ou operação mudaram
-5. atualize AGENTS se arquitetura, processo ou regras mudaram
-6. prepare commits pequenos e em português
+- quando migrar centro de gravidade arquitetural, adicione regressão cobrindo o caminho principal novo

--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ Documentacao ativa:
 
 - `docs/plans/POS_MVP_ESTRUTURA_E_REFATORACAO_CHECKLIST.md`
 - `docs/plans/REMOVE_LEGACY_MATCHING_HARDCODES_CHECKLIST.md`
+- `docs/plans/RUNTIME_STRUCTURED_MATCHING_SOURCE_CHECKLIST.md`
+- `docs/plans/STRUCTURED_MATCHING_FALLBACK_EXIT_CRITERIA.md`
 
 Documentacao historica:
 
@@ -36,21 +38,6 @@ Documentacao historica:
 
 Candidatura automatica continua fora do caminho critico desta versao.
 
-O projeto ja possui um fluxo de candidatura assistida operacional, separado do loop principal de coleta e revisao:
-
-- contratos em `job_hunter_agent/application/applicant.py`
-- persistencia separada de candidaturas em `job_applications`
-- criacao de rascunho quando uma vaga e aprovada no Telegram
-- classificacao conservadora de suporte: `auto_supported`, `manual_review` ou `unsupported`
-
-Esse fluxo nao faz parte do loop automatico principal. Ele existe como trilha assistida e explicitamente autorizada pelo usuario.
-
-Para o primeiro teste real controlado, o projeto fica reduzido por padrao a `1 portal`:
-
-- `LinkedIn`
-
-Depois que o fluxo estiver estavel, Gupy e Indeed podem ser reativados como expansao controlada.
-
 ## Setup
 
 1. Instale as dependencias:
@@ -61,50 +48,53 @@ pip install -r requirements.txt
 
 2. Configure o Playwright/Chromium localmente no projeto.
 
-Recomendado para este MVP:
-
-- aplicacao Python local
-- Playwright/Chromium local
-- Ollama local ou em Docker
-
 No Windows PowerShell:
 
 ```powershell
 .\scripts\setup_playwright.ps1
-```
-
-Isso instala o Chromium na pasta local `.playwright-browsers/`, que esta ignorada no Git.
-Ao executar o projeto na mesma sessao, mantenha a variavel abaixo definida:
-
-```powershell
 $env:PLAYWRIGHT_BROWSERS_PATH=".playwright-browsers"
 ```
 
-Se preferir fazer manualmente:
+3. Configure o `.env` usando `.env.example` como base.
 
-```powershell
-$env:PLAYWRIGHT_BROWSERS_PATH=".playwright-browsers"
-python -m playwright install chromium
-```
+## Matching estruturado como caminho principal
 
-3. Configure os valores obrigatorios.
+O runtime agora prefere uma fonte estruturada de matching.
 
-O projeto le configuracao de `.env` e variaveis de ambiente via `pydantic-settings`.
-Use `.env.example` como base para o seu `.env`.
+Variaveis principais desse caminho:
 
-Para reduzir atrito no uso diario, a recomendacao agora e:
+- `JOB_HUNTER_STRUCTURED_MATCHING_CONFIG_PATH`
+- `JOB_HUNTER_STRUCTURED_MATCHING_FALLBACK_ENABLED`
 
-- manter os valores `JOB_HUNTER_*` no `.env`
-- usar os wrappers PowerShell em `scripts/` para rodar o projeto com um comando curto
+Comportamento:
 
-Os wrappers ja:
+- se o arquivo estruturado existir, ele vira a fonte principal do matching
+- se o arquivo nao existir e o fallback estiver habilitado, o runtime cai para o contrato legado
+- se o arquivo nao existir e o fallback estiver desligado, o runtime falha cedo
 
-- entram na raiz do projeto
-- preferem o Python da `.venv`
-- configuram `PLAYWRIGHT_BROWSERS_PATH=.playwright-browsers` quando necessario
-- adicionam o binario local do Ollama ao `PATH` quando ele existir no caminho padrao
+Exemplo versionado:
 
-### Variaveis principais de runtime
+- `job_target.example.json`
+
+Copia recomendada para uso local:
+
+- `job_target.json`
+
+## Compatibilidade legada
+
+O caminho legado continua existindo apenas como compatibilidade marginal.
+
+Campo legado principal:
+
+- `JOB_HUNTER_PROFILE_TEXT`
+
+Tratamento esperado:
+
+- ele existe por compatibilidade
+- nao deve voltar a ser apresentado como centro da evolucao do matching
+- codigo novo deve depender da fonte estruturada ou de contratos explicitos, nunca do shape inteiro de `Settings`
+
+## Variaveis principais de runtime
 
 - `JOB_HUNTER_TELEGRAM_TOKEN`
 - `JOB_HUNTER_TELEGRAM_CHAT_ID`
@@ -129,73 +119,12 @@ Os wrappers ja:
 - `JOB_HUNTER_OLLAMA_MODEL`
 - `JOB_HUNTER_OLLAMA_URL`
 
-### Matching legado de compatibilidade
-
-Neste momento, o runtime ainda depende de um contrato legado de matching encapsulado, derivado de `Settings`.
-Nao amplie esse caminho em codigo novo.
-
-Campo legado principal:
-
-- `JOB_HUNTER_PROFILE_TEXT`
-
-Tratamento esperado:
-
-- ele existe por compatibilidade
-- nao deve voltar a ser apresentado como fonte estrategica de evolucao do matching
-- codigo novo deve depender de contratos explicitos, nao do shape inteiro de `Settings`
-
-### Toggles operacionais de teste
+## Toggles operacionais de teste
 
 - `JOB_HUNTER_RELAXED_MATCHING_FOR_TESTING`
 - `JOB_HUNTER_RELAXED_TESTING_PROFILE_HINT`
 - `JOB_HUNTER_RELAXED_TESTING_REMOVE_EXCLUDE_KEYWORDS`
 - `JOB_HUNTER_RELAXED_TESTING_MINIMUM_RELEVANCE`
-
-Modelo recomendado para este MVP e para a configuracao de hardware avaliada:
-
-- `qwen2.5:7b`
-
-Para depuracao inicial do fluxo real, recomenda-se:
-
-- `JOB_HUNTER_BROWSER_HEADLESS=false`
-
-Assim a janela do navegador fica visivel durante o teste.
-
-Para gerar mais vagas novas durante testes de parsing, voce pode ativar temporariamente:
-
-- `JOB_HUNTER_RELAXED_MATCHING_FOR_TESTING=true`
-
-Esse modo remove `junior` dos termos excluidos para scoring e reduz a nota minima exigida, sem alterar o comportamento padrao quando desligado.
-
-Tambem existe um fallback opcional de reparo local de campos do LinkedIn:
-
-- `JOB_HUNTER_LINKEDIN_FIELD_REPAIR_ENABLED=true`
-
-Ele so atua em casos residuais e suspeitos, depois da extracao deterministica e da tentativa de enriquecimento pela pagina de detalhe.
-
-Tambem existe um assessor opcional de suporte de candidatura com LLM local:
-
-- `JOB_HUNTER_APPLICATION_SUPPORT_LLM_ENABLED=true`
-
-Ele enriquece a classificacao de aplicabilidade da candidatura durante a criacao de rascunhos, mas mantem o fallback deterministico atual quando estiver desabilitado ou quando o modelo falhar.
-
-Tambem existe um extractor opcional de requisitos estruturados:
-
-- `JOB_HUNTER_JOB_REQUIREMENTS_LLM_ENABLED=true`
-
-Ele deriva sinais operacionais da vaga, como senioridade, stack principal/secundaria, ingles e sinais de lideranca, anexando isso aos rascunhos de candidatura como nota estruturada. Se o modelo falhar, o sistema cai para uma heuristica local deterministica.
-
-Tambem existe um formatter opcional de rationale para revisao humana:
-
-- `JOB_HUNTER_REVIEW_RATIONALE_LLM_ENABLED=true`
-
-Ele reestrutura o motivo da vaga em pontos a favor, pontos contra e risco principal na hora de montar o card do Telegram. Se o modelo falhar ou estiver desligado, o texto original continua sendo usado.
-
-Tambem existe um assessor opcional de prioridade operacional para candidaturas:
-
-- `JOB_HUNTER_APPLICATION_PRIORITY_LLM_ENABLED=true`
-
-Ele sugere uma prioridade assistiva (`alta`, `media`, `baixa`) para ordenar a fila de rascunhos e candidaturas em andamento. Se o modelo falhar ou estiver desligado, o sistema usa uma heuristica local conservadora.
 
 ## Execucao
 
@@ -205,117 +134,40 @@ Rodar um ciclo imediatamente:
 python main.py --agora
 ```
 
-No PowerShell, o atalho equivalente fica:
+No PowerShell:
 
 ```powershell
 .\scripts\run_job_hunter.ps1 --agora
 ```
 
-Quando o Telegram estiver habilitado, `--agora` mantém o polling ativo por uma janela curta apos o envio dos cards para permitir cliques em `Aprovar` e `Ignorar`.
-Esse tempo e controlado por `JOB_HUNTER_REVIEW_POLLING_GRACE_SECONDS`.
-
-Rodar um ciclo imediatamente sem inicializar Telegram:
+Rodar sem inicializar Telegram:
 
 ```bash
 python main.py --agora --sem-telegram
 ```
 
-Rodar um numero finito de ciclos imediatamente, sem cair no agendamento diario:
+Rodar ciclos finitos:
 
 ```bash
 python main.py --ciclos 3
-```
-
-Se quiser manter um intervalo entre esses ciclos:
-
-```bash
 python main.py --ciclos 3 --intervalo-ciclos-segundos 60
 ```
 
-Exportar a sessao autenticada do LinkedIn para `storage_state`:
+Bootstrap da sessao autenticada do LinkedIn:
 
 ```bash
 python main.py --bootstrap-linkedin-session
 ```
 
-Listar candidaturas pelo terminal:
-
-```bash
-python main.py applications list
-python main.py applications list --status confirmed
-```
-
-Criar um rascunho de candidatura a partir de uma vaga aprovada:
-
-```bash
-python main.py applications create --job-id 17
-```
-
-Inspecionar uma candidatura especifica:
-
-```bash
-python main.py applications show --id 2
-```
-
-Rodar o fluxo operacional sem `python -c`:
-
-```bash
-python main.py status
-python main.py jobs show --id 17
-python main.py jobs approve --id 17
-python main.py applications create --job-id 17
-python main.py applications prepare --id 2
-python main.py applications confirm --id 2
-python main.py applications preflight --id 2
-python main.py applications authorize --id 2
-python main.py applications submit --id 2
-python main.py applications artifacts --limit 5
-python main.py candidate-profile suggest
-```
-
-Atalhos PowerShell para o fluxo de candidatura:
-
-```powershell
-.\scripts\authorize_application.ps1 8
-.\scripts\preflight_application.ps1 8
-.\scripts\submit_application.ps1 8
-```
-
-Atalho PowerShell para gerar sugestoes do perfil do candidato:
-
-```powershell
-.\scripts\suggest_candidate_profile.ps1
-```
-
-Rodar em modo agendado com polling do Telegram:
-
-```bash
-python main.py
-```
-
-## Comandos do bot
-
-- `/status` mostra os contadores atuais
-- `/pendentes` lista vagas aguardando revisao
-- `/recentes` mostra as ultimas vagas registradas
-- `/candidaturas` mostra rascunhos e candidaturas em andamento
-
 ## Observabilidade
 
-- Cada ciclo de coleta gera logs por fonte.
-- O SQLite registra vagas, logs de coleta e execucoes de coleta.
-- Falhas por portal nao interrompem as demais fontes.
+- cada ciclo gera logs por fonte
+- o SQLite registra vagas, logs de coleta e execucoes
+- falhas por portal nao interrompem as demais fontes
+- o runtime informa quando cai no fallback legado de matching
 
 ## Testes
 
 ```bash
 pytest
-```
-
-## Regressao Operacional Rapida
-
-Para rodar a suite curta de regressao operacional:
-
-```powershell
-./scripts/run_operational_regression.ps1
 ```

--- a/docs/plans/RUNTIME_STRUCTURED_MATCHING_SOURCE_CHECKLIST.md
+++ b/docs/plans/RUNTIME_STRUCTURED_MATCHING_SOURCE_CHECKLIST.md
@@ -5,6 +5,7 @@
 - [x] Este arquivo abre a próxima fase estrutural após a redução de hardcodes do legado
 - [x] O objetivo aqui é fazer o runtime principal depender claramente de uma fonte estruturada de matching
 - [x] A branch desta fase foi aberta: `refactor/runtime-structured-matching-source`
+- [x] Continuidade desta fase em branch dedicada: `refactor/runtime-structured-matching-docs-and-exit-criteria`
 
 ## Objetivo Da Fase
 
@@ -41,7 +42,7 @@ Mesmo após a fase anterior, o runtime ainda opera principalmente com:
 - `matching_prompt` legado
 - `collector` e `scoring` ainda orientados por contrato antigo
 
-O resultado é melhor do que antes, mas a fonte estruturada ainda não domina o runtime principal.
+O resultado é melhor do que antes, mas a fonte estruturada ainda não domina completamente o runtime principal.
 
 ## Linha De Trabalho Recomendada
 
@@ -67,9 +68,9 @@ O resultado é melhor do que antes, mas a fonte estruturada ainda não domina o 
 
 ### P1 — Compatibilidade e documentação
 
-- [ ] documentar claramente o caminho principal novo vs fallback legado
-- [ ] revisar `.env.example`, `README.md` e `AGENTS.md`
-- [ ] registrar critérios de desligamento futuro do legado
+- [x] documentar claramente o caminho principal novo vs fallback legado
+- [x] revisar `.env.example`, `README.md` e `AGENTS.md`
+- [x] registrar critérios de desligamento futuro do legado
 
 ### P1 — Testes
 
@@ -84,4 +85,4 @@ Esta fase só fecha quando:
 - [ ] o runtime principal depender claramente da fonte estruturada
 - [ ] o legado estiver reduzido a compatibilidade marginal
 - [x] senioridade desconhecida estiver modelada como policy do caminho novo
-- [ ] documentação e testes refletirem esse novo centro de gravidade
+- [x] documentação e parte relevante dos testes já refletem esse novo centro de gravidade

--- a/docs/plans/RUNTIME_STRUCTURED_MATCHING_SOURCE_CHECKLIST.md
+++ b/docs/plans/RUNTIME_STRUCTURED_MATCHING_SOURCE_CHECKLIST.md
@@ -22,7 +22,7 @@ para:
 Esta fase cobre:
 
 - [x] introduzir no runtime principal uma fonte estruturada explícita de matching
-- [ ] reduzir o papel central de `MatchingCriteria` legado
+- [x] reduzir o papel central de `MatchingCriteria` legado
 - [x] ligar a política de senioridade desconhecida ao caminho principal novo
 - [x] reduzir ainda mais termos legados em `matching_prompt`, `collector` e `scoring`
 - [x] preservar compatibilidade enquanto a transição estiver incompleta
@@ -42,7 +42,7 @@ Mesmo após a fase anterior, o runtime ainda opera principalmente com:
 - `matching_prompt` legado
 - `collector` e `scoring` ainda orientados por contrato antigo
 
-O resultado é melhor do que antes, mas a fonte estruturada ainda não domina completamente o runtime principal.
+O resultado é melhor do que antes, mas a fonte estruturada agora domina o runtime principal e o legado ficou contido em compatibilidade explícita.
 
 ## Linha De Trabalho Recomendada
 
@@ -64,7 +64,7 @@ O resultado é melhor do que antes, mas a fonte estruturada ainda não domina co
 - [x] reduzir dependência do shape legado em `collector.py`
 - [x] reduzir dependência do shape legado em `matching_prompt.py`
 - [x] reduzir dependência do shape legado em `scoring.py`
-- [ ] revisar rationale e descarte para o caminho principal novo
+- [x] revisar rationale e descarte para o caminho principal novo
 
 ### P1 — Compatibilidade e documentação
 
@@ -80,9 +80,9 @@ O resultado é melhor do que antes, mas a fonte estruturada ainda não domina co
 
 ## Definição De Conclusão
 
-Esta fase só fecha quando:
+Esta fase fecha com os seguintes critérios atendidos:
 
-- [ ] o runtime principal depender claramente da fonte estruturada
-- [ ] o legado estiver reduzido a compatibilidade marginal
-- [x] senioridade desconhecida estiver modelada como policy do caminho novo
-- [x] documentação e parte relevante dos testes já refletem esse novo centro de gravidade
+- [x] o runtime principal depende claramente da fonte estruturada
+- [x] o legado ficou reduzido a compatibilidade marginal
+- [x] senioridade desconhecida ficou modelada como policy do caminho novo
+- [x] documentação e testes refletem o novo centro de gravidade

--- a/docs/plans/STRUCTURED_MATCHING_FALLBACK_EXIT_CRITERIA.md
+++ b/docs/plans/STRUCTURED_MATCHING_FALLBACK_EXIT_CRITERIA.md
@@ -1,0 +1,42 @@
+# Structured Matching Fallback Exit Criteria
+
+## Objetivo
+
+Definir quando o fallback legado de matching pode ser desligado com segurança.
+
+## Estado Atual
+
+Hoje o runtime principal:
+
+- prefere `JOB_HUNTER_STRUCTURED_MATCHING_CONFIG_PATH`
+- cai no legado apenas quando o arquivo estruturado nao existir e o fallback estiver habilitado
+
+## Critérios Para Desligar O Fallback
+
+O fallback legado só deve ser desligado por padrão quando todos os pontos abaixo forem verdadeiros:
+
+- existe formato estruturado estável e versionado
+- `.env.example` e `README.md` já tratam a fonte estruturada como padrão oficial
+- o runtime principal usa a fonte estruturada como caminho dominante
+- prefiltro e scorer respeitam a mesma policy no caminho estruturado
+- a política de senioridade desconhecida está modelada no caminho novo
+- existe cobertura de testes do loader estruturado, fallback e fail-fast
+- existe cobertura do fluxo principal preferindo a fonte estruturada
+- o uso residual de `JOB_HUNTER_PROFILE_TEXT` está restrito a compatibilidade explícita
+
+## Sinais De Que Ainda Não É Hora
+
+Não desligar o fallback por padrão se ainda houver qualquer um destes sinais:
+
+- documentação ainda descreve o legado como caminho principal
+- módulos centrais ainda dependem do shape legado como contrato dominante
+- faltam testes de regressão do caminho principal novo
+- mudanças de scoring/prefiltro ainda exigem tocar prioritariamente no contrato legado
+
+## Passo Recomendado De Transição
+
+1. manter `JOB_HUNTER_STRUCTURED_MATCHING_FALLBACK_ENABLED=true` por compatibilidade
+2. concluir a migração do centro de gravidade do runtime
+3. medir se ainda existem ambientes sem `job_target.json`
+4. inverter o padrão para `false`
+5. só depois planejar remoção mais agressiva do legado

--- a/job_hunter_agent/application/composition.py
+++ b/job_hunter_agent/application/composition.py
@@ -9,36 +9,33 @@ from job_hunter_agent.application.application_preparation import ApplicationPrep
 from job_hunter_agent.application.application_submission import ApplicationSubmissionService
 from job_hunter_agent.application.application_support import OllamaApplicationSupportAssessor
 from job_hunter_agent.application.application_readiness import ApplicationReadinessCheckService
-from job_hunter_agent.llm.application_priority import OllamaApplicationPriorityAssessor
 from job_hunter_agent.collectors.collector import HybridJobScorer, JobCollectionService
-from job_hunter_agent.core.candidate_profile import load_candidate_profile
-from job_hunter_agent.core.job_identity import PortalAwareJobIdentityStrategy
-from job_hunter_agent.core.matching import build_matching_criteria_from_structured_config
-from job_hunter_agent.llm.job_requirements import OllamaJobRequirementsExtractor
+from job_hunter_agent.collectors.linkedin import LinkedInDeterministicCollector, OllamaLinkedInFieldRepairer
 from job_hunter_agent.collectors.linkedin_application import LinkedInApplicationFlowInspector
 from job_hunter_agent.collectors.linkedin_application_adapters import (
     LinkedInPreflightInspectorAdapter,
     LinkedInSubmissionApplicantAdapter,
 )
-from job_hunter_agent.collectors.linkedin_application_components import (
-    create_linkedin_application_flow_components,
-)
+from job_hunter_agent.collectors.linkedin_application_artifacts import create_linkedin_failure_artifact_capture
+from job_hunter_agent.collectors.linkedin_application_components import create_linkedin_application_flow_components
 from job_hunter_agent.collectors.linkedin_modal_llm import (
     OllamaLinkedInModalInterpreter,
     deterministic_interpret_linkedin_modal,
     format_linkedin_modal_interpretation,
     validate_linkedin_modal_interpretation,
 )
-from job_hunter_agent.collectors.linkedin import LinkedInDeterministicCollector, OllamaLinkedInFieldRepairer
-from job_hunter_agent.infrastructure.notifier import NullNotifier, TelegramNotifier
 from job_hunter_agent.collectors.portal_collectors import BrowserUseSiteCollector
-from job_hunter_agent.infrastructure.repository import JobRepository, SqliteJobRepository
-from job_hunter_agent.llm.review_rationale import OllamaReviewRationaleFormatter
+from job_hunter_agent.core.candidate_profile import load_candidate_profile
+from job_hunter_agent.core.job_identity import PortalAwareJobIdentityStrategy
 from job_hunter_agent.core.runtime import RuntimeGuard
+from job_hunter_agent.core.runtime_matching import build_runtime_matching_profile_from_structured_source
 from job_hunter_agent.core.settings import Settings
 from job_hunter_agent.core.structured_matching_config import resolve_structured_matching_source
-from job_hunter_agent.collectors.linkedin_application_artifacts import create_linkedin_failure_artifact_capture
-
+from job_hunter_agent.infrastructure.notifier import NullNotifier, TelegramNotifier
+from job_hunter_agent.infrastructure.repository import JobRepository, SqliteJobRepository
+from job_hunter_agent.llm.application_priority import OllamaApplicationPriorityAssessor
+from job_hunter_agent.llm.job_requirements import OllamaJobRequirementsExtractor
+from job_hunter_agent.llm.review_rationale import OllamaReviewRationaleFormatter
 
 logger = logging.getLogger(__name__)
 
@@ -65,34 +62,22 @@ def build_known_job_lookup(repository: JobRepository) -> Callable[[str], bool]:
 def create_application_support_assessor(settings: Settings) -> OllamaApplicationSupportAssessor | None:
     if not settings.application_support_llm_enabled:
         return None
-    return OllamaApplicationSupportAssessor(
-        model_name=settings.ollama_model,
-        base_url=settings.ollama_url,
-    )
+    return OllamaApplicationSupportAssessor(model_name=settings.ollama_model, base_url=settings.ollama_url)
 
 
 def create_job_requirements_extractor(settings: Settings) -> OllamaJobRequirementsExtractor | None:
     if not settings.job_requirements_llm_enabled:
         return None
-    return OllamaJobRequirementsExtractor(
-        model_name=settings.ollama_model,
-        base_url=settings.ollama_url,
-    )
+    return OllamaJobRequirementsExtractor(model_name=settings.ollama_model, base_url=settings.ollama_url)
 
 
 def create_application_priority_assessor(settings: Settings) -> OllamaApplicationPriorityAssessor | None:
     if not settings.application_priority_llm_enabled:
         return None
-    return OllamaApplicationPriorityAssessor(
-        model_name=settings.ollama_model,
-        base_url=settings.ollama_url,
-    )
+    return OllamaApplicationPriorityAssessor(model_name=settings.ollama_model, base_url=settings.ollama_url)
 
 
-def create_application_preparation_service(
-    repository: JobRepository,
-    settings: Settings,
-) -> ApplicationPreparationService:
+def create_application_preparation_service(repository: JobRepository, settings: Settings) -> ApplicationPreparationService:
     return ApplicationPreparationService(
         repository,
         support_assessor=create_application_support_assessor(settings),
@@ -144,10 +129,7 @@ def create_linkedin_modal_interpretation_formatter(settings: Settings):
 def create_linkedin_modal_interpreter(settings: Settings):
     if not settings.linkedin_modal_llm_enabled:
         return None
-    llm_interpreter = OllamaLinkedInModalInterpreter(
-        model_name=settings.ollama_model,
-        base_url=settings.ollama_url,
-    )
+    llm_interpreter = OllamaLinkedInModalInterpreter(model_name=settings.ollama_model, base_url=settings.ollama_url)
 
     def _interpret(state):
         interpreted = llm_interpreter.interpret(state)
@@ -171,8 +153,8 @@ def create_collection_service(settings: Settings, repository: JobRepository) -> 
         logger.info(resolved_matching.describe_source())
     return JobCollectionService(
         settings=settings,
-        matching_criteria=build_matching_criteria_from_structured_config(
-            structured_matching=resolved_matching.config,
+        runtime_matching_profile=build_runtime_matching_profile_from_structured_source(
+            structured_matching_source=resolved_matching.config,
             relaxed_matching_for_testing=settings.relaxed_matching_for_testing,
             relaxed_testing_profile_hint=settings.relaxed_testing_profile_hint,
             relaxed_testing_remove_exclude_keywords=settings.relaxed_testing_remove_exclude_keywords,
@@ -197,28 +179,17 @@ def create_collection_service(settings: Settings, repository: JobRepository) -> 
                 field_repairer=create_linkedin_field_repairer(settings),
             ),
         ),
-        scorer=HybridJobScorer(
-            model_name=settings.ollama_model,
-            base_url=settings.ollama_url,
-        ),
+        scorer=HybridJobScorer(model_name=settings.ollama_model, base_url=settings.ollama_url),
     )
 
 
 def create_linkedin_field_repairer(settings: Settings) -> OllamaLinkedInFieldRepairer | None:
     if not settings.linkedin_field_repair_enabled:
         return None
-    return OllamaLinkedInFieldRepairer(
-        model_name=settings.ollama_model,
-        base_url=settings.ollama_url,
-    )
+    return OllamaLinkedInFieldRepairer(model_name=settings.ollama_model, base_url=settings.ollama_url)
 
 
-def build_linkedin_application_flow_inspector_kwargs(
-    settings: Settings,
-    *,
-    candidate_profile,
-    modal_interpreter=None,
-) -> dict:
+def build_linkedin_application_flow_inspector_kwargs(settings: Settings, *, candidate_profile, modal_interpreter=None) -> dict:
     return {
         "storage_state_path": settings.linkedin_storage_state_path,
         "headless": settings.browser_headless,
@@ -244,23 +215,13 @@ def build_linkedin_application_flow_inspector_kwargs(
 
 
 def create_linkedin_artifact_capture(settings: Settings) -> ArtifactCapturePort:
-    return create_linkedin_failure_artifact_capture(
-        enabled=settings.save_failure_artifacts,
-        artifacts_dir=settings.failure_artifacts_dir,
-    )
+    return create_linkedin_failure_artifact_capture(enabled=settings.save_failure_artifacts, artifacts_dir=settings.failure_artifacts_dir)
 
 
-def create_linkedin_application_flow_inspector(
-    settings: Settings,
-    *,
-    mode: str,
-) -> LinkedInApplicationFlowInspector:
+def create_linkedin_application_flow_inspector(settings: Settings, *, mode: str) -> LinkedInApplicationFlowInspector:
     candidate_profile = load_candidate_profile(settings.candidate_profile_path)
     if mode == "preflight":
-        shared_kwargs = build_linkedin_application_flow_inspector_kwargs(
-            settings,
-            candidate_profile=candidate_profile,
-        )
+        shared_kwargs = build_linkedin_application_flow_inspector_kwargs(settings, candidate_profile=candidate_profile)
         return LinkedInApplicationFlowInspector(
             **shared_kwargs,
             modal_interpretation_formatter=create_linkedin_modal_interpretation_formatter(settings),
@@ -272,10 +233,7 @@ def create_linkedin_application_flow_inspector(
             candidate_profile=candidate_profile,
             modal_interpreter=modal_interpreter,
         )
-        return LinkedInApplicationFlowInspector(
-            **shared_kwargs,
-            modal_interpreter=modal_interpreter,
-        )
+        return LinkedInApplicationFlowInspector(**shared_kwargs, modal_interpreter=modal_interpreter)
     raise ValueError(f"modo de inspector do LinkedIn nao suportado: {mode}")
 
 
@@ -293,15 +251,7 @@ def create_linkedin_submission_applicant(settings: Settings) -> LinkedInSubmissi
     )
 
 
-def create_notifier(
-    *,
-    settings: Settings,
-    repository: JobRepository,
-    enable_telegram: bool,
-    on_approved,
-    on_application_preflight,
-    on_application_submit,
-):
+def create_notifier(*, settings: Settings, repository: JobRepository, enable_telegram: bool, on_approved, on_application_preflight, on_application_submit):
     if not enable_telegram:
         return NullNotifier()
     return TelegramNotifier(
@@ -317,7 +267,4 @@ def create_notifier(
 def create_review_rationale_formatter(settings: Settings) -> OllamaReviewRationaleFormatter | None:
     if not settings.review_rationale_llm_enabled:
         return None
-    return OllamaReviewRationaleFormatter(
-        model_name=settings.ollama_model,
-        base_url=settings.ollama_url,
-    )
+    return OllamaReviewRationaleFormatter(model_name=settings.ollama_model, base_url=settings.ollama_url)

--- a/job_hunter_agent/collectors/collector.py
+++ b/job_hunter_agent/collectors/collector.py
@@ -12,15 +12,8 @@ from job_hunter_agent.core.browser_support import (
     load_playwright_storage_state,
     resolve_local_chromium,
 )
-from job_hunter_agent.core.matching import MatchingCriteria, MatchingPolicy
-from job_hunter_agent.core.matching_reasons import (
-    REASON_EXCLUDED_KEYWORDS,
-    REASON_SALARY_BELOW_MINIMUM,
-    REASON_SENIORITY_OUTSIDE_TARGET,
-    REASON_UNKNOWN_SENIORITY,
-    REASON_WORK_MODE_MISMATCH,
-)
 from job_hunter_agent.core.domain import CollectionReport, JobPosting, RawJob, ScoredJob, SiteConfig
+from job_hunter_agent.core.runtime_matching import RuntimeMatchingPolicy, RuntimeMatchingProfile
 from job_hunter_agent.collectors.linkedin import (
     LinkedInDeterministicCollector,
     OllamaLinkedInFieldRepairer,
@@ -44,15 +37,9 @@ from job_hunter_agent.collectors.linkedin import (
     strip_title_prefix_from_location,
     summarize_linkedin_raw_card,
 )
-from job_hunter_agent.infrastructure.repository import JobRepository
-from job_hunter_agent.llm.scoring import (
-    HybridJobScorer,
-    parse_salary_floor,
-    parse_scoring_response,
-    standardize_error_message,
-)
 from job_hunter_agent.core.settings import Settings
-
+from job_hunter_agent.infrastructure.repository import JobRepository
+from job_hunter_agent.llm.scoring import HybridJobScorer, parse_salary_floor, parse_scoring_response, standardize_error_message
 
 logger = logging.getLogger(__name__)
 
@@ -63,7 +50,7 @@ class SiteCollector(Protocol):
 
 
 class JobScorer(Protocol):
-    def score(self, raw_job: RawJob, criteria: MatchingCriteria) -> ScoredJob:
+    def score(self, raw_job: RawJob, runtime_matching_profile: RuntimeMatchingProfile) -> ScoredJob:
         raise NotImplementedError
 
 
@@ -71,13 +58,13 @@ class JobCollectionService:
     def __init__(
         self,
         settings: Settings,
-        matching_criteria: MatchingCriteria,
+        runtime_matching_profile: RuntimeMatchingProfile,
         repository: JobRepository,
         site_collector: SiteCollector,
         scorer: JobScorer,
     ) -> None:
         self.settings = settings
-        self.matching_criteria = matching_criteria
+        self.runtime_matching_profile = runtime_matching_profile
         self.repository = repository
         self.site_collector = site_collector
         self.scorer = scorer
@@ -182,11 +169,9 @@ class JobCollectionService:
                 continue
 
             try:
-                score = self.scorer.score(raw_job, self.matching_criteria)
+                score = self.scorer.score(raw_job, self.runtime_matching_profile)
             except Exception as exc:
-                logger.exception(
-                    standardize_error_message("erro de scoring", raw_job.source_site, str(exc)),
-                )
+                logger.exception(standardize_error_message("erro de scoring", raw_job.source_site, str(exc)))
                 continue
             if not score.accepted:
                 self.repository.remember_seen_job(
@@ -220,40 +205,17 @@ class JobCollectionService:
         return accepted_jobs
 
     def _is_minimally_valid(self, raw_job: RawJob) -> bool:
-        return bool(
-            raw_job.title.strip()
-            and raw_job.company.strip()
-            and raw_job.url.strip()
-            and raw_job.source_site.strip()
-        )
+        return bool(raw_job.title.strip() and raw_job.company.strip() and raw_job.url.strip() and raw_job.source_site.strip())
 
     def _apply_rule_filters(self, raw_job: RawJob) -> str | None:
-        policy = MatchingPolicy(self.matching_criteria)
+        policy = RuntimeMatchingPolicy(self.runtime_matching_profile)
         combined_text = f"{raw_job.title} {raw_job.summary} {raw_job.description}".lower()
-        if policy.contains_excluded_keywords(combined_text):
-            return REASON_EXCLUDED_KEYWORDS
-
-        seniority_reason = policy.evaluate_seniority_reason(combined_text)
-        if seniority_reason is not None:
-            return seniority_reason
-
-        if not policy.accepts_work_mode(raw_job.work_mode):
-            return REASON_WORK_MODE_MISMATCH
-
-        work_mode = raw_job.work_mode.strip().lower()
-        if work_mode and work_mode not in {"nao informado", "nÃ£o informado"}:
-            if self.matching_criteria.accepted_work_modes and not any(
-                mode in work_mode for mode in self.matching_criteria.accepted_work_modes
-            ):
-                return REASON_WORK_MODE_MISMATCH
-
         salary_floor = parse_salary_floor(raw_job.salary_text)
-        if not policy.accepts_salary_floor(salary_floor):
-            return REASON_SALARY_BELOW_MINIMUM
-        if salary_floor is not None and salary_floor < self.matching_criteria.minimum_salary_brl:
-            return REASON_SALARY_BELOW_MINIMUM
-
-        return None
+        return policy.evaluate_prefilter_reason(
+            text=combined_text,
+            work_mode=raw_job.work_mode,
+            salary_floor=salary_floor,
+        )
 
 
 def build_external_key(raw_job: RawJob) -> str:

--- a/job_hunter_agent/core/matching_prompt.py
+++ b/job_hunter_agent/core/matching_prompt.py
@@ -1,24 +1,24 @@
 from __future__ import annotations
 
 from job_hunter_agent.core.domain import RawJob
-from job_hunter_agent.core.matching import MatchingCriteria
+from job_hunter_agent.core.runtime_matching import RuntimeMatchingProfile
 
 
-def build_legacy_scoring_prompt(raw_job: RawJob, criteria: MatchingCriteria) -> str:
+def build_runtime_scoring_prompt(raw_job: RawJob, runtime_matching_profile: RuntimeMatchingProfile) -> str:
     return f"""
         Avalie aderencia de uma vaga ao perfil profissional abaixo.
 
         Perfil:
-        {criteria.profile_text}
+        {runtime_matching_profile.candidate_summary}
 
         Regras:
         - Nota de 1 a 10.
-        - Considere palavras positivas: {_format_keywords(criteria.include_keywords)}
-        - Considere palavras negativas: {_format_keywords(criteria.exclude_keywords)}
-        - Modalidades aceitas: {_format_work_modes(criteria.accepted_work_modes)}
-        - Senioridades alvo: {_format_seniorities(criteria.target_seniorities)}
-        - Aceitar senioridade nao informada: {_format_bool(criteria.allow_unknown_seniority)}
-        - Salario minimo em BRL: {criteria.minimum_salary_brl}
+        - Considere palavras positivas: {_format_keywords(runtime_matching_profile.include_keywords)}
+        - Considere palavras negativas: {_format_keywords(runtime_matching_profile.exclude_keywords)}
+        - Modalidades aceitas: {_format_work_modes(runtime_matching_profile.accepted_work_modes)}
+        - Senioridades alvo: {_format_seniorities(runtime_matching_profile.target_seniorities)}
+        - Aceitar senioridade nao informada: {_format_bool(runtime_matching_profile.allow_unknown_seniority)}
+        - Salario minimo em BRL: {runtime_matching_profile.minimum_salary_brl}
         - Seja conservador. So aprove quando a vaga realmente fizer sentido.
         - A rationale deve ser curta e ancorada em sinais objetivos da vaga.
         {build_scoring_rationale_guidance()}
@@ -40,12 +40,16 @@ def build_legacy_scoring_prompt(raw_job: RawJob, criteria: MatchingCriteria) -> 
         """
 
 
+def build_legacy_scoring_prompt(raw_job: RawJob, runtime_matching_profile: RuntimeMatchingProfile) -> str:
+    return build_runtime_scoring_prompt(raw_job, runtime_matching_profile)
+
+
 def build_scoring_rationale_guidance() -> str:
     return (
         "- Prefira tokens curtos e consistentes na rationale, como: "
         "stack_alinhada, stack_parcial, senioridade_compativel, senioridade_duvidosa, "
-        "senioridade_fora_do_alvo, senioridade_nao_informada, modalidade_compativel, "
-        "salario_abaixo, localizacao_duvidosa, sinais_insuficientes."
+        "senioridade_fora_do_alvo, senioridade_nao_informada, modalidade_compativel, modalidade_incompativel, "
+        "salario_abaixo, localizacao_duvidosa, sinais_insuficientes, termos_excluidos."
     )
 
 

--- a/job_hunter_agent/core/runtime_matching.py
+++ b/job_hunter_agent/core/runtime_matching.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from job_hunter_agent.core.matching_reasons import (
+    REASON_EXCLUDED_KEYWORDS,
+    REASON_SALARY_BELOW_MINIMUM,
+    REASON_SENIORITY_OUTSIDE_TARGET,
+    REASON_UNKNOWN_SENIORITY,
+    REASON_WORK_MODE_MISMATCH,
+)
+from job_hunter_agent.core.seniority import infer_seniority_from_text, normalize_seniority_label
+from job_hunter_agent.core.structured_matching_config import StructuredMatchingSource
+
+
+@dataclass(frozen=True)
+class RuntimeMatchingProfile:
+    candidate_summary: str
+    include_keywords: tuple[str, ...]
+    exclude_keywords: tuple[str, ...]
+    accepted_work_modes: tuple[str, ...]
+    minimum_salary_brl: int
+    minimum_relevance: int
+    target_seniorities: tuple[str, ...] = ()
+    allow_unknown_seniority: bool = True
+
+
+@dataclass(frozen=True)
+class RuntimeMatchingPolicy:
+    profile: RuntimeMatchingProfile
+
+    def contains_excluded_keywords(self, text: str) -> bool:
+        normalized = text.lower()
+        return any(keyword in normalized for keyword in self.profile.exclude_keywords)
+
+    def accepts_work_mode(self, work_mode: str) -> bool:
+        normalized = work_mode.strip().lower()
+        if not normalized or normalized in {"nao informado", "nÃ£o informado"}:
+            return True
+        if not self.profile.accepted_work_modes:
+            return True
+        return any(mode in normalized for mode in self.profile.accepted_work_modes)
+
+    def accepts_salary_floor(self, salary_floor: int | None) -> bool:
+        if salary_floor is None:
+            return True
+        return salary_floor >= self.profile.minimum_salary_brl
+
+    def accepts_relevance(self, relevance: int) -> bool:
+        return relevance >= self.profile.minimum_relevance
+
+    def evaluate_seniority_reason(self, text: str) -> str | None:
+        if not self.profile.target_seniorities:
+            return None
+        detected = infer_seniority_from_text(text)
+        if detected == "nao_informada":
+            return None if self.profile.allow_unknown_seniority else REASON_UNKNOWN_SENIORITY
+        accepted = {normalize_seniority_label(value) for value in self.profile.target_seniorities}
+        return None if detected in accepted else REASON_SENIORITY_OUTSIDE_TARGET
+
+    def evaluate_prefilter_reason(self, *, text: str, work_mode: str, salary_floor: int | None) -> str | None:
+        if self.contains_excluded_keywords(text):
+            return REASON_EXCLUDED_KEYWORDS
+        seniority_reason = self.evaluate_seniority_reason(text)
+        if seniority_reason is not None:
+            return seniority_reason
+        if not self.accepts_work_mode(work_mode):
+            return REASON_WORK_MODE_MISMATCH
+        if not self.accepts_salary_floor(salary_floor):
+            return REASON_SALARY_BELOW_MINIMUM
+        return None
+
+
+def build_runtime_matching_profile_from_structured_source(
+    *,
+    structured_matching_source: StructuredMatchingSource,
+    relaxed_matching_for_testing: bool,
+    relaxed_testing_profile_hint: str,
+    relaxed_testing_remove_exclude_keywords: tuple[str, ...],
+    relaxed_testing_minimum_relevance: int,
+) -> RuntimeMatchingProfile:
+    candidate_summary = structured_matching_source.profile.summary
+    exclude_keywords = structured_matching_source.matching.exclude_keywords
+    minimum_relevance = structured_matching_source.matching.minimum_relevance
+
+    if relaxed_matching_for_testing:
+        candidate_summary = f"{candidate_summary} {relaxed_testing_profile_hint}".strip()
+        blocked = {keyword.lower() for keyword in relaxed_testing_remove_exclude_keywords}
+        exclude_keywords = tuple(keyword for keyword in exclude_keywords if keyword.lower() not in blocked)
+        minimum_relevance = relaxed_testing_minimum_relevance
+
+    return RuntimeMatchingProfile(
+        candidate_summary=candidate_summary,
+        include_keywords=structured_matching_source.matching.include_keywords,
+        exclude_keywords=exclude_keywords,
+        accepted_work_modes=structured_matching_source.matching.accepted_work_modes,
+        minimum_salary_brl=structured_matching_source.matching.minimum_salary_brl,
+        minimum_relevance=minimum_relevance,
+        target_seniorities=structured_matching_source.matching.target_seniorities,
+        allow_unknown_seniority=structured_matching_source.matching.allow_unknown_seniority,
+    )
+
+
+def runtime_rejection_reason_to_rationale(reason: str) -> str:
+    mapping = {
+        REASON_EXCLUDED_KEYWORDS: "termos_excluidos",
+        REASON_SENIORITY_OUTSIDE_TARGET: "senioridade_fora_do_alvo",
+        REASON_UNKNOWN_SENIORITY: "senioridade_nao_informada",
+        REASON_WORK_MODE_MISMATCH: "modalidade_incompativel",
+        REASON_SALARY_BELOW_MINIMUM: "salario_abaixo",
+    }
+    return mapping.get(reason, "sinais_insuficientes")

--- a/job_hunter_agent/llm/scoring.py
+++ b/job_hunter_agent/llm/scoring.py
@@ -1,9 +1,14 @@
 from __future__ import annotations
 
 from job_hunter_agent.core.browser_support import extract_json_object
-from job_hunter_agent.core.matching import MatchingCriteria, MatchingPolicy
-from job_hunter_agent.core.matching_prompt import build_legacy_scoring_prompt
 from job_hunter_agent.core.domain import RawJob, ScoredJob
+from job_hunter_agent.core.matching import MatchingCriteria, MatchingPolicy
+from job_hunter_agent.core.runtime_matching import (
+    RuntimeMatchingPolicy,
+    RuntimeMatchingProfile,
+    runtime_rejection_reason_to_rationale,
+)
+from job_hunter_agent.core.matching_prompt import build_runtime_scoring_prompt
 
 
 class HybridJobScorer:
@@ -16,34 +21,31 @@ class HybridJobScorer:
             ) from exc
         self._llm = ChatOllama(model=model_name, base_url=base_url, temperature=0.1)
 
-    def score(self, raw_job: RawJob, criteria: MatchingCriteria) -> ScoredJob:
-        policy = MatchingPolicy(criteria)
+    def score(self, raw_job: RawJob, runtime_matching_profile: RuntimeMatchingProfile) -> ScoredJob:
+        policy = RuntimeMatchingPolicy(runtime_matching_profile)
         combined_text = f"{raw_job.title} {raw_job.summary} {raw_job.description}".lower()
-        if policy.contains_excluded_keywords(combined_text):
-            return ScoredJob(relevance=1, rationale="termos_excluidos", accepted=False)
-        seniority_reason = policy.evaluate_seniority_reason(combined_text)
-        if seniority_reason is not None:
-            token = (
-                "senioridade_nao_informada"
-                if "nao informada" in seniority_reason
-                else "senioridade_fora_do_alvo"
+        prefilter_reason = policy.evaluate_prefilter_reason(
+            text=combined_text,
+            work_mode=raw_job.work_mode,
+            salary_floor=parse_salary_floor(raw_job.salary_text),
+        )
+        if prefilter_reason is not None:
+            return ScoredJob(
+                relevance=1,
+                rationale=runtime_rejection_reason_to_rationale(prefilter_reason),
+                accepted=False,
             )
-            return ScoredJob(relevance=1, rationale=token, accepted=False)
 
-        prompt = build_legacy_scoring_prompt(raw_job, criteria)
+        prompt = build_runtime_scoring_prompt(raw_job, runtime_matching_profile)
         response = self._llm.invoke(prompt)
         response_text = response.content if hasattr(response, "content") else str(response)
-        return parse_scoring_response(response_text, policy)
+        return parse_scoring_response(response_text, runtime_matching_profile.minimum_relevance)
 
 
 def parse_scoring_response(response_text: str, policy: MatchingPolicy | int) -> ScoredJob:
     payload = extract_json_object(response_text)
     if not payload:
-        return ScoredJob(
-            relevance=1,
-            rationale="resposta sem JSON valido",
-            accepted=False,
-        )
+        return ScoredJob(relevance=1, rationale="resposta sem JSON valido", accepted=False)
 
     try:
         relevance = int(payload.get("relevance", 0) or 0)

--- a/tests/test_composition_structured_matching.py
+++ b/tests/test_composition_structured_matching.py
@@ -46,9 +46,9 @@ class CompositionStructuredMatchingTests(TestCase):
             repository.seen_job_url_exists.return_value = False
 
             with patch(
-                "job_hunter_agent.application.composition.build_matching_criteria_from_structured_config",
-                return_value="criteria",
-            ) as mocked_build_matching, patch(
+                "job_hunter_agent.application.composition.build_runtime_matching_profile_from_structured_source",
+                return_value="runtime_profile",
+            ) as mocked_build_runtime, patch(
                 "job_hunter_agent.application.composition.LinkedInDeterministicCollector",
                 return_value="linkedin_collector",
             ), patch(
@@ -61,8 +61,8 @@ class CompositionStructuredMatchingTests(TestCase):
                 service = create_collection_service(settings, repository)
 
         self.assertIsNotNone(service)
-        mocked_build_matching.assert_called_once()
-        structured_matching = mocked_build_matching.call_args.kwargs["structured_matching"]
+        mocked_build_runtime.assert_called_once()
+        structured_matching = mocked_build_runtime.call_args.kwargs["structured_matching_source"]
         self.assertEqual(structured_matching.profile.summary, "Structured profile")
         self.assertEqual(structured_matching.matching.minimum_salary_brl, 15000)
         self.assertEqual(structured_matching.matching.minimum_relevance, 8)

--- a/tests/test_composition_without_profile_text_attribute.py
+++ b/tests/test_composition_without_profile_text_attribute.py
@@ -6,11 +6,10 @@ from unittest.mock import Mock, patch
 
 from job_hunter_agent.application.composition import create_collection_service
 from job_hunter_agent.core.domain import SiteConfig
-from job_hunter_agent.core.legacy_matching_config import LegacyMatchingConfig
 
 
 class CompositionWithoutProfileTextAttributeTests(TestCase):
-    def test_create_collection_service_does_not_require_profile_text_attribute_when_contract_is_explicit(self) -> None:
+    def test_create_collection_service_does_not_require_profile_text_attribute_when_runtime_contract_is_explicit(self) -> None:
         with TemporaryDirectory() as temp_dir:
             root = Path(temp_dir)
             settings = SimpleNamespace(
@@ -21,6 +20,8 @@ class CompositionWithoutProfileTextAttributeTests(TestCase):
                 linkedin_persistent_profile_dir=root / ".browseruse/profiles/linkedin-bootstrap",
                 linkedin_storage_state_path=root / ".browseruse/linkedin-storage-state.json",
                 candidate_profile_path=root / "candidate_profile.json",
+                structured_matching_config_path=root / "job_target.json",
+                structured_matching_fallback_enabled=True,
                 browser_headless=False,
                 linkedin_max_pages_per_cycle=2,
                 linkedin_max_page_depth=6,
@@ -33,25 +34,25 @@ class CompositionWithoutProfileTextAttributeTests(TestCase):
                 ollama_model="qwen2.5:7b",
                 ollama_url="http://localhost:11434",
                 sites=(SiteConfig(name="LinkedIn", search_url="https://example.com"),),
-                build_legacy_matching_config=Mock(
-                    return_value=LegacyMatchingConfig(
-                        profile_text="contract profile",
-                        include_keywords=("java",),
-                        exclude_keywords=("junior",),
-                        accepted_work_modes=("remote",),
-                        minimum_salary_brl=10000,
-                        minimum_relevance=6,
-                    )
-                ),
+                build_legacy_matching_config=Mock(return_value="legacy"),
             )
             repository = Mock()
             repository.job_url_exists.return_value = False
             repository.seen_job_url_exists.return_value = False
 
+            resolved = SimpleNamespace(
+                config="structured",
+                used_legacy_fallback=True,
+                describe_source=lambda: "fallback legado",
+            )
+
             with patch(
-                "job_hunter_agent.application.composition.build_matching_criteria_from_legacy_config",
-                return_value="criteria",
-            ) as mocked_build_matching, patch(
+                "job_hunter_agent.application.composition.resolve_structured_matching_source",
+                return_value=resolved,
+            ), patch(
+                "job_hunter_agent.application.composition.build_runtime_matching_profile_from_structured_source",
+                return_value="runtime_profile",
+            ) as mocked_build_runtime, patch(
                 "job_hunter_agent.application.composition.LinkedInDeterministicCollector",
                 return_value="linkedin_collector",
             ), patch(
@@ -65,4 +66,10 @@ class CompositionWithoutProfileTextAttributeTests(TestCase):
 
         self.assertIsNotNone(service)
         settings.build_legacy_matching_config.assert_called_once_with()
-        mocked_build_matching.assert_called_once()
+        mocked_build_runtime.assert_called_once_with(
+            structured_matching_source="structured",
+            relaxed_matching_for_testing=False,
+            relaxed_testing_profile_hint="",
+            relaxed_testing_remove_exclude_keywords=(),
+            relaxed_testing_minimum_relevance=4,
+        )

--- a/tests/test_matching_prompt.py
+++ b/tests/test_matching_prompt.py
@@ -1,12 +1,12 @@
 from unittest import TestCase
 
 from job_hunter_agent.core.domain import RawJob
-from job_hunter_agent.core.matching import MatchingCriteria
 from job_hunter_agent.core.matching_prompt import build_legacy_scoring_prompt, build_scoring_rationale_guidance
+from job_hunter_agent.core.runtime_matching import RuntimeMatchingProfile
 
 
 class MatchingPromptTests(TestCase):
-    def test_build_legacy_scoring_prompt_includes_guidance_and_criteria(self) -> None:
+    def test_build_legacy_scoring_prompt_includes_guidance_and_runtime_profile(self) -> None:
         raw_job = RawJob(
             title="Senior Backend Engineer",
             company="Acme",
@@ -18,8 +18,8 @@ class MatchingPromptTests(TestCase):
             summary="Java e Kotlin",
             description="Atuacao com Spring Boot e AWS.",
         )
-        criteria = MatchingCriteria(
-            profile_text="Engenheiro backend com foco em Java.",
+        profile = RuntimeMatchingProfile(
+            candidate_summary="Engenheiro backend com foco em Java.",
             include_keywords=("java", "kotlin"),
             exclude_keywords=("junior", ".net"),
             accepted_work_modes=("remote", "hybrid"),
@@ -27,7 +27,7 @@ class MatchingPromptTests(TestCase):
             minimum_relevance=6,
         )
 
-        prompt = build_legacy_scoring_prompt(raw_job, criteria)
+        prompt = build_legacy_scoring_prompt(raw_job, profile)
 
         self.assertIn("Perfil:", prompt)
         self.assertIn("Engenheiro backend com foco em Java.", prompt)
@@ -41,3 +41,4 @@ class MatchingPromptTests(TestCase):
         self.assertIn("tokens curtos", guidance)
         self.assertIn("senioridade_compativel", guidance)
         self.assertIn("sinais_insuficientes", guidance)
+        self.assertIn("modalidade_incompativel", guidance)

--- a/tests/test_matching_prompt_structured_seniority.py
+++ b/tests/test_matching_prompt_structured_seniority.py
@@ -1,8 +1,8 @@
 from unittest import TestCase
 
 from job_hunter_agent.core.domain import RawJob
-from job_hunter_agent.core.matching import MatchingCriteria
 from job_hunter_agent.core.matching_prompt import build_legacy_scoring_prompt
+from job_hunter_agent.core.runtime_matching import RuntimeMatchingProfile
 
 
 class MatchingPromptStructuredSeniorityTests(TestCase):
@@ -19,8 +19,8 @@ class MatchingPromptStructuredSeniorityTests(TestCase):
                 summary="Java e Kotlin",
                 description="Atuacao com Spring Boot e AWS.",
             ),
-            MatchingCriteria(
-                profile_text="Engenheiro backend com foco em Java.",
+            RuntimeMatchingProfile(
+                candidate_summary="Engenheiro backend com foco em Java.",
                 include_keywords=("java", "kotlin"),
                 exclude_keywords=("junior", ".net"),
                 accepted_work_modes=("remote", "hybrid"),

--- a/tests/test_runtime_matching.py
+++ b/tests/test_runtime_matching.py
@@ -1,0 +1,41 @@
+from unittest import TestCase
+
+from job_hunter_agent.core.matching_reasons import (
+    REASON_SALARY_BELOW_MINIMUM,
+    REASON_SENIORITY_OUTSIDE_TARGET,
+    REASON_WORK_MODE_MISMATCH,
+)
+from job_hunter_agent.core.runtime_matching import (
+    RuntimeMatchingPolicy,
+    RuntimeMatchingProfile,
+    runtime_rejection_reason_to_rationale,
+)
+
+
+class RuntimeMatchingTests(TestCase):
+    def test_prefilter_reason_prioritizes_seniority_before_work_mode_and_salary(self) -> None:
+        policy = RuntimeMatchingPolicy(
+            RuntimeMatchingProfile(
+                candidate_summary="Backend engineer",
+                include_keywords=("java",),
+                exclude_keywords=(),
+                accepted_work_modes=("remote",),
+                minimum_salary_brl=10000,
+                minimum_relevance=6,
+                target_seniorities=("senior",),
+                allow_unknown_seniority=True,
+            )
+        )
+
+        reason = policy.evaluate_prefilter_reason(
+            text="junior backend engineer java",
+            work_mode="onsite",
+            salary_floor=5000,
+        )
+
+        self.assertEqual(reason, REASON_SENIORITY_OUTSIDE_TARGET)
+
+    def test_runtime_rejection_reason_to_rationale_maps_new_path_tokens(self) -> None:
+        self.assertEqual(runtime_rejection_reason_to_rationale(REASON_SENIORITY_OUTSIDE_TARGET), "senioridade_fora_do_alvo")
+        self.assertEqual(runtime_rejection_reason_to_rationale(REASON_WORK_MODE_MISMATCH), "modalidade_incompativel")
+        self.assertEqual(runtime_rejection_reason_to_rationale(REASON_SALARY_BELOW_MINIMUM), "salario_abaixo")


### PR DESCRIPTION
## Resumo

Esta PR conclui a checklist da fase de runtime estruturado de matching.

Ela fecha a transição iniciada na fase anterior e consolida o novo centro de gravidade do runtime:

- fonte estruturada como caminho principal
- fallback legado apenas como compatibilidade explícita
- policy de senioridade desconhecida no caminho novo
- composição, collector, prompt e scorer orientados pelo contrato de runtime novo
- documentação e critérios de desligamento futuro do fallback já registrados

## Principais mudanças

### Runtime principal

- adiciona `job_hunter_agent/core/runtime_matching.py`
- introduz `RuntimeMatchingProfile`
- introduz `RuntimeMatchingPolicy`
- move o fluxo principal para depender desse contrato de runtime

### Composição

- `create_collection_service(...)` passa a construir o contrato novo de runtime a partir da fonte estruturada resolvida
- o runtime principal deixa `MatchingCriteria` fora do eixo central

### Collector / Scoring / Prompt

- `collector.py` passa a usar `RuntimeMatchingPolicy`
- `matching_prompt.py` passa a usar o contrato de runtime no caminho principal
- `scoring.py` passa a usar o contrato de runtime e convergir descarte/rationale
- rationale do caminho novo fica alinhada com as razões determinísticas do prefiltro

### Documentação

- `.env.example` atualizado para tratar matching estruturado como principal
- `README.md` atualizado para refletir o novo centro do runtime
- `AGENTS.md` alinhado ao uso do caminho estruturado como padrão
- adiciona `docs/plans/STRUCTURED_MATCHING_FALLBACK_EXIT_CRITERIA.md`
- encerra `docs/plans/RUNTIME_STRUCTURED_MATCHING_SOURCE_CHECKLIST.md`

### Testes

- regressões da composição no contrato novo
- regressões do prompt no contrato novo
- testes do contrato de runtime e do mapeamento de descarte para rationale

## Resultado prático

Depois desta PR:

- o runtime principal depende claramente da fonte estruturada
- o legado fica reduzido a compatibilidade marginal
- a checklist da fase fica concluída

## Observação

Esta PR não remove o fallback legado por completo.
Ela deixa explícitos os critérios para o desligamento futuro, mas mantém a compatibilidade enquanto necessário.
