### PR TITLE
refactor: remove hardcodes de perfil/vaga e externaliza taxonomia de skills

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,7 @@ JOB_HUNTER_APPLICATION_CONTACT_EMAIL=
 JOB_HUNTER_APPLICATION_PHONE=
 JOB_HUNTER_APPLICATION_PHONE_COUNTRY_CODE=
 JOB_HUNTER_CANDIDATE_PROFILE_PATH=./candidate_profile.json
+JOB_HUNTER_SKILL_TAXONOMY_PATH=./skill_taxonomy.json
 JOB_HUNTER_COLLECTION_TIME=08:00
 JOB_HUNTER_DATABASE_PATH=./jobs.db
 JOB_HUNTER_BROWSER_USE_CONFIG_DIR=./.browseruse
@@ -28,12 +29,17 @@ JOB_HUNTER_OLLAMA_URL=http://localhost:11434
 # Matching estruturado principal
 # O runtime agora prefere este arquivo como fonte principal de matching.
 JOB_HUNTER_STRUCTURED_MATCHING_CONFIG_PATH=./job_target.json
-JOB_HUNTER_STRUCTURED_MATCHING_FALLBACK_ENABLED=true
+JOB_HUNTER_STRUCTURED_MATCHING_FALLBACK_ENABLED=false
 
 # Compatibilidade legada
 # Mantenha estes campos apenas enquanto o fallback legado ainda for necessário.
 # Não expanda o uso de PROFILE_TEXT em código novo.
-JOB_HUNTER_PROFILE_TEXT=Engenheiro de Software Senior com experiencia em Java, Kotlin, Spring Boot e cloud.
+JOB_HUNTER_PROFILE_TEXT=
+JOB_HUNTER_INCLUDE_KEYWORDS=
+JOB_HUNTER_EXCLUDE_KEYWORDS=
+JOB_HUNTER_ACCEPTED_WORK_MODES=
+JOB_HUNTER_MINIMUM_SALARY_BRL=0
+JOB_HUNTER_MINIMUM_RELEVANCE=6
 
 # Toggles operacionais de teste
 JOB_HUNTER_RELAXED_MATCHING_FOR_TESTING=false

--- a/README.md
+++ b/README.md
@@ -65,12 +65,14 @@ Variaveis principais desse caminho:
 
 - `JOB_HUNTER_STRUCTURED_MATCHING_CONFIG_PATH`
 - `JOB_HUNTER_STRUCTURED_MATCHING_FALLBACK_ENABLED`
+- `JOB_HUNTER_SKILL_TAXONOMY_PATH`
 
 Comportamento:
 
 - se o arquivo estruturado existir, ele vira a fonte principal do matching
 - se o arquivo nao existir e o fallback estiver habilitado, o runtime cai para o contrato legado
 - se o arquivo nao existir e o fallback estiver desligado, o runtime falha cedo
+- o fallback vem desligado por padrao (`JOB_HUNTER_STRUCTURED_MATCHING_FALLBACK_ENABLED=false`)
 
 Exemplo versionado:
 
@@ -84,13 +86,19 @@ Copia recomendada para uso local:
 
 O caminho legado continua existindo apenas como compatibilidade marginal.
 
-Campo legado principal:
+Campos legados de compatibilidade:
 
 - `JOB_HUNTER_PROFILE_TEXT`
+- `JOB_HUNTER_INCLUDE_KEYWORDS`
+- `JOB_HUNTER_EXCLUDE_KEYWORDS`
+- `JOB_HUNTER_ACCEPTED_WORK_MODES`
+- `JOB_HUNTER_MINIMUM_SALARY_BRL`
+- `JOB_HUNTER_MINIMUM_RELEVANCE`
 
 Tratamento esperado:
 
 - ele existe por compatibilidade
+- ele exige configuracao explicita quando fallback legado estiver habilitado
 - nao deve voltar a ser apresentado como centro da evolucao do matching
 - codigo novo deve depender da fonte estruturada ou de contratos explicitos, nunca do shape inteiro de `Settings`
 
@@ -102,6 +110,7 @@ Tratamento esperado:
 - `JOB_HUNTER_APPLICATION_PHONE`
 - `JOB_HUNTER_APPLICATION_PHONE_COUNTRY_CODE`
 - `JOB_HUNTER_CANDIDATE_PROFILE_PATH`
+- `JOB_HUNTER_SKILL_TAXONOMY_PATH`
 - `JOB_HUNTER_COLLECTION_TIME`
 - `JOB_HUNTER_DATABASE_PATH`
 - `JOB_HUNTER_BROWSER_USE_CONFIG_DIR`

--- a/docs/plans/REMOVE_HARDCODES_PROFILE_TARGET_CHECKLIST.md
+++ b/docs/plans/REMOVE_HARDCODES_PROFILE_TARGET_CHECKLIST.md
@@ -1,0 +1,30 @@
+# Remove Hardcodes De Perfil E Vaga
+
+## Objetivo
+
+Eliminar hardcodes ligados a definicao de perfil do candidato e vaga alvo no runtime principal, mantendo compatibilidade controlada e fail-fast explicito.
+
+## Escopo
+
+- `job_hunter_agent/core/settings.py`
+- `job_hunter_agent/core/legacy_matching_config.py`
+- `job_hunter_agent/core/structured_matching_config.py`
+- `README.md`
+- testes afetados por defaults legados
+
+## Checklist
+
+- [x] Mapear hardcodes ativos de perfil/vaga e pontos de fallback
+- [x] Remover defaults legados de perfil/matching em `Settings`
+- [x] Desligar fallback legado por padrao (`structured_matching_fallback_enabled=false`)
+- [x] Remover query hardcoded de vaga alvo na `search_url` default
+- [x] Garantir erro explicito quando fallback legado estiver habilitado sem configuracao minima
+- [x] Ajustar testes para o novo comportamento sem hardcode
+- [x] Atualizar documentacao operacional (`README`) com novo contrato
+- [x] Validar testes relevantes da area alterada
+
+## Proxima Onda (Remanescentes)
+
+- [x] Externalizar aliases de skills hoje fixos em `core/candidate_profile.py`
+- [x] Externalizar listas de stack primaria/secundaria hoje fixas em `llm/job_requirements.py`
+- [x] Remover lista fixa de stacks no prompt de `llm/candidate_profile_extractor.py`

--- a/job_hunter_agent/application/composition.py
+++ b/job_hunter_agent/application/composition.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+from pathlib import Path
 from typing import Callable
 
 from job_hunter_agent.application.contracts import ArtifactCapturePort
@@ -142,9 +143,13 @@ def create_linkedin_modal_interpreter(settings: Settings):
 
 def create_collection_service(settings: Settings, repository: JobRepository) -> JobCollectionService:
     known_job_lookup = build_known_job_lookup(repository)
+    structured_config_path = Path(settings.structured_matching_config_path)
+    legacy_matching = None
+    if settings.structured_matching_fallback_enabled and not structured_config_path.exists():
+        legacy_matching = settings.build_legacy_matching_config()
     resolved_matching = resolve_structured_matching_source(
-        structured_matching_config_path=settings.structured_matching_config_path,
-        legacy_matching=settings.build_legacy_matching_config(),
+        structured_matching_config_path=structured_config_path,
+        legacy_matching=legacy_matching,
         legacy_fallback_enabled=settings.structured_matching_fallback_enabled,
     )
     if resolved_matching.used_legacy_fallback:

--- a/job_hunter_agent/collectors/collector.py
+++ b/job_hunter_agent/collectors/collector.py
@@ -13,6 +13,7 @@ from job_hunter_agent.core.browser_support import (
     resolve_local_chromium,
 )
 from job_hunter_agent.core.domain import CollectionReport, JobPosting, RawJob, ScoredJob, SiteConfig
+from job_hunter_agent.core.matching import MatchingCriteria
 from job_hunter_agent.core.runtime_matching import RuntimeMatchingPolicy, RuntimeMatchingProfile
 from job_hunter_agent.collectors.linkedin import (
     LinkedInDeterministicCollector,
@@ -58,11 +59,26 @@ class JobCollectionService:
     def __init__(
         self,
         settings: Settings,
-        runtime_matching_profile: RuntimeMatchingProfile,
         repository: JobRepository,
         site_collector: SiteCollector,
         scorer: JobScorer,
+        *,
+        runtime_matching_profile: RuntimeMatchingProfile | None = None,
+        matching_criteria: MatchingCriteria | None = None,
     ) -> None:
+        if runtime_matching_profile is None and matching_criteria is None:
+            raise ValueError("Informe runtime_matching_profile ou matching_criteria.")
+        if runtime_matching_profile is None:
+            runtime_matching_profile = RuntimeMatchingProfile(
+                candidate_summary=matching_criteria.profile_text,
+                include_keywords=matching_criteria.include_keywords,
+                exclude_keywords=matching_criteria.exclude_keywords,
+                accepted_work_modes=matching_criteria.accepted_work_modes,
+                minimum_salary_brl=matching_criteria.minimum_salary_brl,
+                minimum_relevance=matching_criteria.minimum_relevance,
+                target_seniorities=matching_criteria.target_seniorities,
+                allow_unknown_seniority=matching_criteria.allow_unknown_seniority,
+            )
         self.settings = settings
         self.runtime_matching_profile = runtime_matching_profile
         self.repository = repository

--- a/job_hunter_agent/core/candidate_profile.py
+++ b/job_hunter_agent/core/candidate_profile.py
@@ -5,16 +5,7 @@ import json
 import re
 from pathlib import Path
 
-
-_SKILL_ALIASES: dict[str, tuple[str, ...]] = {
-    "java": ("java",),
-    "angular": ("angular", "angular framework"),
-    "ejb": ("ejb", "enterprise java beans"),
-    "kotlin": ("kotlin",),
-    "spring": ("spring", "spring boot"),
-    "postgresql": ("postgresql", "postgres", "postgre sql"),
-    "docker": ("docker",),
-}
+from job_hunter_agent.core.skill_taxonomy import get_runtime_skill_taxonomy
 
 
 def _normalize_text(value: str) -> str:
@@ -101,7 +92,7 @@ def record_pending_questions(path: str | Path, questions: tuple[str, ...]) -> Pa
 
 def normalize_skill_key(value: str) -> str:
     normalized = _normalize_text(value)
-    for skill_key, aliases in _SKILL_ALIASES.items():
+    for skill_key, aliases in get_runtime_skill_taxonomy().skill_aliases.items():
         if normalized == skill_key:
             return skill_key
         if any(alias in normalized for alias in aliases):
@@ -143,7 +134,7 @@ def extract_supported_experience_answers(
                 skill_key=skill_key,
                 years=years,
                 question=question,
-                aliases=_SKILL_ALIASES.get(skill_key, (skill_key,)),
+                aliases=get_runtime_skill_taxonomy().skill_aliases.get(skill_key, (skill_key,)),
             )
         )
     return tuple(answers), tuple(unresolved)
@@ -164,7 +155,7 @@ def extract_skill_key_from_experience_question(question: str) -> str | None:
     )
     if not any(hint in normalized for hint in experience_hints):
         return None
-    for skill_key, aliases in _SKILL_ALIASES.items():
+    for skill_key, aliases in get_runtime_skill_taxonomy().skill_aliases.items():
         if any(alias in normalized for alias in aliases):
             return skill_key
     return None

--- a/job_hunter_agent/core/legacy_matching_config.py
+++ b/job_hunter_agent/core/legacy_matching_config.py
@@ -14,11 +14,35 @@ class LegacyMatchingConfig:
 
 
 def build_legacy_matching_config_from_settings(settings) -> LegacyMatchingConfig:
+    profile_text = str(getattr(settings, "profile_text", "")).strip()
+    if not profile_text:
+        raise ValueError(
+            "Fallback legado exige JOB_HUNTER_PROFILE_TEXT nao vazio ou desabilite JOB_HUNTER_STRUCTURED_MATCHING_FALLBACK_ENABLED."
+        )
+    include_keywords = tuple(
+        token.strip().lower()
+        for token in tuple(getattr(settings, "include_keywords", ()))
+        if str(token).strip()
+    )
+    if not include_keywords:
+        raise ValueError(
+            "Fallback legado exige include_keywords configurado ou desabilite JOB_HUNTER_STRUCTURED_MATCHING_FALLBACK_ENABLED."
+        )
+    exclude_keywords = tuple(
+        token.strip().lower()
+        for token in tuple(getattr(settings, "exclude_keywords", ()))
+        if str(token).strip()
+    )
+    accepted_work_modes = tuple(
+        token.strip().lower()
+        for token in tuple(getattr(settings, "accepted_work_modes", ()))
+        if str(token).strip()
+    )
     return LegacyMatchingConfig(
-        profile_text=settings.profile_text,
-        include_keywords=tuple(settings.include_keywords),
-        exclude_keywords=tuple(settings.exclude_keywords),
-        accepted_work_modes=tuple(settings.accepted_work_modes),
+        profile_text=profile_text,
+        include_keywords=include_keywords,
+        exclude_keywords=exclude_keywords,
+        accepted_work_modes=accepted_work_modes,
         minimum_salary_brl=settings.minimum_salary_brl,
         minimum_relevance=settings.minimum_relevance,
     )

--- a/job_hunter_agent/core/settings.py
+++ b/job_hunter_agent/core/settings.py
@@ -11,6 +11,7 @@ from job_hunter_agent.core.legacy_matching_config import (
     LegacyMatchingConfig,
     build_legacy_matching_config_from_settings,
 )
+from job_hunter_agent.core.skill_taxonomy import set_runtime_skill_taxonomy_path
 
 
 class Settings(BaseSettings):
@@ -29,7 +30,8 @@ class Settings(BaseSettings):
     resume_path: Path = Path("./curriculo.pdf")
     candidate_profile_path: Path = Path("./candidate_profile.json")
     structured_matching_config_path: Path = Path("./job_target.json")
-    structured_matching_fallback_enabled: bool = True
+    skill_taxonomy_path: Path = Path("./skill_taxonomy.json")
+    structured_matching_fallback_enabled: bool = False
     database_path: Path = Path("./jobs.db")
     browser_use_config_dir: Path = Path("./.browseruse")
     linkedin_persistent_profile_dir: Path = Path("./.browseruse/profiles/linkedin-bootstrap")
@@ -52,30 +54,11 @@ class Settings(BaseSettings):
     ollama_url: str = "http://localhost:11434"
 
     # Matching legado de compatibilidade
-    profile_text: str = (
-        "Engenheiro de Software Senior com experiencia em Java, Kotlin, Spring Boot, "
-        "PostgreSQL, Docker e cloud."
-    )
-    include_keywords: tuple[str, ...] = (
-        "java",
-        "kotlin",
-        "spring",
-        "backend",
-        "engenheiro de software",
-        "software engineer",
-        "desenvolvedor backend",
-    )
-    exclude_keywords: tuple[str, ...] = (
-        "estagio",
-        "junior",
-        "trainee",
-        ".net",
-        "c#",
-        "php",
-        "ruby",
-    )
-    accepted_work_modes: tuple[str, ...] = ("remoto", "hibrido", "hybrid")
-    minimum_salary_brl: int = 10000
+    profile_text: str = ""
+    include_keywords: tuple[str, ...] = ()
+    exclude_keywords: tuple[str, ...] = ()
+    accepted_work_modes: tuple[str, ...] = ()
+    minimum_salary_brl: int = 0
     minimum_relevance: int = 6
 
     # Toggles operacionais de teste
@@ -98,7 +81,7 @@ class Settings(BaseSettings):
         default_factory=lambda: (
             SiteConfig(
                 name="LinkedIn",
-                search_url="https://www.linkedin.com/jobs/search/?keywords=engenheiro+software+kotlin&location=Brasil",
+                search_url="https://www.linkedin.com/jobs/search/",
             ),
         )
     )
@@ -109,9 +92,7 @@ class Settings(BaseSettings):
     @field_validator("profile_text")
     @classmethod
     def validate_profile_text(cls, value: str) -> str:
-        if not value.strip():
-            raise ValueError("Preencha JOB_HUNTER_PROFILE_TEXT.")
-        return value
+        return value.strip()
 
     @field_validator("application_contact_email")
     @classmethod
@@ -151,7 +132,12 @@ class Settings(BaseSettings):
             )
         return normalized
 
-    @field_validator("resume_path", "linkedin_storage_state_path", "structured_matching_config_path")
+    @field_validator(
+        "resume_path",
+        "linkedin_storage_state_path",
+        "structured_matching_config_path",
+        "skill_taxonomy_path",
+    )
     @classmethod
     def validate_runtime_paths(cls, value: Path, info) -> Path:
         path = Path(value)
@@ -202,4 +188,6 @@ class Settings(BaseSettings):
 
 
 def load_settings() -> Settings:
-    return Settings()
+    settings = Settings()
+    set_runtime_skill_taxonomy_path(settings.skill_taxonomy_path)
+    return settings

--- a/job_hunter_agent/core/skill_taxonomy.py
+++ b/job_hunter_agent/core/skill_taxonomy.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+import json
+from pathlib import Path
+from typing import Any
+
+
+@dataclass(frozen=True)
+class SkillTaxonomy:
+    skill_aliases: dict[str, tuple[str, ...]]
+    primary_stack_keywords: tuple[str, ...]
+    secondary_stack_keywords: tuple[str, ...]
+    leadership_keywords: tuple[str, ...]
+
+    @property
+    def prompt_focus_stacks(self) -> tuple[str, ...]:
+        ordered: list[str] = []
+        for token in self.primary_stack_keywords + self.secondary_stack_keywords:
+            if token not in ordered:
+                ordered.append(token)
+        return tuple(ordered)
+
+
+_runtime_skill_taxonomy_path = Path("./skill_taxonomy.json")
+_cached_runtime_taxonomy: SkillTaxonomy | None = None
+_cached_runtime_taxonomy_path: Path | None = None
+
+
+def set_runtime_skill_taxonomy_path(path: str | Path) -> None:
+    global _runtime_skill_taxonomy_path, _cached_runtime_taxonomy, _cached_runtime_taxonomy_path
+    _runtime_skill_taxonomy_path = Path(path)
+    _cached_runtime_taxonomy = None
+    _cached_runtime_taxonomy_path = None
+
+
+def get_runtime_skill_taxonomy() -> SkillTaxonomy:
+    global _cached_runtime_taxonomy, _cached_runtime_taxonomy_path
+    runtime_path = _runtime_skill_taxonomy_path.resolve()
+    if _cached_runtime_taxonomy is not None and _cached_runtime_taxonomy_path == runtime_path:
+        return _cached_runtime_taxonomy
+    loaded = load_skill_taxonomy(runtime_path)
+    _cached_runtime_taxonomy = loaded
+    _cached_runtime_taxonomy_path = runtime_path
+    return loaded
+
+
+def load_skill_taxonomy(path: str | Path) -> SkillTaxonomy:
+    taxonomy_path = Path(path)
+    try:
+        payload = json.loads(taxonomy_path.read_text(encoding="utf-8"))
+    except FileNotFoundError as exc:
+        raise ValueError(f"Arquivo de taxonomia de skills nao encontrado: {taxonomy_path}") from exc
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"Arquivo de taxonomia de skills invalido: JSON malformado em {taxonomy_path}") from exc
+    if not isinstance(payload, dict):
+        raise ValueError("Arquivo de taxonomia de skills invalido: raiz deve ser um objeto JSON.")
+    return parse_skill_taxonomy(payload)
+
+
+def parse_skill_taxonomy(payload: dict[str, Any]) -> SkillTaxonomy:
+    aliases_payload = payload.get("skill_aliases")
+    if not isinstance(aliases_payload, dict) or not aliases_payload:
+        raise ValueError("Arquivo de taxonomia de skills invalido: campo 'skill_aliases' ausente ou invalido.")
+    skill_aliases: dict[str, tuple[str, ...]] = {}
+    for raw_key, raw_value in aliases_payload.items():
+        key = str(raw_key).strip().lower()
+        if not key:
+            continue
+        aliases = _normalize_string_list(raw_value, field="skill_aliases")
+        merged: list[str] = []
+        for token in (key, *aliases):
+            if token not in merged:
+                merged.append(token)
+        skill_aliases[key] = tuple(merged)
+    if not skill_aliases:
+        raise ValueError("Arquivo de taxonomia de skills invalido: nenhuma skill valida em 'skill_aliases'.")
+
+    return SkillTaxonomy(
+        skill_aliases=skill_aliases,
+        primary_stack_keywords=_required_string_list(payload, "primary_stack_keywords"),
+        secondary_stack_keywords=_required_string_list(payload, "secondary_stack_keywords"),
+        leadership_keywords=_required_string_list(payload, "leadership_keywords"),
+    )
+
+
+def _required_string_list(payload: dict[str, Any], key: str) -> tuple[str, ...]:
+    values = _normalize_string_list(payload.get(key), field=key)
+    if not values:
+        raise ValueError(
+            f"Arquivo de taxonomia de skills invalido: campo '{key}' deve conter ao menos um item."
+        )
+    return values
+
+
+def _normalize_string_list(value: Any, *, field: str) -> tuple[str, ...]:
+    if not isinstance(value, list):
+        raise ValueError(f"Arquivo de taxonomia de skills invalido: campo '{field}' deve ser lista.")
+    normalized: list[str] = []
+    for item in value:
+        token = str(item).strip().lower()
+        if token and token not in normalized:
+            normalized.append(token)
+    return tuple(normalized)

--- a/job_hunter_agent/core/structured_matching_config.py
+++ b/job_hunter_agent/core/structured_matching_config.py
@@ -120,7 +120,7 @@ def build_structured_matching_source_from_legacy(
 def resolve_structured_matching_source(
     *,
     structured_matching_config_path: str | Path,
-    legacy_matching: LegacyMatchingConfig,
+    legacy_matching: LegacyMatchingConfig | None,
     legacy_fallback_enabled: bool,
 ) -> ResolvedStructuredMatchingSource:
     config_path = Path(structured_matching_config_path)
@@ -133,6 +133,10 @@ def resolve_structured_matching_source(
     if not legacy_fallback_enabled:
         raise ValueError(
             f"Arquivo de matching estruturado nao encontrado em {config_path} e o fallback legado esta desabilitado."
+        )
+    if legacy_matching is None:
+        raise ValueError(
+            "Fallback legado habilitado sem configuracao valida de perfil legado."
         )
     return ResolvedStructuredMatchingSource(
         config=build_structured_matching_source_from_legacy(legacy_matching),

--- a/job_hunter_agent/llm/candidate_profile_extractor.py
+++ b/job_hunter_agent/llm/candidate_profile_extractor.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 from job_hunter_agent.core.browser_support import extract_json_object
 from job_hunter_agent.core.candidate_profile import normalize_skill_key
+from job_hunter_agent.core.skill_taxonomy import get_runtime_skill_taxonomy
 
 
 @dataclass(frozen=True)
@@ -42,6 +43,7 @@ class OllamaCandidateProfileSuggester:
         self._llm = ChatOllama(model=model_name, base_url=base_url, temperature=0.1)
 
     def suggest_from_resume_text(self, resume_text: str) -> CandidateProfileSuggestion:
+        focus_stacks = ", ".join(get_runtime_skill_taxonomy().prompt_focus_stacks)
         response = self._llm.invoke(
             f"""
             Extraia sugestoes conservadoras de anos de experiencia por tecnologia a partir do curriculo.
@@ -52,7 +54,7 @@ class OllamaCandidateProfileSuggester:
             - Use apenas tecnologias claramente presentes no curriculo.
             - Nunca preencha `confirmed`.
             - Retorne apenas `suggested` com numeros inteiros.
-            - Foque em stacks usadas pelo fluxo atual de candidatura: java, angular, ejb, kotlin, spring, postgresql, docker.
+            - Foque nas stacks priorizadas do runtime atual: {focus_stacks}.
 
             Curriculo:
             {resume_text[:12000]}

--- a/job_hunter_agent/llm/job_requirements.py
+++ b/job_hunter_agent/llm/job_requirements.py
@@ -6,6 +6,7 @@ from typing import Protocol
 from job_hunter_agent.core.browser_support import extract_json_object
 from job_hunter_agent.core.domain import JobPosting
 from job_hunter_agent.core.seniority import infer_seniority_from_text, normalize_seniority_label
+from job_hunter_agent.core.skill_taxonomy import SkillTaxonomy, get_runtime_skill_taxonomy
 
 
 @dataclass(frozen=True)
@@ -24,19 +25,16 @@ class JobRequirementsExtractor(Protocol):
 
 
 class DeterministicJobRequirementsExtractor:
+    def __init__(self, *, taxonomy: SkillTaxonomy | None = None) -> None:
+        self._taxonomy = taxonomy or get_runtime_skill_taxonomy()
+
     def extract(self, job: JobPosting) -> JobRequirementSignals:
         combined = f"{job.title} {job.summary}".lower()
         seniority = infer_seniority_from_text(combined)
-        primary_stack = _find_keywords(combined, ("java", "kotlin", "spring", "spring boot", "angular", "react"))
-        secondary_stack = _find_keywords(
-            combined,
-            ("aws", "azure", "docker", "kubernetes", "postgresql", "sql", "microservices"),
-        )
+        primary_stack = _find_keywords(combined, self._taxonomy.primary_stack_keywords)
+        secondary_stack = _find_keywords(combined, self._taxonomy.secondary_stack_keywords)
         english_level = _infer_english_level(combined)
-        leadership_signals = seniority == "lideranca" or any(
-            token in combined
-            for token in ("lideranca", "liderar", "tech lead", "mentoria", "coordenar", "ownership")
-        )
+        leadership_signals = seniority == "lideranca" or any(token in combined for token in self._taxonomy.leadership_keywords)
         return JobRequirementSignals(
             seniority=seniority,
             primary_stack=primary_stack,

--- a/skill_taxonomy.json
+++ b/skill_taxonomy.json
@@ -1,0 +1,36 @@
+{
+  "skill_aliases": {
+    "java": ["java"],
+    "angular": ["angular", "angular framework"],
+    "ejb": ["ejb", "enterprise java beans"],
+    "kotlin": ["kotlin"],
+    "spring": ["spring", "spring boot"],
+    "postgresql": ["postgresql", "postgres", "postgre sql"],
+    "docker": ["docker"]
+  },
+  "primary_stack_keywords": [
+    "java",
+    "kotlin",
+    "spring",
+    "spring boot",
+    "angular",
+    "react"
+  ],
+  "secondary_stack_keywords": [
+    "aws",
+    "azure",
+    "docker",
+    "kubernetes",
+    "postgresql",
+    "sql",
+    "microservices"
+  ],
+  "leadership_keywords": [
+    "lideranca",
+    "liderar",
+    "tech lead",
+    "mentoria",
+    "coordenar",
+    "ownership"
+  ]
+}

--- a/tests/test_composition_legacy_matching.py
+++ b/tests/test_composition_legacy_matching.py
@@ -21,6 +21,7 @@ class CompositionLegacyMatchingTests(TestCase):
                 linkedin_persistent_profile_dir=root / ".browseruse/profiles/linkedin-bootstrap",
                 linkedin_storage_state_path=root / ".browseruse/linkedin-storage-state.json",
                 candidate_profile_path=root / "candidate_profile.json",
+                structured_matching_fallback_enabled=True,
                 sites=(SiteConfig(name="LinkedIn", search_url="https://example.com"),),
             )
             repository = Mock()
@@ -36,10 +37,19 @@ class CompositionLegacyMatchingTests(TestCase):
                 minimum_relevance=7,
             )
 
+            resolved = Mock(
+                config="resolved_matching",
+                used_legacy_fallback=True,
+                describe_source=Mock(return_value="fallback legado"),
+            )
+
             with patch.object(Settings, "build_legacy_matching_config", return_value=legacy) as mocked_build_legacy, patch(
-                "job_hunter_agent.application.composition.build_matching_criteria_from_legacy_config",
-                return_value="criteria",
-            ) as mocked_build_matching_criteria, patch(
+                "job_hunter_agent.application.composition.resolve_structured_matching_source",
+                return_value=resolved,
+            ), patch(
+                "job_hunter_agent.application.composition.build_runtime_matching_profile_from_structured_source",
+                return_value="runtime_profile",
+            ) as mocked_build_runtime, patch(
                 "job_hunter_agent.application.composition.LinkedInDeterministicCollector",
                 return_value="linkedin_collector",
             ), patch(
@@ -53,8 +63,8 @@ class CompositionLegacyMatchingTests(TestCase):
 
         self.assertIsNotNone(service)
         mocked_build_legacy.assert_called_once_with()
-        mocked_build_matching_criteria.assert_called_once_with(
-            legacy_matching=legacy,
+        mocked_build_runtime.assert_called_once_with(
+            structured_matching_source="resolved_matching",
             relaxed_matching_for_testing=settings.relaxed_matching_for_testing,
             relaxed_testing_profile_hint=settings.relaxed_testing_profile_hint,
             relaxed_testing_remove_exclude_keywords=settings.relaxed_testing_remove_exclude_keywords,

--- a/tests/test_legacy_matching_config.py
+++ b/tests/test_legacy_matching_config.py
@@ -30,3 +30,25 @@ class LegacyMatchingConfigTests(TestCase):
                 minimum_relevance=7,
             ),
         )
+
+    def test_settings_build_legacy_matching_config_fails_when_profile_text_is_empty(self) -> None:
+        settings = Settings(
+            telegram_token="token",
+            telegram_chat_id="chat",
+            profile_text="",
+            include_keywords=("java",),
+        )
+
+        with self.assertRaisesRegex(ValueError, "JOB_HUNTER_PROFILE_TEXT"):
+            settings.build_legacy_matching_config()
+
+    def test_settings_build_legacy_matching_config_fails_when_include_keywords_is_empty(self) -> None:
+        settings = Settings(
+            telegram_token="token",
+            telegram_chat_id="chat",
+            profile_text="Backend engineer",
+            include_keywords=(),
+        )
+
+        with self.assertRaisesRegex(ValueError, "include_keywords"):
+            settings.build_legacy_matching_config()

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -7,7 +7,12 @@ from job_hunter_agent.core.settings import Settings, load_settings
 
 class SettingsTests(TestCase):
     def test_settings_accepts_placeholder_telegram_credentials_for_non_telegram_execution(self) -> None:
-        settings = Settings()
+        previous_env_file = Settings.model_config.get("env_file")
+        Settings.model_config["env_file"] = None
+        try:
+            settings = Settings()
+        finally:
+            Settings.model_config["env_file"] = previous_env_file
 
         self.assertEqual(settings.telegram_token, "SEU_TOKEN_AQUI")
         self.assertEqual(settings.telegram_chat_id, "SEU_CHAT_ID_AQUI")
@@ -40,9 +45,11 @@ class SettingsTests(TestCase):
         self.assertEqual(settings.application_phone_country_code, "")
         self.assertEqual(str(settings.candidate_profile_path), "candidate_profile.json")
         self.assertFalse(settings.relaxed_matching_for_testing)
+        self.assertFalse(settings.structured_matching_fallback_enabled)
         self.assertTrue(settings.linkedin_field_repair_enabled)
         self.assertTrue(settings.application_priority_llm_enabled)
         self.assertEqual(settings.failure_artifacts_dir, Path("./.artifacts/linkedin_failures"))
+        self.assertEqual(settings.sites[0].search_url, "https://www.linkedin.com/jobs/search/")
 
     def test_load_settings_from_env_prefix(self) -> None:
         previous_prefix = Settings.model_config.get("env_prefix")

--- a/tests/test_skill_taxonomy.py
+++ b/tests/test_skill_taxonomy.py
@@ -1,0 +1,64 @@
+import json
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest import TestCase
+
+from job_hunter_agent.core.skill_taxonomy import (
+    get_runtime_skill_taxonomy,
+    load_skill_taxonomy,
+    set_runtime_skill_taxonomy_path,
+)
+
+
+class SkillTaxonomyTests(TestCase):
+    def setUp(self) -> None:
+        self._original_runtime_path = Path("./skill_taxonomy.json")
+        set_runtime_skill_taxonomy_path(self._original_runtime_path)
+
+    def tearDown(self) -> None:
+        set_runtime_skill_taxonomy_path(self._original_runtime_path)
+
+    def test_load_skill_taxonomy_reads_valid_file(self) -> None:
+        with TemporaryDirectory() as temp_dir:
+            path = Path(temp_dir) / "taxonomy.json"
+            path.write_text(
+                json.dumps(
+                    {
+                        "skill_aliases": {
+                            "python": ["python", "cpython"],
+                            "sql": ["sql"],
+                        },
+                        "primary_stack_keywords": ["python"],
+                        "secondary_stack_keywords": ["sql"],
+                        "leadership_keywords": ["mentoria"],
+                    }
+                ),
+                encoding="utf-8",
+            )
+            taxonomy = load_skill_taxonomy(path)
+
+        self.assertEqual(taxonomy.skill_aliases["python"], ("python", "cpython"))
+        self.assertEqual(taxonomy.primary_stack_keywords, ("python",))
+        self.assertEqual(taxonomy.secondary_stack_keywords, ("sql",))
+        self.assertEqual(taxonomy.leadership_keywords, ("mentoria",))
+        self.assertEqual(taxonomy.prompt_focus_stacks, ("python", "sql"))
+
+    def test_get_runtime_skill_taxonomy_uses_runtime_path(self) -> None:
+        with TemporaryDirectory() as temp_dir:
+            path = Path(temp_dir) / "taxonomy.json"
+            path.write_text(
+                json.dumps(
+                    {
+                        "skill_aliases": {"go": ["go", "golang"]},
+                        "primary_stack_keywords": ["go"],
+                        "secondary_stack_keywords": ["kubernetes"],
+                        "leadership_keywords": ["lideranca"],
+                    }
+                ),
+                encoding="utf-8",
+            )
+            set_runtime_skill_taxonomy_path(path)
+            taxonomy = get_runtime_skill_taxonomy()
+
+        self.assertEqual(taxonomy.skill_aliases["go"], ("go", "golang"))
+        self.assertEqual(taxonomy.primary_stack_keywords, ("go",))


### PR DESCRIPTION
## Resumo
Esta PR remove hardcodes de perfil/vaga do runtime principal, desliga fallback legado por padrão e externaliza taxonomia de skills para configuração versionada.

## O que mudou
- remove defaults legados de matching em `Settings` e define valores neutros
- altera `JOB_HUNTER_STRUCTURED_MATCHING_FALLBACK_ENABLED` para `false` por padrão
- remove query hardcoded da URL default de busca LinkedIn
- torna fallback legado fail-fast quando configuração mínima não existe
- evita construção ansiosa de legado quando arquivo estruturado existe (lazy fallback)
- adiciona taxonomia de skills em `skill_taxonomy.json` e loader em `core/skill_taxonomy.py`
- passa `candidate_profile`, `job_requirements` e `candidate_profile_extractor` a usar taxonomia configurável
- mantém compatibilidade de `JobCollectionService` com `matching_criteria` legado nos testes/contratos antigos
- adiciona checklist de execução da frente

## Testes
- `pytest`
- resultado: `406 passed`

## Observações
- branch segue GitFlow (`refactor/*`)
- commits em português e recorte incremental