### PR TITLE
Adiciona eventos de domínio de review e candidatura

### DIFF
--- a/job_hunter_agent/core/event_bus.py
+++ b/job_hunter_agent/core/event_bus.py
@@ -4,13 +4,17 @@ from pathlib import Path
 from typing import Protocol
 
 from job_hunter_agent.core.events import (
+    ApplicationAuthorizedV1,
+    ApplicationBlockedV1,
+    ApplicationSubmittedV1,
+    DomainEvent,
     JobCollectedV1,
+    JobReviewRequestedV1,
+    JobReviewedV1,
     JobScoredV1,
     event_from_json,
     event_to_json,
 )
-
-DomainEvent = JobCollectedV1 | JobScoredV1
 
 
 class EventBusPort(Protocol):
@@ -51,3 +55,18 @@ class LocalNdjsonEventBus:
 
     def read_job_scored(self) -> tuple[JobScoredV1, ...]:
         return tuple(event for event in self.read_all() if isinstance(event, JobScoredV1))
+
+    def read_job_review_requested(self) -> tuple[JobReviewRequestedV1, ...]:
+        return tuple(event for event in self.read_all() if isinstance(event, JobReviewRequestedV1))
+
+    def read_job_reviewed(self) -> tuple[JobReviewedV1, ...]:
+        return tuple(event for event in self.read_all() if isinstance(event, JobReviewedV1))
+
+    def read_application_authorized(self) -> tuple[ApplicationAuthorizedV1, ...]:
+        return tuple(event for event in self.read_all() if isinstance(event, ApplicationAuthorizedV1))
+
+    def read_application_submitted(self) -> tuple[ApplicationSubmittedV1, ...]:
+        return tuple(event for event in self.read_all() if isinstance(event, ApplicationSubmittedV1))
+
+    def read_application_blocked(self) -> tuple[ApplicationBlockedV1, ...]:
+        return tuple(event for event in self.read_all() if isinstance(event, ApplicationBlockedV1))

--- a/job_hunter_agent/core/events.py
+++ b/job_hunter_agent/core/events.py
@@ -44,27 +44,119 @@ class JobScoredV1:
     correlation_id: str = ""
 
 
-def event_to_dict(event: JobCollectedV1 | JobScoredV1) -> dict[str, Any]:
+@dataclass(frozen=True)
+class JobReviewRequestedV1:
+    job_id: int
+    external_key: str
+    source_site: str
+    relevance: int
+    reason: str = ""
+    event_id: str = field(default_factory=new_event_id)
+    event_type: str = "JobReviewRequestedV1"
+    event_version: int = 1
+    occurred_at: str = field(default_factory=utc_now_iso)
+    correlation_id: str = ""
+
+
+@dataclass(frozen=True)
+class JobReviewedV1:
+    job_id: int
+    decision: str
+    status: str
+    reviewed_by: str = ""
+    notes: str = ""
+    external_key: str = ""
+    event_id: str = field(default_factory=new_event_id)
+    event_type: str = "JobReviewedV1"
+    event_version: int = 1
+    occurred_at: str = field(default_factory=utc_now_iso)
+    correlation_id: str = ""
+
+
+@dataclass(frozen=True)
+class ApplicationAuthorizedV1:
+    application_id: int
+    job_id: int
+    authorized_by: str = ""
+    authorization_source: str = "manual"
+    status: str = "authorized_submit"
+    event_id: str = field(default_factory=new_event_id)
+    event_type: str = "ApplicationAuthorizedV1"
+    event_version: int = 1
+    occurred_at: str = field(default_factory=utc_now_iso)
+    correlation_id: str = ""
+
+
+@dataclass(frozen=True)
+class ApplicationSubmittedV1:
+    application_id: int
+    job_id: int
+    portal: str
+    confirmation_reference: str = ""
+    submitted_url: str = ""
+    event_id: str = field(default_factory=new_event_id)
+    event_type: str = "ApplicationSubmittedV1"
+    event_version: int = 1
+    occurred_at: str = field(default_factory=utc_now_iso)
+    correlation_id: str = ""
+
+
+@dataclass(frozen=True)
+class ApplicationBlockedV1:
+    application_id: int
+    job_id: int
+    reason: str
+    detail: str = ""
+    retryable: bool = False
+    event_id: str = field(default_factory=new_event_id)
+    event_type: str = "ApplicationBlockedV1"
+    event_version: int = 1
+    occurred_at: str = field(default_factory=utc_now_iso)
+    correlation_id: str = ""
+
+
+DomainEvent = (
+    JobCollectedV1
+    | JobScoredV1
+    | JobReviewRequestedV1
+    | JobReviewedV1
+    | ApplicationAuthorizedV1
+    | ApplicationSubmittedV1
+    | ApplicationBlockedV1
+)
+
+
+def event_to_dict(event: DomainEvent) -> dict[str, Any]:
     return asdict(event)
 
 
-def event_to_json(event: JobCollectedV1 | JobScoredV1) -> str:
+def event_to_json(event: DomainEvent) -> str:
     return json.dumps(event_to_dict(event), ensure_ascii=False, separators=(",", ":"))
 
 
-def event_from_json(payload: str) -> JobCollectedV1 | JobScoredV1:
+def event_from_json(payload: str) -> DomainEvent:
     decoded = json.loads(payload)
     if not isinstance(decoded, dict):
         raise ValueError("Evento deve ser um objeto JSON.")
     return event_from_dict(decoded)
 
 
-def event_from_dict(payload: dict[str, Any]) -> JobCollectedV1 | JobScoredV1:
+def event_from_dict(payload: dict[str, Any]) -> DomainEvent:
     event_type = str(payload.get("event_type") or "").strip()
     if event_type == "JobCollectedV1" or _looks_like_legacy_job_collected(payload):
         return job_collected_from_dict(payload)
     if event_type == "JobScoredV1" or _looks_like_legacy_job_scored(payload):
         return job_scored_from_dict(payload)
+    if event_type == "JobReviewRequestedV1":
+        return job_review_requested_from_dict(payload)
+    if event_type == "JobReviewedV1":
+        return job_reviewed_from_dict(payload)
+    if event_type == "ApplicationAuthorizedV1":
+        return application_authorized_from_dict(payload)
+    if event_type == "ApplicationSubmittedV1":
+        return application_submitted_from_dict(payload)
+    if event_type == "ApplicationBlockedV1":
+        return application_blocked_from_dict(payload)
     raise ValueError(f"Tipo de evento nao suportado: {event_type or '<ausente>'}")
 
 
@@ -90,10 +182,86 @@ def job_scored_from_dict(payload: dict[str, Any]) -> JobScoredV1:
     return JobScoredV1(
         run_id=_safe_int(payload.get("run_id")),
         external_key=_safe_str(payload.get("external_key")),
-        accepted=bool(payload.get("accepted")),
+        accepted=_safe_bool(payload.get("accepted")),
         relevance=_safe_int(payload.get("relevance")),
         event_id=_safe_str(payload.get("event_id")) or new_event_id(),
         event_type="JobScoredV1",
+        event_version=_safe_int(payload.get("event_version")) or 1,
+        occurred_at=_safe_str(payload.get("occurred_at")) or utc_now_iso(),
+        correlation_id=_safe_str(payload.get("correlation_id")),
+    )
+
+
+def job_review_requested_from_dict(payload: dict[str, Any]) -> JobReviewRequestedV1:
+    return JobReviewRequestedV1(
+        job_id=_safe_int(payload.get("job_id")),
+        external_key=_safe_str(payload.get("external_key")),
+        source_site=_safe_str(payload.get("source_site")),
+        relevance=_safe_int(payload.get("relevance")),
+        reason=_safe_str(payload.get("reason")),
+        event_id=_safe_str(payload.get("event_id")) or new_event_id(),
+        event_type="JobReviewRequestedV1",
+        event_version=_safe_int(payload.get("event_version")) or 1,
+        occurred_at=_safe_str(payload.get("occurred_at")) or utc_now_iso(),
+        correlation_id=_safe_str(payload.get("correlation_id")),
+    )
+
+
+def job_reviewed_from_dict(payload: dict[str, Any]) -> JobReviewedV1:
+    return JobReviewedV1(
+        job_id=_safe_int(payload.get("job_id")),
+        decision=_safe_str(payload.get("decision")),
+        status=_safe_str(payload.get("status")),
+        reviewed_by=_safe_str(payload.get("reviewed_by")),
+        notes=_safe_str(payload.get("notes")),
+        external_key=_safe_str(payload.get("external_key")),
+        event_id=_safe_str(payload.get("event_id")) or new_event_id(),
+        event_type="JobReviewedV1",
+        event_version=_safe_int(payload.get("event_version")) or 1,
+        occurred_at=_safe_str(payload.get("occurred_at")) or utc_now_iso(),
+        correlation_id=_safe_str(payload.get("correlation_id")),
+    )
+
+
+def application_authorized_from_dict(payload: dict[str, Any]) -> ApplicationAuthorizedV1:
+    return ApplicationAuthorizedV1(
+        application_id=_safe_int(payload.get("application_id")),
+        job_id=_safe_int(payload.get("job_id")),
+        authorized_by=_safe_str(payload.get("authorized_by")),
+        authorization_source=_safe_str(payload.get("authorization_source")) or "manual",
+        status=_safe_str(payload.get("status")) or "authorized_submit",
+        event_id=_safe_str(payload.get("event_id")) or new_event_id(),
+        event_type="ApplicationAuthorizedV1",
+        event_version=_safe_int(payload.get("event_version")) or 1,
+        occurred_at=_safe_str(payload.get("occurred_at")) or utc_now_iso(),
+        correlation_id=_safe_str(payload.get("correlation_id")),
+    )
+
+
+def application_submitted_from_dict(payload: dict[str, Any]) -> ApplicationSubmittedV1:
+    return ApplicationSubmittedV1(
+        application_id=_safe_int(payload.get("application_id")),
+        job_id=_safe_int(payload.get("job_id")),
+        portal=_safe_str(payload.get("portal")),
+        confirmation_reference=_safe_str(payload.get("confirmation_reference")),
+        submitted_url=_safe_str(payload.get("submitted_url")),
+        event_id=_safe_str(payload.get("event_id")) or new_event_id(),
+        event_type="ApplicationSubmittedV1",
+        event_version=_safe_int(payload.get("event_version")) or 1,
+        occurred_at=_safe_str(payload.get("occurred_at")) or utc_now_iso(),
+        correlation_id=_safe_str(payload.get("correlation_id")),
+    )
+
+
+def application_blocked_from_dict(payload: dict[str, Any]) -> ApplicationBlockedV1:
+    return ApplicationBlockedV1(
+        application_id=_safe_int(payload.get("application_id")),
+        job_id=_safe_int(payload.get("job_id")),
+        reason=_safe_str(payload.get("reason")),
+        detail=_safe_str(payload.get("detail")),
+        retryable=_safe_bool(payload.get("retryable")),
+        event_id=_safe_str(payload.get("event_id")) or new_event_id(),
+        event_type="ApplicationBlockedV1",
         event_version=_safe_int(payload.get("event_version")) or 1,
         occurred_at=_safe_str(payload.get("occurred_at")) or utc_now_iso(),
         correlation_id=_safe_str(payload.get("correlation_id")),
@@ -131,6 +299,14 @@ def _looks_like_legacy_job_collected(payload: dict[str, Any]) -> bool:
 
 def _looks_like_legacy_job_scored(payload: dict[str, Any]) -> bool:
     return "external_key" in payload and "accepted" in payload and "relevance" in payload
+
+
+def _safe_bool(value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return value.strip().lower() in {"1", "true", "yes", "y", "sim", "s"}
+    return bool(value)
 
 
 def _safe_int(value: Any) -> int:

--- a/job_hunter_agent/core/idempotency.py
+++ b/job_hunter_agent/core/idempotency.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from job_hunter_agent.core.events import JobCollectedV1, JobScoredV1
+from job_hunter_agent.core.events import DomainEvent, JobCollectedV1
 
 
 def normalize_idempotency_part(value: object) -> str:
@@ -22,7 +22,7 @@ def build_job_scoring_key(*, event: JobCollectedV1, external_key: str) -> str:
     )
 
 
-def build_event_processing_key(*, event: JobCollectedV1 | JobScoredV1, subject: str = "") -> str:
+def build_event_processing_key(*, event: DomainEvent, subject: str = "") -> str:
     event_subject = normalize_idempotency_part(subject) or normalize_idempotency_part(event.event_id)
     return build_event_subject_key(
         event_type=event.event_type,

--- a/tests/test_event_bus.py
+++ b/tests/test_event_bus.py
@@ -5,7 +5,15 @@ from unittest import TestCase
 
 from job_hunter_agent.core.domain import JobPosting
 from job_hunter_agent.core.event_bus import LocalNdjsonEventBus
-from job_hunter_agent.core.events import JobCollectedV1, JobScoredV1
+from job_hunter_agent.core.events import (
+    ApplicationAuthorizedV1,
+    ApplicationBlockedV1,
+    ApplicationSubmittedV1,
+    JobCollectedV1,
+    JobReviewRequestedV1,
+    JobReviewedV1,
+    JobScoredV1,
+)
 from tests.tmp_workspace import prepare_workspace_tmp_dir
 
 
@@ -86,6 +94,53 @@ class LocalNdjsonEventBusTests(TestCase):
 
         self.assertEqual(len(bus.read_job_collected()), 1)
         self.assertEqual(len(bus.read_job_scored()), 1)
+
+    def test_read_helpers_filter_domain_review_and_application_events(self) -> None:
+        bus = LocalNdjsonEventBus(self.events_path)
+        bus.publish(
+            JobReviewRequestedV1(
+                job_id=123,
+                external_key="job-key-123",
+                source_site="LinkedIn",
+                relevance=9,
+            )
+        )
+        bus.publish(
+            JobReviewedV1(
+                job_id=123,
+                decision="approve",
+                status="approved",
+            )
+        )
+        bus.publish(
+            ApplicationAuthorizedV1(
+                application_id=55,
+                job_id=123,
+            )
+        )
+        bus.publish(
+            ApplicationSubmittedV1(
+                application_id=55,
+                job_id=123,
+                portal="LinkedIn",
+            )
+        )
+        bus.publish(
+            ApplicationBlockedV1(
+                application_id=56,
+                job_id=124,
+                reason="outside_schedule",
+                retryable=True,
+            )
+        )
+
+        self.assertEqual(len(bus.read_job_review_requested()), 1)
+        self.assertEqual(len(bus.read_job_reviewed()), 1)
+        self.assertEqual(len(bus.read_application_authorized()), 1)
+        self.assertEqual(len(bus.read_application_submitted()), 1)
+        self.assertEqual(len(bus.read_application_blocked()), 1)
+        self.assertEqual(bus.read_application_blocked()[0].reason, "outside_schedule")
+        self.assertTrue(bus.read_application_blocked()[0].retryable)
 
     def test_read_all_ignores_invalid_lines(self) -> None:
         self.events_path.parent.mkdir(parents=True, exist_ok=True)

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -4,7 +4,12 @@ from unittest import TestCase
 
 from job_hunter_agent.core.domain import JobPosting
 from job_hunter_agent.core.events import (
+    ApplicationAuthorizedV1,
+    ApplicationBlockedV1,
+    ApplicationSubmittedV1,
     JobCollectedV1,
+    JobReviewRequestedV1,
+    JobReviewedV1,
     JobScoredV1,
     event_from_dict,
     event_from_json,
@@ -77,6 +82,123 @@ class EventContractTests(TestCase):
         self.assertEqual(decoded.external_key, "job-key-123")
         self.assertTrue(decoded.accepted)
         self.assertEqual(decoded.relevance, 9)
+
+    def test_job_review_requested_round_trip_json_preserves_payload_and_metadata(self) -> None:
+        event = JobReviewRequestedV1(
+            job_id=123,
+            external_key="job-key-123",
+            source_site="LinkedIn",
+            relevance=9,
+            reason="accepted_by_matching",
+            event_id="evt-review-requested",
+            occurred_at="2026-04-24T12:02:00+00:00",
+            correlation_id="collection-run:7",
+        )
+
+        decoded = event_from_json(event_to_json(event))
+
+        self.assertIsInstance(decoded, JobReviewRequestedV1)
+        self.assertEqual(decoded.event_type, "JobReviewRequestedV1")
+        self.assertEqual(decoded.event_version, 1)
+        self.assertEqual(decoded.event_id, "evt-review-requested")
+        self.assertEqual(decoded.job_id, 123)
+        self.assertEqual(decoded.external_key, "job-key-123")
+        self.assertEqual(decoded.source_site, "LinkedIn")
+        self.assertEqual(decoded.relevance, 9)
+        self.assertEqual(decoded.reason, "accepted_by_matching")
+        self.assertEqual(decoded.correlation_id, "collection-run:7")
+
+    def test_job_reviewed_round_trip_json_preserves_payload_and_metadata(self) -> None:
+        event = JobReviewedV1(
+            job_id=123,
+            decision="approve",
+            status="approved",
+            reviewed_by="telegram",
+            notes="boa vaga",
+            external_key="job-key-123",
+            event_id="evt-reviewed",
+            occurred_at="2026-04-24T12:03:00+00:00",
+            correlation_id="collection-run:7",
+        )
+
+        decoded = event_from_json(event_to_json(event))
+
+        self.assertIsInstance(decoded, JobReviewedV1)
+        self.assertEqual(decoded.event_type, "JobReviewedV1")
+        self.assertEqual(decoded.job_id, 123)
+        self.assertEqual(decoded.decision, "approve")
+        self.assertEqual(decoded.status, "approved")
+        self.assertEqual(decoded.reviewed_by, "telegram")
+        self.assertEqual(decoded.notes, "boa vaga")
+        self.assertEqual(decoded.external_key, "job-key-123")
+
+    def test_application_authorized_round_trip_json_preserves_payload_and_metadata(self) -> None:
+        event = ApplicationAuthorizedV1(
+            application_id=55,
+            job_id=123,
+            authorized_by="cli",
+            authorization_source="manual",
+            event_id="evt-authorized",
+            occurred_at="2026-04-24T12:04:00+00:00",
+            correlation_id="application:55",
+        )
+
+        decoded = event_from_json(event_to_json(event))
+
+        self.assertIsInstance(decoded, ApplicationAuthorizedV1)
+        self.assertEqual(decoded.event_type, "ApplicationAuthorizedV1")
+        self.assertEqual(decoded.application_id, 55)
+        self.assertEqual(decoded.job_id, 123)
+        self.assertEqual(decoded.authorized_by, "cli")
+        self.assertEqual(decoded.authorization_source, "manual")
+        self.assertEqual(decoded.status, "authorized_submit")
+        self.assertEqual(decoded.correlation_id, "application:55")
+
+    def test_application_submitted_round_trip_json_preserves_payload_and_metadata(self) -> None:
+        event = ApplicationSubmittedV1(
+            application_id=55,
+            job_id=123,
+            portal="LinkedIn",
+            confirmation_reference="ok-123",
+            submitted_url="https://www.linkedin.com/jobs/view/123/",
+            event_id="evt-submitted",
+            occurred_at="2026-04-24T12:05:00+00:00",
+            correlation_id="application:55",
+        )
+
+        decoded = event_from_json(event_to_json(event))
+
+        self.assertIsInstance(decoded, ApplicationSubmittedV1)
+        self.assertEqual(decoded.event_type, "ApplicationSubmittedV1")
+        self.assertEqual(decoded.application_id, 55)
+        self.assertEqual(decoded.job_id, 123)
+        self.assertEqual(decoded.portal, "LinkedIn")
+        self.assertEqual(decoded.confirmation_reference, "ok-123")
+        self.assertEqual(decoded.submitted_url, "https://www.linkedin.com/jobs/view/123/")
+        self.assertEqual(decoded.correlation_id, "application:55")
+
+    def test_application_blocked_round_trip_json_preserves_payload_and_metadata(self) -> None:
+        event = ApplicationBlockedV1(
+            application_id=55,
+            job_id=123,
+            reason="outside_schedule",
+            detail="janela operacional fechada",
+            retryable=True,
+            event_id="evt-blocked",
+            occurred_at="2026-04-24T12:06:00+00:00",
+            correlation_id="application:55",
+        )
+
+        decoded = event_from_json(event_to_json(event))
+
+        self.assertIsInstance(decoded, ApplicationBlockedV1)
+        self.assertEqual(decoded.event_type, "ApplicationBlockedV1")
+        self.assertEqual(decoded.application_id, 55)
+        self.assertEqual(decoded.job_id, 123)
+        self.assertEqual(decoded.reason, "outside_schedule")
+        self.assertEqual(decoded.detail, "janela operacional fechada")
+        self.assertTrue(decoded.retryable)
+        self.assertEqual(decoded.correlation_id, "application:55")
 
     def test_job_collected_accepts_legacy_payload_without_event_metadata(self) -> None:
         legacy_payload = {


### PR DESCRIPTION
## Resumo

Adiciona contratos versionados para eventos de domínio de review e candidatura, mantendo a mudança limitada a contratos, serialização e testes.

## O que entrou

- Novos eventos em `job_hunter_agent/core/events.py`:
  - `JobReviewRequestedV1`
  - `JobReviewedV1`
  - `ApplicationAuthorizedV1`
  - `ApplicationSubmittedV1`
  - `ApplicationBlockedV1`
- `DomainEvent` ampliado para incluir os novos contratos.
- `event_from_dict` / `event_from_json` atualizados para desserializar os novos eventos.
- `LocalNdjsonEventBus` ampliado com helpers de leitura por tipo.
- `build_event_processing_key` atualizado para aceitar o union `DomainEvent`.

## Validacao

- Testes de round-trip JSON para todos os eventos novos.
- Testes do event bus local com filtros para eventos de review/application.

## Escopo consciente

- Sem alterar fluxo runtime de review/candidatura ainda.
- Sem broker externo.
- Sem Docker/Compose nesta frente.
- Sem migracao de banco.

## Proximo passo sugerido

Integrar esses eventos aos pontos reais de transição, começando por review de vagas e autorização/submissão de candidaturas.