### PR TITLE
Publica eventos de transição de domínio

### DIFF
--- a/job_hunter_agent/application/application_commands.py
+++ b/job_hunter_agent/application/application_commands.py
@@ -7,12 +7,15 @@ from job_hunter_agent.application.application_messages import (
 )
 from job_hunter_agent.application.contracts import PreparationPort
 from job_hunter_agent.application.review_workflow import resolve_application_action, resolve_review_action
+from job_hunter_agent.core.event_bus import EventBusPort
+from job_hunter_agent.core.events import ApplicationAuthorizedV1, JobReviewedV1
 from job_hunter_agent.infrastructure.repository import JobRepository
 
 
 class JobReviewCommandService:
-    def __init__(self, repository: JobRepository) -> None:
+    def __init__(self, repository: JobRepository, event_bus: EventBusPort | None = None) -> None:
         self.repository = repository
+        self.event_bus = event_bus
 
     def review_job(self, job_id: int, action: str) -> str:
         job = self.repository.get_job(job_id)
@@ -22,6 +25,18 @@ class JobReviewCommandService:
         if next_status is None:
             return detail
         self.repository.mark_status(job_id, next_status, detail=detail)
+        if self.event_bus is not None:
+            self.event_bus.publish(
+                JobReviewedV1(
+                    job_id=job_id,
+                    decision=action,
+                    status=next_status,
+                    reviewed_by="command",
+                    notes=detail,
+                    external_key=job.external_key,
+                    correlation_id=f"job:{job_id}",
+                )
+            )
         return detail
 
 
@@ -60,8 +75,9 @@ class ApplicationDraftCommandService:
 
 
 class ApplicationTransitionCommandService:
-    def __init__(self, repository: JobRepository) -> None:
+    def __init__(self, repository: JobRepository, event_bus: EventBusPort | None = None) -> None:
         self.repository = repository
+        self.event_bus = event_bus
 
     def transition_application(self, application_id: int, action: str) -> str:
         application = self.repository.get_application(application_id)
@@ -71,6 +87,17 @@ class ApplicationTransitionCommandService:
         if next_status is None:
             return detail
         self.repository.mark_application_status(application_id, status=next_status, event_detail=detail)
+        if self.event_bus is not None and next_status == "authorized_submit":
+            self.event_bus.publish(
+                ApplicationAuthorizedV1(
+                    application_id=application_id,
+                    job_id=application.job_id,
+                    authorized_by="command",
+                    authorization_source="manual",
+                    status=next_status,
+                    correlation_id=f"application:{application_id}",
+                )
+            )
         return detail
 
     def authorize_application(self, application_id: int) -> str:

--- a/job_hunter_agent/application/application_submission.py
+++ b/job_hunter_agent/application/application_submission.py
@@ -22,6 +22,8 @@ from job_hunter_agent.application.application_ports import (
     normalize_application_submission_result,
 )
 from job_hunter_agent.application.application_readiness import ApplicationReadinessCheckService
+from job_hunter_agent.core.event_bus import EventBusPort
+from job_hunter_agent.core.events import ApplicationBlockedV1, ApplicationSubmittedV1
 from job_hunter_agent.core.portal_capabilities import get_portal_capabilities
 from job_hunter_agent.infrastructure.repository import JobRepository
 
@@ -39,11 +41,13 @@ class ApplicationSubmissionService:
         repository: JobRepository,
         applicant: SubmitPort | None = None,
         readiness_checker: ApplicationReadinessCheckService | None = None,
+        event_bus: EventBusPort | None = None,
     ) -> None:
         self.repository = repository
         self.applicant = applicant
         self.flow = ApplicationFlowCoordinator(repository)
         self.readiness_checker = readiness_checker
+        self.event_bus = event_bus
 
     def run_dry_run_for_application(self, application_id: int) -> ApplicationSubmitResult:
         context = load_application_context(self.repository, application_id)
@@ -120,6 +124,13 @@ class ApplicationSubmissionService:
                 notes=append_note(application.notes, detail),
                 last_error=detail,
             )
+            self._publish_blocked_event(
+                application_id=application.id,
+                job_id=job.id or application.job_id,
+                reason="preflight_not_ready",
+                detail=detail,
+                retryable=True,
+            )
             return ApplicationSubmitResult(
                 outcome="ignored",
                 detail=detail,
@@ -134,6 +145,13 @@ class ApplicationSubmissionService:
                 status="error_submit",
                 notes=append_note(application.notes, detail),
                 last_error=detail,
+            )
+            self._publish_blocked_event(
+                application_id=application.id,
+                job_id=job.id or application.job_id,
+                reason="portal_not_supported",
+                detail=detail,
+                retryable=False,
             )
             return ApplicationSubmitResult(
                 outcome="blocked",
@@ -151,6 +169,13 @@ class ApplicationSubmissionService:
                     notes=append_note(application.notes, detail),
                     last_error="",
                 )
+                self._publish_blocked_event(
+                    application_id=application.id,
+                    job_id=job.id or application.job_id,
+                    reason="readiness_incomplete",
+                    detail=detail,
+                    retryable=True,
+                )
                 return ApplicationSubmitResult(
                     outcome="ignored",
                     detail=detail,
@@ -165,6 +190,13 @@ class ApplicationSubmissionService:
                 event_type="submit_ignored",
                 status="authorized_submit",
                 clear_error=True,
+            )
+            self._publish_blocked_event(
+                application_id=application.id,
+                job_id=job.id or application.job_id,
+                reason="submit_unavailable",
+                detail=detail,
+                retryable=True,
             )
             return ApplicationSubmitResult(
                 outcome="ignored",
@@ -183,6 +215,13 @@ class ApplicationSubmissionService:
                 status="error_submit",
                 clear_error=False,
             )
+            self._publish_blocked_event(
+                application_id=application.id,
+                job_id=job.id or application.job_id,
+                reason="applicant_error",
+                detail=detail,
+                retryable=True,
+            )
             return ApplicationSubmitResult(
                 outcome="error",
                 detail=detail,
@@ -200,6 +239,17 @@ class ApplicationSubmissionService:
                 clear_error=True,
                 submitted_at=self.flow.resolve_submitted_at(result.submitted_at),
             )
+            if self.event_bus is not None:
+                self.event_bus.publish(
+                    ApplicationSubmittedV1(
+                        application_id=application.id,
+                        job_id=job.id or application.job_id,
+                        portal=capabilities.portal_name,
+                        confirmation_reference=result.external_reference,
+                        submitted_url=job.url,
+                        correlation_id=f"application:{application.id}",
+                    )
+                )
             return ApplicationSubmitResult(
                 outcome="submitted",
                 detail=detail,
@@ -213,10 +263,39 @@ class ApplicationSubmissionService:
             status="error_submit",
             clear_error=False,
         )
+        self._publish_blocked_event(
+            application_id=application.id,
+            job_id=job.id or application.job_id,
+            reason="submit_not_completed",
+            detail=detail,
+            retryable=True,
+        )
         return ApplicationSubmitResult(
             outcome="error",
             detail=detail,
             application_status=application_status,
+        )
+
+    def _publish_blocked_event(
+        self,
+        *,
+        application_id: int | None,
+        job_id: int,
+        reason: str,
+        detail: str,
+        retryable: bool,
+    ) -> None:
+        if self.event_bus is None or application_id is None:
+            return
+        self.event_bus.publish(
+            ApplicationBlockedV1(
+                application_id=application_id,
+                job_id=job_id,
+                reason=reason,
+                detail=detail,
+                retryable=retryable,
+                correlation_id=f"application:{application_id}",
+            )
         )
 
 

--- a/tests/test_domain_transition_events.py
+++ b/tests/test_domain_transition_events.py
@@ -1,0 +1,220 @@
+from __future__ import annotations
+
+from unittest import TestCase
+
+from job_hunter_agent.application.application_commands import (
+    ApplicationTransitionCommandService,
+    JobReviewCommandService,
+)
+from job_hunter_agent.application.application_submission import ApplicationSubmissionService
+from job_hunter_agent.application.contracts import ApplicationSubmissionResult
+from job_hunter_agent.core.domain import JobApplication, JobPosting
+from job_hunter_agent.core.events import (
+    ApplicationAuthorizedV1,
+    ApplicationBlockedV1,
+    ApplicationSubmittedV1,
+    DomainEvent,
+    JobReviewedV1,
+)
+
+
+class _EventBus:
+    def __init__(self) -> None:
+        self.events: list[DomainEvent] = []
+
+    def publish(self, event: DomainEvent) -> None:
+        self.events.append(event)
+
+    def read_all(self) -> tuple[DomainEvent, ...]:
+        return tuple(self.events)
+
+
+def _job(*, job_id: int = 10, source_site: str = "LinkedIn") -> JobPosting:
+    return JobPosting(
+        id=job_id,
+        title="Backend Java",
+        company="ACME",
+        location="Brasil",
+        work_mode="remoto",
+        salary_text="Nao informado",
+        url=f"https://www.linkedin.com/jobs/view/{job_id}/",
+        source_site=source_site,
+        summary="Resumo",
+        relevance=9,
+        rationale="fit",
+        external_key=f"job-key-{job_id}",
+        status="collected",
+    )
+
+
+class DomainTransitionEventTests(TestCase):
+    def test_review_job_publishes_job_reviewed_when_status_changes(self) -> None:
+        class _Repository:
+            def __init__(self) -> None:
+                self.marked: list[tuple[int, str, str]] = []
+
+            def get_job(self, job_id: int):
+                return _job(job_id=job_id)
+
+            def mark_status(self, job_id: int, status: str, *, detail: str = "") -> None:
+                self.marked.append((job_id, status, detail))
+
+        event_bus = _EventBus()
+        repository = _Repository()
+        service = JobReviewCommandService(repository, event_bus=event_bus)
+
+        detail = service.review_job(10, "approve")
+
+        self.assertEqual(detail, "Vaga aprovada: Backend Java - ACME")
+        self.assertEqual(repository.marked, [(10, "approved", "Vaga aprovada: Backend Java - ACME")])
+        self.assertEqual(len(event_bus.events), 1)
+        event = event_bus.events[0]
+        self.assertIsInstance(event, JobReviewedV1)
+        self.assertEqual(event.job_id, 10)
+        self.assertEqual(event.decision, "approve")
+        self.assertEqual(event.status, "approved")
+        self.assertEqual(event.reviewed_by, "command")
+        self.assertEqual(event.external_key, "job-key-10")
+        self.assertEqual(event.correlation_id, "job:10")
+
+    def test_review_job_does_not_publish_when_transition_is_ignored(self) -> None:
+        class _Repository:
+            def get_job(self, job_id: int):
+                return JobPosting(
+                    **{**_job(job_id=job_id).__dict__, "status": "approved"}
+                )
+
+            def mark_status(self, job_id: int, status: str, *, detail: str = "") -> None:
+                raise AssertionError("mark_status should not be called")
+
+        event_bus = _EventBus()
+        service = JobReviewCommandService(_Repository(), event_bus=event_bus)
+
+        detail = service.review_job(10, "approve")
+
+        self.assertEqual(detail, "Vaga ja estava aprovada: Backend Java - ACME")
+        self.assertEqual(event_bus.events, [])
+
+    def test_authorize_application_publishes_application_authorized(self) -> None:
+        class _Repository:
+            def __init__(self) -> None:
+                self.marked: list[tuple[int, str, str]] = []
+
+            def get_application(self, application_id: int):
+                return JobApplication(id=application_id, job_id=10, status="confirmed")
+
+            def mark_application_status(
+                self,
+                application_id: int,
+                *,
+                status: str,
+                event_detail="",
+                notes=None,
+                last_preflight_detail=None,
+                last_submit_detail=None,
+                last_error=None,
+                submitted_at=None,
+            ) -> None:
+                self.marked.append((application_id, status, event_detail))
+
+        event_bus = _EventBus()
+        repository = _Repository()
+        service = ApplicationTransitionCommandService(repository, event_bus=event_bus)
+
+        detail = service.authorize_application(55)
+
+        self.assertEqual(detail, "Candidatura autorizada para envio: id=55")
+        self.assertEqual(repository.marked, [(55, "authorized_submit", "Candidatura autorizada para envio: id=55")])
+        self.assertEqual(len(event_bus.events), 1)
+        event = event_bus.events[0]
+        self.assertIsInstance(event, ApplicationAuthorizedV1)
+        self.assertEqual(event.application_id, 55)
+        self.assertEqual(event.job_id, 10)
+        self.assertEqual(event.authorized_by, "command")
+        self.assertEqual(event.status, "authorized_submit")
+        self.assertEqual(event.correlation_id, "application:55")
+
+    def test_application_submission_publishes_submitted_event(self) -> None:
+        class _Repository:
+            def __init__(self) -> None:
+                self.marked: list[dict[str, object]] = []
+                self.events: list[dict[str, object]] = []
+
+            def get_application(self, application_id: int):
+                return JobApplication(
+                    id=application_id,
+                    job_id=10,
+                    status="authorized_submit",
+                    last_preflight_detail="preflight real | pronto_para_envio=sim",
+                )
+
+            def get_job(self, job_id: int):
+                return _job(job_id=job_id)
+
+            def mark_application_status(self, application_id: int, **kwargs) -> None:
+                self.marked.append({"application_id": application_id, **kwargs})
+
+            def record_application_event(self, application_id: int, **kwargs) -> None:
+                self.events.append({"application_id": application_id, **kwargs})
+
+        class _Applicant:
+            def submit(self, application: JobApplication, job: JobPosting):
+                return ApplicationSubmissionResult(
+                    status="submitted",
+                    detail="submissao concluida",
+                    submitted_at="2026-04-24T12:00:00+00:00",
+                    external_reference="ref-123",
+                )
+
+        event_bus = _EventBus()
+        repository = _Repository()
+        service = ApplicationSubmissionService(repository, applicant=_Applicant(), event_bus=event_bus)
+
+        result = service.run_for_application(55)
+
+        self.assertEqual(result.outcome, "submitted")
+        self.assertEqual(result.application_status, "submitted")
+        self.assertEqual(len(event_bus.events), 1)
+        event = event_bus.events[0]
+        self.assertIsInstance(event, ApplicationSubmittedV1)
+        self.assertEqual(event.application_id, 55)
+        self.assertEqual(event.job_id, 10)
+        self.assertEqual(event.portal, "LinkedIn")
+        self.assertEqual(event.confirmation_reference, "ref-123")
+        self.assertEqual(event.submitted_url, "https://www.linkedin.com/jobs/view/10/")
+        self.assertEqual(event.correlation_id, "application:55")
+
+    def test_application_submission_publishes_blocked_event_when_preflight_not_ready(self) -> None:
+        class _Repository:
+            def __init__(self) -> None:
+                self.marked: list[dict[str, object]] = []
+
+            def get_application(self, application_id: int):
+                return JobApplication(
+                    id=application_id,
+                    job_id=10,
+                    status="authorized_submit",
+                    last_preflight_detail="preflight inconclusivo",
+                )
+
+            def get_job(self, job_id: int):
+                return _job(job_id=job_id)
+
+            def mark_application_status(self, application_id: int, **kwargs) -> None:
+                self.marked.append({"application_id": application_id, **kwargs})
+
+        event_bus = _EventBus()
+        service = ApplicationSubmissionService(_Repository(), applicant=object(), event_bus=event_bus)
+
+        result = service.run_for_application(55)
+
+        self.assertEqual(result.outcome, "ignored")
+        self.assertEqual(result.application_status, "authorized_submit")
+        self.assertEqual(len(event_bus.events), 1)
+        event = event_bus.events[0]
+        self.assertIsInstance(event, ApplicationBlockedV1)
+        self.assertEqual(event.application_id, 55)
+        self.assertEqual(event.job_id, 10)
+        self.assertEqual(event.reason, "preflight_not_ready")
+        self.assertTrue(event.retryable)
+        self.assertEqual(event.correlation_id, "application:55")


### PR DESCRIPTION
## Resumo

Integra os contratos de eventos de domínio aos pontos reais de transição, mantendo a publicação opcional via `EventBusPort` injetado.

## O que entrou

- `JobReviewCommandService` publica `JobReviewedV1` quando uma vaga muda de status por review.
- `ApplicationTransitionCommandService` publica `ApplicationAuthorizedV1` quando uma candidatura é autorizada para envio.
- `ApplicationSubmissionService` publica:
  - `ApplicationSubmittedV1` quando a submissão real é concluída.
  - `ApplicationBlockedV1` para bloqueios/ignores relevantes no submit real.
- Testes cobrindo publicação e ausência de publicação quando transições são ignoradas.

## Escopo consciente

- Event bus continua opcional.
- Sem broker externo.
- Sem Docker/Compose.
- Sem mudança obrigatória no runtime atual.
- Sem migração de banco.

## Próximo passo sugerido

Depois de validar esta frente, conectar um `LocalNdjsonEventBus` configurável no runtime/CLI apenas se quisermos persistir esses eventos fora dos eventos já gravados no SQLite.