### PR TITLE
Integra auto-apply no ciclo principal com flag de runtime

### DIFF
--- a/docs/plans/AUTO_EASY_APPLY_GATES_LIMITS_CHECKLIST.md
+++ b/docs/plans/AUTO_EASY_APPLY_GATES_LIMITS_CHECKLIST.md
@@ -13,6 +13,7 @@ Permitir envio assistido em lote com segurancas explicitas para evitar submissao
 - [x] Implementar limites operacionais por ciclo e por dia.
 - [x] Implementar cooldown entre submits e circuit breaker por erros consecutivos.
 - [x] Expor comando CLI `applications auto-apply`.
+- [x] Integrar `auto-apply` no ciclo principal quando `auto_easy_apply_enabled=true`.
 - [x] Cobrir fluxo com testes unitarios.
 - [x] Executar suite de testes impactada.
 - [x] Endurecer gates avancados (detecao explicita de easy apply no detalhe, denylist configuravel, janela horaria e stop por bloqueios repetidos).

--- a/job_hunter_agent/application/app.py
+++ b/job_hunter_agent/application/app.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import logging
 from pathlib import Path
 
@@ -216,12 +217,16 @@ class JobHunterApplication:
         )
 
     async def run_collection_cycle(self) -> bool:
-        return await run_collection_cycle_runtime(
+        jobs_sent_for_review = await run_collection_cycle_runtime(
             self.repository,
             self.collector,
             self.notifier,
             logger=logger,
         )
+        if getattr(self.settings, "auto_easy_apply_enabled", False):
+            auto_apply_report = await asyncio.to_thread(self.run_auto_easy_apply_once)
+            logger.info("Execucao auto easy apply apos ciclo:\n%s", auto_apply_report)
+        return jobs_sent_for_review
 
     async def wait_for_review_window(self) -> None:
         await wait_for_review_window_runtime(

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import asyncio
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 from unittest import IsolatedAsyncioTestCase
 
 from job_hunter_agent.application.app import JobHunterApplication, parse_args, suggest_candidate_profile
@@ -279,6 +279,48 @@ class JobHunterApplicationRunTests(IsolatedAsyncioTestCase):
         self.assertEqual(called, [(2, 15)])
         self.assertTrue(app.notifier.started)
         self.assertTrue(app.notifier.stopped)
+
+    async def test_run_collection_cycle_triggers_auto_apply_when_enabled(self) -> None:
+        app = JobHunterApplication.__new__(JobHunterApplication)
+        app.repository = object()
+        app.collector = object()
+        app.notifier = object()
+        app.settings = type("Settings", (), {"auto_easy_apply_enabled": True})()
+        app.run_auto_easy_apply_once = lambda: "auto-report"
+
+        with patch(
+            "job_hunter_agent.application.app.run_collection_cycle_runtime",
+            new=AsyncMock(return_value=True),
+        ) as runtime_mock, patch(
+            "job_hunter_agent.application.app.asyncio.to_thread",
+            new=AsyncMock(return_value="auto-report"),
+        ) as to_thread_mock:
+            jobs_sent = await app.run_collection_cycle()
+
+        self.assertTrue(jobs_sent)
+        runtime_mock.assert_awaited_once()
+        to_thread_mock.assert_awaited_once_with(app.run_auto_easy_apply_once)
+
+    async def test_run_collection_cycle_skips_auto_apply_when_disabled(self) -> None:
+        app = JobHunterApplication.__new__(JobHunterApplication)
+        app.repository = object()
+        app.collector = object()
+        app.notifier = object()
+        app.settings = type("Settings", (), {"auto_easy_apply_enabled": False})()
+        app.run_auto_easy_apply_once = lambda: "auto-report"
+
+        with patch(
+            "job_hunter_agent.application.app.run_collection_cycle_runtime",
+            new=AsyncMock(return_value=False),
+        ) as runtime_mock, patch(
+            "job_hunter_agent.application.app.asyncio.to_thread",
+            new=AsyncMock(return_value="auto-report"),
+        ) as to_thread_mock:
+            jobs_sent = await app.run_collection_cycle()
+
+        self.assertFalse(jobs_sent)
+        runtime_mock.assert_awaited_once()
+        to_thread_mock.assert_not_awaited()
 
 
 class ParseArgsTests(IsolatedAsyncioTestCase):

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -431,7 +431,7 @@ class ParseArgsTests(IsolatedAsyncioTestCase):
 
         self.assertEqual(args.command, "worker")
         self.assertEqual(args.worker_command, "collect")
-        self.assertEqual(str(args.output), "logs\\events.ndjson")
+        self.assertEqual(args.output, Path("logs/events.ndjson"))
 
     async def test_parse_args_accepts_worker_match_command(self) -> None:
         with patch(
@@ -452,9 +452,9 @@ class ParseArgsTests(IsolatedAsyncioTestCase):
 
         self.assertEqual(args.command, "worker")
         self.assertEqual(args.worker_command, "match")
-        self.assertEqual(str(args.input), "logs\\in.ndjson")
-        self.assertEqual(str(args.output), "logs\\out.ndjson")
-        self.assertEqual(str(args.state), "logs\\state.json")
+        self.assertEqual(args.input, Path("logs/in.ndjson"))
+        self.assertEqual(args.output, Path("logs/out.ndjson"))
+        self.assertEqual(args.state, Path("logs/state.json"))
 
     async def test_parse_args_rejects_operational_command_with_agora(self) -> None:
         with patch("sys.argv", ["main.py", "--agora", "applications", "list"]):


### PR DESCRIPTION
## Resumo
Integra o fluxo de auto easy apply no ciclo principal de execução, acionado apenas quando `JOB_HUNTER_AUTO_EASY_APPLY_ENABLED=true`.

## O que mudou
- `JobHunterApplication.run_collection_cycle` agora executa `run_auto_easy_apply_once` ao final do ciclo quando a flag está habilitada.
- O relatório de auto-apply passa a ser registrado em log ao final do ciclo.
- Checklist operacional de auto-apply atualizada com o item de integração no ciclo principal.

## Validação de código
- `pytest tests/test_app.py -q`
- `pytest tests/test_auto_easy_apply.py -q`
- `pytest tests/test_application_cli_dispatch.py tests/test_app_bootstrap.py tests/test_settings.py -q`

## Validação prática (runtime)
Execução real com flag habilitada confirmou a integração no fluxo:
- coleta executou normalmente
- auto-apply rodou automaticamente após o ciclo
- log incluiu `Execucao auto easy apply apos ciclo`
- gates bloquearam com segurança casos fora de condição (`preflight_sem_easy_apply_explicito`, `empresa_na_denylist`)

## Observação
Comportamento padrão permanece conservador: com a flag desabilitada, nada muda no ciclo atual.