### PR TITLE
Auto Easy Apply: gates e limites operacionais

### DIFF
--- a/docs/plans/AUTO_EASY_APPLY_GATES_LIMITS_CHECKLIST.md
+++ b/docs/plans/AUTO_EASY_APPLY_GATES_LIMITS_CHECKLIST.md
@@ -15,4 +15,4 @@ Permitir envio assistido em lote com segurancas explicitas para evitar submissao
 - [x] Expor comando CLI `applications auto-apply`.
 - [x] Cobrir fluxo com testes unitarios.
 - [x] Executar suite de testes impactada.
-- [ ] Endurecer gates avancados (detecao explicita de easy apply no detalhe, denylist configuravel, janela horaria e stop por bloqueios repetidos).
+- [x] Endurecer gates avancados (detecao explicita de easy apply no detalhe, denylist configuravel, janela horaria e stop por bloqueios repetidos).

--- a/docs/plans/AUTO_EASY_APPLY_GATES_LIMITS_CHECKLIST.md
+++ b/docs/plans/AUTO_EASY_APPLY_GATES_LIMITS_CHECKLIST.md
@@ -1,0 +1,18 @@
+# Auto Easy Apply - Gates e Limites
+
+## Objetivo
+
+Permitir envio assistido em lote com segurancas explicitas para evitar submissao fora de perfil e reduzir risco operacional.
+
+## Checklist
+
+- [x] Criar branch de trabalho `feature/auto-easy-apply-gates-limits`.
+- [x] Definir checklist versionada da feature.
+- [x] Adicionar configuracoes validadas de auto apply em `Settings`.
+- [x] Implementar servico de `auto_easy_apply` com gates iniciais obrigatorios.
+- [x] Implementar limites operacionais por ciclo e por dia.
+- [x] Implementar cooldown entre submits e circuit breaker por erros consecutivos.
+- [x] Expor comando CLI `applications auto-apply`.
+- [x] Cobrir fluxo com testes unitarios.
+- [x] Executar suite de testes impactada.
+- [ ] Endurecer gates avancados (detecao explicita de easy apply no detalhe, denylist configuravel, janela horaria e stop por bloqueios repetidos).

--- a/job_hunter_agent/application/app.py
+++ b/job_hunter_agent/application/app.py
@@ -8,6 +8,10 @@ from job_hunter_agent.application.application_commands import (
     ApplicationTransitionCommandService,
     JobReviewCommandService,
 )
+from job_hunter_agent.application.auto_easy_apply import (
+    AutoEasyApplyService,
+    render_auto_easy_apply_report,
+)
 from job_hunter_agent.application.application_health import (
     build_application_health_report,
     render_application_health_report,
@@ -115,6 +119,13 @@ class JobHunterApplication:
     def _initialize_flow_services(self) -> None:
         self.application_preflight = create_application_preflight_service(self.repository, self.settings)
         self.application_submission = create_application_submission_service(self.repository, self.settings)
+        self.auto_easy_apply = AutoEasyApplyService(
+            repository=self.repository,
+            preflight=self.application_preflight,
+            submission=self.application_submission,
+            transitions=self._application_transition_commands(),
+            settings=self.settings,
+        )
 
     async def handle_approved_jobs(self, job_ids: list[int]) -> None:
         await run_approved_jobs_handler(
@@ -150,6 +161,13 @@ class JobHunterApplication:
             detail=result.detail,
             application_status=result.application_status,
         )
+
+    def run_auto_easy_apply_once(self) -> str:
+        service = getattr(self, "auto_easy_apply", None)
+        if service is None:
+            self._initialize_flow_services()
+            service = self.auto_easy_apply
+        return render_auto_easy_apply_report(service.run_once())
 
     def list_applications(self, *, status: str | None = None) -> str:
         return self._query_service().list_applications(status=status)

--- a/job_hunter_agent/application/application_cli.py
+++ b/job_hunter_agent/application/application_cli.py
@@ -156,6 +156,11 @@ def parse_args() -> argparse.Namespace:
         help="Valida se o submit poderia rodar agora, sem alterar estado nem tocar o portal.",
     )
 
+    applications_subparsers.add_parser(
+        "auto-apply",
+        help="Executa envio em lote com gates e limites de seguranca do auto easy apply.",
+    )
+
     candidate_profile_parser = subparsers.add_parser(
         "candidate-profile",
         help="Operacoes do perfil estruturado do candidato.",

--- a/job_hunter_agent/application/application_cli_dispatch.py
+++ b/job_hunter_agent/application/application_cli_dispatch.py
@@ -12,6 +12,7 @@ from job_hunter_agent.application.collector_worker import run_collector_worker_o
 from job_hunter_agent.application.matching_worker import run_matching_worker_once
 from job_hunter_agent.application.cli_bootstrap import (
     create_application_flow_app,
+    create_auto_apply_app,
     create_query_app,
     create_review_app,
 )
@@ -102,6 +103,10 @@ def _run_applications_command(args: Namespace) -> None:
     if args.applications_command == "authorize":
         app = create_review_app()
         print(app.authorize_application(args.id))
+        return
+    if args.applications_command == "auto-apply":
+        app = create_auto_apply_app()
+        print(app.run_auto_easy_apply_once())
         return
     app = create_application_flow_app()
     if args.applications_command == "preflight":

--- a/job_hunter_agent/application/auto_easy_apply.py
+++ b/job_hunter_agent/application/auto_easy_apply.py
@@ -1,0 +1,183 @@
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+from datetime import datetime
+
+from job_hunter_agent.application.application_preflight import ApplicationPreflightService
+from job_hunter_agent.application.application_submission import ApplicationSubmissionService
+from job_hunter_agent.application.application_commands import ApplicationTransitionCommandService
+from job_hunter_agent.core.domain import JobApplication, JobPosting
+from job_hunter_agent.core.settings import Settings
+from job_hunter_agent.infrastructure.repository import JobRepository
+
+
+@dataclass(frozen=True)
+class AutoEasyApplyReport:
+    analyzed: int
+    submitted: int
+    blocked: int
+    skipped: int
+    consecutive_errors: int
+    details: tuple[str, ...]
+
+
+def render_auto_easy_apply_report(report: AutoEasyApplyReport) -> str:
+    lines = [
+        "Auto Easy Apply:",
+        f"- analisadas={report.analyzed}",
+        f"- enviadas={report.submitted}",
+        f"- bloqueadas={report.blocked}",
+        f"- puladas={report.skipped}",
+        f"- erros_consecutivos={report.consecutive_errors}",
+    ]
+    if report.details:
+        lines.append("- detalhes:")
+        lines.extend(f"  - {detail}" for detail in report.details)
+    return "\n".join(lines)
+
+
+class AutoEasyApplyService:
+    def __init__(
+        self,
+        *,
+        repository: JobRepository,
+        preflight: ApplicationPreflightService,
+        submission: ApplicationSubmissionService,
+        transitions: ApplicationTransitionCommandService,
+        settings: Settings,
+    ) -> None:
+        self.repository = repository
+        self.preflight = preflight
+        self.submission = submission
+        self.transitions = transitions
+        self.settings = settings
+
+    def run_once(self) -> AutoEasyApplyReport:
+        details: list[str] = []
+        analyzed = 0
+        submitted = 0
+        blocked = 0
+        skipped = 0
+        consecutive_errors = 0
+
+        if not self.settings.auto_easy_apply_enabled:
+            return AutoEasyApplyReport(
+                analyzed=0,
+                submitted=0,
+                blocked=0,
+                skipped=0,
+                consecutive_errors=0,
+                details=("auto_easy_apply desabilitado em JOB_HUNTER_AUTO_EASY_APPLY_ENABLED",),
+            )
+
+        start_of_day = datetime.now().replace(hour=0, minute=0, second=0, microsecond=0).isoformat(timespec="seconds")
+        daily_submitted = self.repository.count_submitted_applications_since(start_of_day)
+        if daily_submitted >= self.settings.auto_easy_apply_max_submits_per_day:
+            return AutoEasyApplyReport(
+                analyzed=0,
+                submitted=0,
+                blocked=1,
+                skipped=0,
+                consecutive_errors=0,
+                details=(
+                    f"limite diario atingido: {daily_submitted}/{self.settings.auto_easy_apply_max_submits_per_day}",
+                ),
+            )
+
+        candidates = self._load_candidates()
+        for application, job in candidates:
+            if submitted >= self.settings.auto_easy_apply_max_submits_per_cycle:
+                details.append(
+                    f"limite por ciclo atingido: {submitted}/{self.settings.auto_easy_apply_max_submits_per_cycle}"
+                )
+                break
+            if daily_submitted + submitted >= self.settings.auto_easy_apply_max_submits_per_day:
+                details.append(
+                    f"limite diario atingido: {daily_submitted + submitted}/{self.settings.auto_easy_apply_max_submits_per_day}"
+                )
+                break
+            if consecutive_errors >= self.settings.auto_easy_apply_max_consecutive_errors:
+                details.append(
+                    f"circuit breaker acionado apos {consecutive_errors} erro(s) consecutivo(s)"
+                )
+                break
+
+            analyzed += 1
+            gate_reason = self._evaluate_gates(application=application, job=job)
+            if gate_reason is not None:
+                skipped += 1
+                details.append(f"app_id={application.id} gate={gate_reason}")
+                continue
+
+            final_application = application
+            if application.status == "confirmed":
+                preflight_result = self.preflight.run_for_application(application.id)
+                if preflight_result.outcome != "ready":
+                    blocked += 1
+                    details.append(
+                        f"app_id={application.id} preflight_bloqueou={preflight_result.detail}"
+                    )
+                    consecutive_errors = 0
+                    continue
+                self.transitions.authorize_application(application.id)
+                refreshed = self.repository.get_application(application.id)
+                if refreshed is None:
+                    blocked += 1
+                    details.append(f"app_id={application.id} nao encontrada apos autorizar")
+                    continue
+                final_application = refreshed
+
+            submit_result = self.submission.run_for_application(final_application.id)
+            if submit_result.outcome == "submitted":
+                submitted += 1
+                consecutive_errors = 0
+                details.append(f"app_id={final_application.id} enviada com sucesso")
+                if (
+                    submitted < self.settings.auto_easy_apply_max_submits_per_cycle
+                    and self.settings.auto_easy_apply_cooldown_seconds > 0
+                ):
+                    time.sleep(self.settings.auto_easy_apply_cooldown_seconds)
+                continue
+
+            blocked += 1
+            consecutive_errors += 1
+            details.append(
+                f"app_id={final_application.id} submit_{submit_result.outcome}={submit_result.detail}"
+            )
+
+        return AutoEasyApplyReport(
+            analyzed=analyzed,
+            submitted=submitted,
+            blocked=blocked,
+            skipped=skipped,
+            consecutive_errors=consecutive_errors,
+            details=tuple(details),
+        )
+
+    def _load_candidates(self) -> list[tuple[JobApplication, JobPosting]]:
+        ordered: list[tuple[JobApplication, JobPosting]] = []
+        for status in ("authorized_submit", "confirmed"):
+            for application in self.repository.list_applications_by_status(status):
+                job = self.repository.get_job(application.job_id)
+                if job is None:
+                    continue
+                ordered.append((application, job))
+        ordered.sort(key=lambda item: item[1].relevance, reverse=True)
+        return ordered
+
+    def _evaluate_gates(self, *, application: JobApplication, job: JobPosting) -> str | None:
+        if application.status not in {"confirmed", "authorized_submit"}:
+            return "status_invalido"
+        if job.status != "approved":
+            return "vaga_nao_aprovada"
+        if job.relevance < self.settings.auto_easy_apply_min_score:
+            return "score_abaixo_do_limiar"
+        source_site = (job.source_site or "").strip().lower()
+        if source_site != "linkedin":
+            return "portal_fora_do_alvo"
+        if "linkedin.com/jobs/" not in (job.url or "").lower():
+            return "url_fora_do_fluxo_linkedin_jobs"
+        if application.support_level == "unsupported":
+            return "suporte_automatico_indisponivel"
+        return None

--- a/job_hunter_agent/application/auto_easy_apply.py
+++ b/job_hunter_agent/application/auto_easy_apply.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import time
+from collections import defaultdict
 from dataclasses import dataclass
 from datetime import datetime
 
@@ -60,6 +61,7 @@ class AutoEasyApplyService:
         blocked = 0
         skipped = 0
         consecutive_errors = 0
+        blocked_by_reason: dict[str, int] = defaultdict(int)
 
         if not self.settings.auto_easy_apply_enabled:
             return AutoEasyApplyReport(
@@ -69,6 +71,17 @@ class AutoEasyApplyService:
                 skipped=0,
                 consecutive_errors=0,
                 details=("auto_easy_apply desabilitado em JOB_HUNTER_AUTO_EASY_APPLY_ENABLED",),
+            )
+        if not self._is_within_allowed_window(datetime.now()):
+            return AutoEasyApplyReport(
+                analyzed=0,
+                submitted=0,
+                blocked=1,
+                skipped=0,
+                consecutive_errors=0,
+                details=(
+                    "fora da janela horaria permitida para auto apply",
+                ),
             )
 
         start_of_day = datetime.now().replace(hour=0, minute=0, second=0, microsecond=0).isoformat(timespec="seconds")
@@ -115,10 +128,30 @@ class AutoEasyApplyService:
                 preflight_result = self.preflight.run_for_application(application.id)
                 if preflight_result.outcome != "ready":
                     blocked += 1
+                    reason_code = f"preflight:{preflight_result.outcome}"
+                    blocked_by_reason[reason_code] += 1
                     details.append(
                         f"app_id={application.id} preflight_bloqueou={preflight_result.detail}"
                     )
                     consecutive_errors = 0
+                    if self._should_stop_for_repeated_block(blocked_by_reason):
+                        details.append(
+                            f"parada por bloqueio repetido: {reason_code}={blocked_by_reason[reason_code]}"
+                        )
+                        break
+                    continue
+                if not _preflight_indicates_easy_apply(preflight_result.detail):
+                    blocked += 1
+                    reason_code = "preflight:sem_easy_apply_explicito"
+                    blocked_by_reason[reason_code] += 1
+                    details.append(
+                        f"app_id={application.id} preflight_sem_easy_apply={preflight_result.detail}"
+                    )
+                    if self._should_stop_for_repeated_block(blocked_by_reason):
+                        details.append(
+                            f"parada por bloqueio repetido: {reason_code}={blocked_by_reason[reason_code]}"
+                        )
+                        break
                     continue
                 self.transitions.authorize_application(application.id)
                 refreshed = self.repository.get_application(application.id)
@@ -142,9 +175,16 @@ class AutoEasyApplyService:
 
             blocked += 1
             consecutive_errors += 1
+            reason_code = f"submit:{submit_result.outcome}"
+            blocked_by_reason[reason_code] += 1
             details.append(
                 f"app_id={final_application.id} submit_{submit_result.outcome}={submit_result.detail}"
             )
+            if self._should_stop_for_repeated_block(blocked_by_reason):
+                details.append(
+                    f"parada por bloqueio repetido: {reason_code}={blocked_by_reason[reason_code]}"
+                )
+                break
 
         return AutoEasyApplyReport(
             analyzed=analyzed,
@@ -180,4 +220,41 @@ class AutoEasyApplyService:
             return "url_fora_do_fluxo_linkedin_jobs"
         if application.support_level == "unsupported":
             return "suporte_automatico_indisponivel"
+        company_text = (job.company or "").strip().lower()
+        for denied in self.settings.auto_easy_apply_denylist_company_terms:
+            if denied and denied in company_text:
+                return "empresa_na_denylist"
+        url_text = (job.url or "").strip().lower()
+        for denied in self.settings.auto_easy_apply_denylist_url_terms:
+            if denied and denied in url_text:
+                return "url_na_denylist"
+        if application.status == "authorized_submit" and not _preflight_indicates_easy_apply(
+            application.last_preflight_detail
+        ):
+            return "preflight_sem_easy_apply_explicito"
         return None
+
+    def _is_within_allowed_window(self, now: datetime) -> bool:
+        start_hour = int(self.settings.auto_easy_apply_allowed_start_hour)
+        end_hour = int(self.settings.auto_easy_apply_allowed_end_hour)
+        current_hour = int(now.hour)
+        if start_hour == end_hour:
+            return True
+        if start_hour < end_hour:
+            return start_hour <= current_hour < end_hour
+        return current_hour >= start_hour or current_hour < end_hour
+
+    def _should_stop_for_repeated_block(self, blocked_by_reason: dict[str, int]) -> bool:
+        limit = int(self.settings.auto_easy_apply_max_blocks_same_reason)
+        if limit <= 0:
+            return False
+        return any(count >= limit for count in blocked_by_reason.values())
+
+
+def _preflight_indicates_easy_apply(detail: str) -> bool:
+    normalized = (detail or "").strip().lower()
+    if not normalized:
+        return False
+    if "pronto_para_envio=sim" in normalized:
+        return True
+    return "easy apply" in normalized

--- a/job_hunter_agent/application/cli_bootstrap.py
+++ b/job_hunter_agent/application/cli_bootstrap.py
@@ -25,6 +25,14 @@ def create_application_flow_app() -> JobHunterApplication:
     return app
 
 
+def create_auto_apply_app() -> JobHunterApplication:
+    app = _create_cli_app_base()
+    app._initialize_query_services()
+    app._initialize_review_services()
+    app._initialize_flow_services()
+    return app
+
+
 def _create_cli_app_base() -> JobHunterApplication:
     app = JobHunterApplication.__new__(JobHunterApplication)
     app.enable_telegram = False

--- a/job_hunter_agent/core/settings.py
+++ b/job_hunter_agent/core/settings.py
@@ -63,6 +63,12 @@ class Settings(BaseSettings):
     adaptive_polling_backoff_multiplier: float = 2.0
     adaptive_polling_max_interval_seconds: int = 900
     collection_time: str = "08:00"
+    auto_easy_apply_enabled: bool = False
+    auto_easy_apply_min_score: int = 8
+    auto_easy_apply_max_submits_per_cycle: int = 3
+    auto_easy_apply_max_submits_per_day: int = 10
+    auto_easy_apply_cooldown_seconds: int = 120
+    auto_easy_apply_max_consecutive_errors: int = 2
 
     telegram_token: str = "SEU_TOKEN_AQUI"
     telegram_chat_id: str = "SEU_CHAT_ID_AQUI"
@@ -273,6 +279,25 @@ class Settings(BaseSettings):
             raise ValueError(
                 "JOB_HUNTER_PRIORITY_MEDIUM_MIN_RELEVANCE nao pode ser maior que JOB_HUNTER_PRIORITY_HIGH_MIN_RELEVANCE."
             )
+        return value
+
+    @field_validator("auto_easy_apply_min_score")
+    @classmethod
+    def validate_auto_easy_apply_min_score(cls, value: int) -> int:
+        if not (1 <= value <= 10):
+            raise ValueError("JOB_HUNTER_AUTO_EASY_APPLY_MIN_SCORE deve estar entre 1 e 10.")
+        return value
+
+    @field_validator(
+        "auto_easy_apply_max_submits_per_cycle",
+        "auto_easy_apply_max_submits_per_day",
+        "auto_easy_apply_cooldown_seconds",
+        "auto_easy_apply_max_consecutive_errors",
+    )
+    @classmethod
+    def validate_auto_easy_apply_limits(cls, value: int, info) -> int:
+        if value <= 0:
+            raise ValueError(f"JOB_HUNTER_{info.field_name.upper()} deve ser maior que zero.")
         return value
 
     @field_validator("sites")

--- a/job_hunter_agent/core/settings.py
+++ b/job_hunter_agent/core/settings.py
@@ -69,6 +69,11 @@ class Settings(BaseSettings):
     auto_easy_apply_max_submits_per_day: int = 10
     auto_easy_apply_cooldown_seconds: int = 120
     auto_easy_apply_max_consecutive_errors: int = 2
+    auto_easy_apply_max_blocks_same_reason: int = 5
+    auto_easy_apply_allowed_start_hour: int = 8
+    auto_easy_apply_allowed_end_hour: int = 22
+    auto_easy_apply_denylist_company_terms: tuple[str, ...] = ()
+    auto_easy_apply_denylist_url_terms: tuple[str, ...] = ()
 
     telegram_token: str = "SEU_TOKEN_AQUI"
     telegram_chat_id: str = "SEU_CHAT_ID_AQUI"
@@ -293,12 +298,25 @@ class Settings(BaseSettings):
         "auto_easy_apply_max_submits_per_day",
         "auto_easy_apply_cooldown_seconds",
         "auto_easy_apply_max_consecutive_errors",
+        "auto_easy_apply_max_blocks_same_reason",
     )
     @classmethod
     def validate_auto_easy_apply_limits(cls, value: int, info) -> int:
         if value <= 0:
             raise ValueError(f"JOB_HUNTER_{info.field_name.upper()} deve ser maior que zero.")
         return value
+
+    @field_validator("auto_easy_apply_allowed_start_hour", "auto_easy_apply_allowed_end_hour")
+    @classmethod
+    def validate_auto_easy_apply_hours(cls, value: int, info) -> int:
+        if not (0 <= value <= 23):
+            raise ValueError(f"JOB_HUNTER_{info.field_name.upper()} deve estar entre 0 e 23.")
+        return value
+
+    @field_validator("auto_easy_apply_denylist_company_terms", "auto_easy_apply_denylist_url_terms")
+    @classmethod
+    def validate_auto_easy_apply_denylist_terms(cls, value: tuple[str, ...]) -> tuple[str, ...]:
+        return tuple(item.strip().lower() for item in value if item and item.strip())
 
     @field_validator("sites")
     @classmethod

--- a/job_hunter_agent/infrastructure/repository.py
+++ b/job_hunter_agent/infrastructure/repository.py
@@ -140,6 +140,9 @@ class JobRepository(Protocol):
     def list_recent_application_events_since(self, since: str) -> list[JobApplicationEvent]:
         raise NotImplementedError
 
+    def count_submitted_applications_since(self, since: str) -> int:
+        raise NotImplementedError
+
     def get_collection_cursor(self, source_site: str, search_url: str) -> int:
         raise NotImplementedError
 
@@ -843,6 +846,20 @@ class SqliteJobRepository:
                 (since,),
             ).fetchall()
         return [self._row_to_application_event(row) for row in rows]
+
+    def count_submitted_applications_since(self, since: str) -> int:
+        with self._connect() as connection:
+            row = connection.execute(
+                """
+                SELECT COUNT(1)
+                FROM job_applications
+                WHERE status = 'submitted'
+                  AND submitted_at IS NOT NULL
+                  AND submitted_at >= ?
+                """,
+                (since,),
+            ).fetchone()
+        return int((row[0] if row else 0) or 0)
 
     def get_collection_cursor(self, source_site: str, search_url: str) -> int:
         with self._connect() as connection:

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -369,6 +369,13 @@ class ParseArgsTests(IsolatedAsyncioTestCase):
         self.assertEqual(args.applications_command, "submit")
         self.assertEqual(args.id, 7)
 
+    async def test_parse_args_accepts_applications_auto_apply_command(self) -> None:
+        with patch("sys.argv", ["main.py", "applications", "auto-apply"]):
+            args = parse_args()
+
+        self.assertEqual(args.command, "applications")
+        self.assertEqual(args.applications_command, "auto-apply")
+
     async def test_parse_args_accepts_candidate_profile_suggest_command(self) -> None:
         with patch("sys.argv", ["main.py", "candidate-profile", "suggest"]):
             args = parse_args()

--- a/tests/test_app_bootstrap.py
+++ b/tests/test_app_bootstrap.py
@@ -3,6 +3,7 @@ from unittest.mock import patch
 
 from job_hunter_agent.application.app import JobHunterApplication
 from job_hunter_agent.application.cli_bootstrap import (
+    create_auto_apply_app,
     create_application_flow_app,
     create_query_app,
     create_review_app,
@@ -83,6 +84,31 @@ class JobHunterApplicationBootstrapTests(TestCase):
 
         initialize_query_mock.assert_called_once_with()
         initialize_review_mock.assert_not_called()
+        initialize_flow_mock.assert_called_once_with()
+        self.assertIs(app.repository, repository)
+        self.assertFalse(app.enable_telegram)
+
+    def test_create_auto_apply_app_initializes_review_and_flow_services(self) -> None:
+        settings = object()
+        repository = object()
+
+        with patch("job_hunter_agent.application.cli_bootstrap.load_settings", return_value=settings), patch(
+            "job_hunter_agent.application.cli_bootstrap.create_repository",
+            return_value=repository,
+        ), patch.object(
+            JobHunterApplication,
+            "_initialize_query_services",
+        ) as initialize_query_mock, patch.object(
+            JobHunterApplication,
+            "_initialize_review_services",
+        ) as initialize_review_mock, patch.object(
+            JobHunterApplication,
+            "_initialize_flow_services",
+        ) as initialize_flow_mock:
+            app = create_auto_apply_app()
+
+        initialize_query_mock.assert_called_once_with()
+        initialize_review_mock.assert_called_once_with()
         initialize_flow_mock.assert_called_once_with()
         self.assertIs(app.repository, repository)
         self.assertFalse(app.enable_telegram)

--- a/tests/test_application_cli_dispatch.py
+++ b/tests/test_application_cli_dispatch.py
@@ -89,6 +89,32 @@ class ApplicationCliDispatchTests(TestCase):
         asyncio_run.assert_called_once_with("preflight=7")
         print_mock.assert_called_once_with("preflight=7")
 
+    def test_execute_cli_command_dispatches_application_auto_apply(self) -> None:
+        fake_app = type(
+            "FakeApp",
+            (),
+            {
+                "run_auto_easy_apply_once": lambda self: "auto-apply ok",
+            },
+        )()
+
+        args = Namespace(
+            bootstrap_linkedin_session=False,
+            command="applications",
+            applications_command="auto-apply",
+            sem_telegram=True,
+        )
+
+        with patch(
+            "job_hunter_agent.application.application_cli_dispatch.create_auto_apply_app",
+            return_value=fake_app,
+        ) as app_factory, patch("builtins.print") as print_mock:
+            handled = execute_cli_command(args)
+
+        self.assertTrue(handled)
+        app_factory.assert_called_once_with()
+        print_mock.assert_called_once_with("auto-apply ok")
+
     def test_execute_cli_command_returns_false_for_scheduler_mode(self) -> None:
         args = Namespace(
             bootstrap_linkedin_session=False,

--- a/tests/test_auto_easy_apply.py
+++ b/tests/test_auto_easy_apply.py
@@ -1,0 +1,175 @@
+from __future__ import annotations
+
+from unittest import TestCase
+from unittest.mock import patch
+
+from job_hunter_agent.application.auto_easy_apply import AutoEasyApplyService
+from job_hunter_agent.core.domain import JobApplication, JobPosting
+
+
+def _job(*, job_id: int, relevance: int = 9, status: str = "approved") -> JobPosting:
+    return JobPosting(
+        id=job_id,
+        title="Backend Java",
+        company="ACME",
+        location="Brasil",
+        work_mode="remoto",
+        salary_text="Nao informado",
+        url=f"https://www.linkedin.com/jobs/view/{job_id}/",
+        source_site="LinkedIn",
+        summary="Java backend",
+        relevance=relevance,
+        rationale="fit",
+        external_key=f"key-{job_id}",
+        status=status,
+    )
+
+
+def _application(*, app_id: int, job_id: int, status: str = "authorized_submit") -> JobApplication:
+    return JobApplication(
+        id=app_id,
+        job_id=job_id,
+        status=status,
+        support_level="manual_review",
+    )
+
+
+class _FakeRepository:
+    def __init__(self, applications: list[JobApplication], jobs: dict[int, JobPosting], submitted_today: int = 0) -> None:
+        self._applications = applications
+        self._jobs = jobs
+        self.submitted_today = submitted_today
+
+    def count_submitted_applications_since(self, since: str) -> int:
+        return self.submitted_today
+
+    def list_applications_by_status(self, status: str) -> list[JobApplication]:
+        return [item for item in self._applications if item.status == status]
+
+    def get_job(self, job_id: int):
+        return self._jobs.get(job_id)
+
+    def get_application(self, application_id: int):
+        for item in self._applications:
+            if item.id == application_id:
+                return item
+        return None
+
+
+class _FakePreflight:
+    def run_for_application(self, application_id: int):
+        return type("Result", (), {"outcome": "ready", "detail": "ok"})()
+
+
+class _FakeTransitions:
+    def authorize_application(self, application_id: int) -> str:
+        return f"autorizada {application_id}"
+
+
+class _FakeSubmission:
+    def __init__(self) -> None:
+        self.called: list[int] = []
+
+    def run_for_application(self, application_id: int):
+        self.called.append(application_id)
+        return type("Result", (), {"outcome": "submitted", "detail": "ok"})()
+
+
+class AutoEasyApplyServiceTests(TestCase):
+    def _settings(self, **overrides):
+        base = {
+            "auto_easy_apply_enabled": True,
+            "auto_easy_apply_min_score": 8,
+            "auto_easy_apply_max_submits_per_cycle": 3,
+            "auto_easy_apply_max_submits_per_day": 10,
+            "auto_easy_apply_cooldown_seconds": 1,
+            "auto_easy_apply_max_consecutive_errors": 2,
+        }
+        base.update(overrides)
+        return type("Settings", (), base)()
+
+    def test_run_once_submits_authorized_jobs_within_limits(self) -> None:
+        repository = _FakeRepository(
+            applications=[_application(app_id=1, job_id=10)],
+            jobs={10: _job(job_id=10, relevance=9)},
+        )
+        submission = _FakeSubmission()
+        service = AutoEasyApplyService(
+            repository=repository,
+            preflight=_FakePreflight(),
+            submission=submission,
+            transitions=_FakeTransitions(),
+            settings=self._settings(auto_easy_apply_cooldown_seconds=0),
+        )
+
+        report = service.run_once()
+
+        self.assertEqual(report.submitted, 1)
+        self.assertEqual(report.blocked, 0)
+        self.assertEqual(report.skipped, 0)
+        self.assertEqual(submission.called, [1])
+
+    def test_run_once_skips_below_min_score(self) -> None:
+        repository = _FakeRepository(
+            applications=[_application(app_id=1, job_id=10)],
+            jobs={10: _job(job_id=10, relevance=6)},
+        )
+        service = AutoEasyApplyService(
+            repository=repository,
+            preflight=_FakePreflight(),
+            submission=_FakeSubmission(),
+            transitions=_FakeTransitions(),
+            settings=self._settings(),
+        )
+
+        report = service.run_once()
+
+        self.assertEqual(report.submitted, 0)
+        self.assertEqual(report.skipped, 1)
+        self.assertIn("score_abaixo_do_limiar", " | ".join(report.details))
+
+    def test_run_once_respects_daily_limit(self) -> None:
+        repository = _FakeRepository(
+            applications=[_application(app_id=1, job_id=10)],
+            jobs={10: _job(job_id=10)},
+            submitted_today=10,
+        )
+        service = AutoEasyApplyService(
+            repository=repository,
+            preflight=_FakePreflight(),
+            submission=_FakeSubmission(),
+            transitions=_FakeTransitions(),
+            settings=self._settings(auto_easy_apply_max_submits_per_day=10),
+        )
+
+        report = service.run_once()
+
+        self.assertEqual(report.submitted, 0)
+        self.assertEqual(report.blocked, 1)
+        self.assertIn("limite diario atingido", " | ".join(report.details))
+
+    def test_run_once_applies_cooldown_between_successful_submissions(self) -> None:
+        repository = _FakeRepository(
+            applications=[
+                _application(app_id=1, job_id=10),
+                _application(app_id=2, job_id=11),
+            ],
+            jobs={
+                10: _job(job_id=10, relevance=9),
+                11: _job(job_id=11, relevance=9),
+            },
+        )
+        submission = _FakeSubmission()
+        service = AutoEasyApplyService(
+            repository=repository,
+            preflight=_FakePreflight(),
+            submission=submission,
+            transitions=_FakeTransitions(),
+            settings=self._settings(auto_easy_apply_max_submits_per_cycle=2, auto_easy_apply_cooldown_seconds=3),
+        )
+
+        with patch("time.sleep") as sleep_mock:
+            report = service.run_once()
+
+        self.assertEqual(report.submitted, 2)
+        sleep_mock.assert_called_once_with(3)

--- a/tests/test_auto_easy_apply.py
+++ b/tests/test_auto_easy_apply.py
@@ -31,6 +31,7 @@ def _application(*, app_id: int, job_id: int, status: str = "authorized_submit")
         job_id=job_id,
         status=status,
         support_level="manual_review",
+        last_preflight_detail="preflight real ok | pronto_para_envio=sim",
     )
 
 
@@ -84,6 +85,11 @@ class AutoEasyApplyServiceTests(TestCase):
             "auto_easy_apply_max_submits_per_day": 10,
             "auto_easy_apply_cooldown_seconds": 1,
             "auto_easy_apply_max_consecutive_errors": 2,
+            "auto_easy_apply_max_blocks_same_reason": 5,
+            "auto_easy_apply_allowed_start_hour": 0,
+            "auto_easy_apply_allowed_end_hour": 0,
+            "auto_easy_apply_denylist_company_terms": (),
+            "auto_easy_apply_denylist_url_terms": (),
         }
         base.update(overrides)
         return type("Settings", (), base)()
@@ -173,3 +179,88 @@ class AutoEasyApplyServiceTests(TestCase):
 
         self.assertEqual(report.submitted, 2)
         sleep_mock.assert_called_once_with(3)
+
+    def test_run_once_skips_company_in_denylist(self) -> None:
+        repository = _FakeRepository(
+            applications=[_application(app_id=1, job_id=10)],
+            jobs={10: _job(job_id=10)},
+        )
+        service = AutoEasyApplyService(
+            repository=repository,
+            preflight=_FakePreflight(),
+            submission=_FakeSubmission(),
+            transitions=_FakeTransitions(),
+            settings=self._settings(auto_easy_apply_denylist_company_terms=("acme",)),
+        )
+
+        report = service.run_once()
+
+        self.assertEqual(report.submitted, 0)
+        self.assertEqual(report.skipped, 1)
+        self.assertIn("empresa_na_denylist", " | ".join(report.details))
+
+    def test_run_once_blocks_outside_allowed_window(self) -> None:
+        repository = _FakeRepository(
+            applications=[_application(app_id=1, job_id=10)],
+            jobs={10: _job(job_id=10)},
+        )
+        service = AutoEasyApplyService(
+            repository=repository,
+            preflight=_FakePreflight(),
+            submission=_FakeSubmission(),
+            transitions=_FakeTransitions(),
+            settings=self._settings(
+                auto_easy_apply_allowed_start_hour=10,
+                auto_easy_apply_allowed_end_hour=11,
+            ),
+        )
+
+        fake_now = type("FakeNow", (), {"hour": 12})()
+        with patch("job_hunter_agent.application.auto_easy_apply.datetime") as dt_mock:
+            dt_mock.now.return_value = fake_now
+            report = service.run_once()
+
+        self.assertEqual(report.submitted, 0)
+        self.assertEqual(report.blocked, 1)
+        self.assertIn("fora da janela horaria", " | ".join(report.details))
+
+    def test_run_once_stops_when_same_block_reason_reaches_limit(self) -> None:
+        class _ErrorSubmission:
+            def __init__(self) -> None:
+                self.called: list[int] = []
+
+            def run_for_application(self, application_id: int):
+                self.called.append(application_id)
+                return type("Result", (), {"outcome": "error", "detail": "falha"})()
+
+        repository = _FakeRepository(
+            applications=[
+                _application(app_id=1, job_id=10),
+                _application(app_id=2, job_id=11),
+                _application(app_id=3, job_id=12),
+            ],
+            jobs={
+                10: _job(job_id=10),
+                11: _job(job_id=11),
+                12: _job(job_id=12),
+            },
+        )
+        submission = _ErrorSubmission()
+        service = AutoEasyApplyService(
+            repository=repository,
+            preflight=_FakePreflight(),
+            submission=submission,
+            transitions=_FakeTransitions(),
+            settings=self._settings(
+                auto_easy_apply_cooldown_seconds=0,
+                auto_easy_apply_max_consecutive_errors=5,
+                auto_easy_apply_max_blocks_same_reason=2,
+            ),
+        )
+
+        report = service.run_once()
+
+        self.assertEqual(report.submitted, 0)
+        self.assertEqual(report.blocked, 2)
+        self.assertEqual(submission.called, [1, 2])
+        self.assertIn("parada por bloqueio repetido", " | ".join(report.details))


### PR DESCRIPTION
## Resumo
Implementa o primeiro fluxo de `applications auto-apply` com gates de seguranca e limites operacionais para envio assistido de Easy Apply.

## O que entrou
- Novo servico `AutoEasyApplyService` com relatorio operacional.
- Novo comando CLI: `python main.py applications auto-apply`.
- Configuracoes novas no `Settings`:
  - `auto_easy_apply_enabled`
  - `auto_easy_apply_min_score`
  - `auto_easy_apply_max_submits_per_cycle`
  - `auto_easy_apply_max_submits_per_day`
  - `auto_easy_apply_cooldown_seconds`
  - `auto_easy_apply_max_consecutive_errors`
  - `auto_easy_apply_max_blocks_same_reason`
  - `auto_easy_apply_allowed_start_hour`
  - `auto_easy_apply_allowed_end_hour`
  - `auto_easy_apply_denylist_company_terms`
  - `auto_easy_apply_denylist_url_terms`
- Gate adicional de preflight exigindo indicio explicito de Easy Apply (`pronto_para_envio=sim` ou `easy apply`).
- Stop por bloqueio repetido do mesmo motivo.
- Contagem diaria de candidaturas enviadas no repositório (`count_submitted_applications_since`).
- Checklist da feature em `docs/plans/AUTO_EASY_APPLY_GATES_LIMITS_CHECKLIST.md`.

## Testes
- `pytest tests/test_auto_easy_apply.py -q`
- `pytest tests/test_settings.py -q`
- `pytest tests/test_application_cli_dispatch.py tests/test_app.py tests/test_app_bootstrap.py -q`

Resultado local: todos passando.

## Observacao
Fluxo continua conservador por padrao (`auto_easy_apply_enabled=false`).