### PR TITLE
Adiciona CLI para inspecionar eventos de domínio

### DIFF
--- a/docs/plans/EVENT_DRIVEN_WORKERS_CHECKLIST.md
+++ b/docs/plans/EVENT_DRIVEN_WORKERS_CHECKLIST.md
@@ -25,46 +25,50 @@ A meta desta frente e criar seams reais para execucao distribuida futura, manten
 
 ## Estado Atual Relevante
 
-O CLI ja possui comandos de worker isolado:
+O CLI possui comandos de worker e inspecao de eventos:
 
 - `python main.py worker list`
 - `python main.py worker collect`
 - `python main.py worker match`
+- `python main.py domain-events list`
 
-Esses comandos sao a base inicial para a extracao gradual.
+Esses comandos sao a base inicial para a extracao gradual e para observabilidade local sem broker externo.
 
 ## Fase 0 — Plano E Fronteiras
 
 - [x] Criar checklist da frente event-driven workers.
-- [ ] Mapear fluxos atuais que viram eventos.
-- [ ] Definir glossario minimo de eventos e comandos.
-- [ ] Registrar decisoes de fronteira entre runtime atual, workers e storage.
-- [ ] Garantir que nenhuma mudanca desta fase altere comportamento operacional.
+- [x] Mapear fluxos atuais que viram eventos.
+- [x] Definir glossario minimo de eventos e comandos.
+- [x] Registrar decisoes de fronteira entre runtime atual, workers e storage.
+- [x] Garantir que nenhuma mudanca desta fase altere comportamento operacional por padrao.
 
 ## Fase 1 — Contratos De Eventos Versionados
 
 Criar contratos pequenos, explicitos e testaveis para eventos do pipeline.
 
-Eventos candidatos:
+Eventos implementados:
 
 - `JobCollectedV1`
 - `JobScoredV1`
-- `JobPersistedV1`
 - `JobReviewRequestedV1`
 - `JobReviewedV1`
-- `ApplicationDraftCreatedV1`
-- `ApplicationPreflightCompletedV1`
 - `ApplicationAuthorizedV1`
 - `ApplicationSubmittedV1`
 - `ApplicationBlockedV1`
+
+Eventos ainda candidatos/futuros:
+
+- `JobPersistedV1`
+- `ApplicationDraftCreatedV1`
+- `ApplicationPreflightCompletedV1`
 
 Checklist:
 
 - [x] Criar modulo de contratos de eventos em `job_hunter_agent/core/events.py` ou pacote equivalente.
 - [x] Definir campos minimos para `JobCollectedV1`.
 - [x] Definir campos minimos para `JobScoredV1`.
-- [ ] Definir campos minimos para eventos de revisao.
-- [ ] Definir campos minimos para eventos de candidatura.
+- [x] Definir campos minimos para eventos de revisao.
+- [x] Definir campos minimos para eventos de candidatura.
 - [x] Incluir `event_id`, `event_type`, `event_version`, `occurred_at` e `correlation_id` onde fizer sentido.
 - [x] Adicionar serializacao/deserializacao JSON.
 - [x] Adicionar testes de round-trip dos eventos.
@@ -116,7 +120,9 @@ Checklist:
 - [x] Criar estrategia de idempotencia por evento.
 - [x] Avaliar schema versionado para SQLite.
 - [x] Padronizar timestamps em UTC para novos eventos/artefatos de worker.
-- [ ] Registrar eventos de dominio para transicoes relevantes.
+- [x] Registrar eventos de dominio para transicoes relevantes.
+- [x] Permitir publicacao opcional de eventos de dominio em NDJSON via `JOB_HUNTER_DOMAIN_EVENTS_ENABLED`.
+- [x] Adicionar CLI somente leitura para inspecionar eventos de dominio.
 - [x] Garantir que reprocessar o mesmo evento nao duplica vagas ou candidaturas.
 
 ## Fase 5 — Docker Compose Local
@@ -146,9 +152,9 @@ Checklist:
 
 ## Fase 6 — Broker Externo Opcional
 
-Somente apos contratos, workers e idempotencia estarem estaveis.
+Somente apos contratos, workers e idempotencia estarem estaveis e se houver necessidade real.
 
-Opcoes:
+Opcoes futuras:
 
 - Redis Streams
 - RabbitMQ
@@ -156,11 +162,11 @@ Opcoes:
 
 Checklist:
 
-- [ ] Escolher broker com base em simplicidade operacional.
+- [ ] Escolher broker com base em simplicidade operacional, somente se necessario.
 - [ ] Implementar adapter mantendo `EventBusPort`.
-- [ ] Manter `LocalNdjsonEventBus` para testes e desenvolvimento.
+- [x] Manter `LocalNdjsonEventBus` para testes e desenvolvimento.
 - [ ] Criar testes de contrato compartilhados entre adapters.
-- [ ] Documentar retries, dead-letter e poison messages.
+- [ ] Documentar retries, dead-letter e poison messages para broker externo.
 
 ## Fase 7 — Avaliacao De Microservicos Reais
 
@@ -171,8 +177,8 @@ Criterios para considerar multiplos repos:
 - [ ] deploy independente realmente necessario
 - [ ] ciclos de mudanca muito diferentes entre componentes
 - [ ] necessidade de escalar workers independentemente
-- [ ] contratos versionados ja estaveis
-- [ ] observabilidade e retry ja resolvidos
+- [x] contratos versionados ja estaveis para os fluxos principais
+- [x] observabilidade e retry local basicos ja resolvidos
 - [ ] custo de operacao aceito conscientemente
 
 ## Fora De Escopo Nesta Frente
@@ -183,18 +189,26 @@ Criterios para considerar multiplos repos:
 - introduzir Kubernetes
 - separar repositorios antes dos contratos
 - automatizar submissao sem gates humanos e operacionais
+- introduzir broker externo sem dor operacional concreta
 
 ## Definicao De Pronto Da Frente
 
 Esta frente sera considerada concluida quando:
 
-- workers principais puderem rodar separadamente no mesmo repositorio
-- contratos de eventos tiverem testes de round-trip
-- o transporte local NDJSON estiver atras de uma porta
-- reprocessamento basico for idempotente
-- Docker Compose local estiver documentado
-- o runtime atual continuar funcionando sem regressao
+- [x] workers principais puderem rodar separadamente no mesmo repositorio
+- [x] contratos de eventos tiverem testes de round-trip
+- [x] o transporte local NDJSON estiver atras de uma porta
+- [x] reprocessamento basico for idempotente
+- [x] Docker Compose local estiver documentado
+- [x] o runtime atual continuar funcionando sem regressao em CI
 
 ## Proximo Passo Imediato
 
-Manter NDJSON local como transporte de desenvolvimento. Iniciar Fase 6 somente se surgir necessidade real de broker externo, como concorrencia entre multiplos consumidores, retries persistentes mais fortes ou execucao distribuida fora da maquina local.
+Validar manualmente o fluxo de eventos de dominio com:
+
+```bash
+JOB_HUNTER_DOMAIN_EVENTS_ENABLED=true python main.py jobs approve --id <job_id>
+python main.py domain-events list --limit 20
+```
+
+Depois disso, manter NDJSON local como transporte de desenvolvimento. Iniciar Fase 6 somente se surgir necessidade real de broker externo, como concorrencia entre multiplos consumidores, retries persistentes mais fortes ou execucao distribuida fora da maquina local.

--- a/job_hunter_agent/application/application_cli.py
+++ b/job_hunter_agent/application/application_cli.py
@@ -161,6 +161,22 @@ def parse_args() -> argparse.Namespace:
         help="Executa envio em lote com gates e limites de seguranca do auto easy apply.",
     )
 
+    domain_events_parser = subparsers.add_parser("domain-events", help="Inspeciona eventos de dominio em NDJSON.")
+    domain_events_subparsers = domain_events_parser.add_subparsers(dest="domain_events_command", required=True)
+    domain_events_list_parser = domain_events_subparsers.add_parser("list", help="Lista eventos de dominio recentes.")
+    domain_events_list_parser.add_argument(
+        "--path",
+        type=Path,
+        default=None,
+        help="Arquivo NDJSON de eventos. Usa JOB_HUNTER_DOMAIN_EVENTS_PATH por padrao.",
+    )
+    domain_events_list_parser.add_argument(
+        "--limit",
+        type=int,
+        default=20,
+        help="Quantidade maxima de eventos exibidos.",
+    )
+
     candidate_profile_parser = subparsers.add_parser(
         "candidate-profile",
         help="Operacoes do perfil estruturado do candidato.",
@@ -231,6 +247,8 @@ def parse_args() -> argparse.Namespace:
         parser.error("--ciclos deve ser maior que zero")
     if args.intervalo_ciclos_segundos < 0:
         parser.error("--intervalo-ciclos-segundos nao pode ser negativo")
+    if getattr(args, "limit", 1) is not None and getattr(args, "limit", 1) <= 0:
+        parser.error("--limit deve ser maior que zero")
     if args.agora and args.ciclos is not None:
         parser.error("use --agora ou --ciclos, nao ambos")
     if args.command is not None and (args.agora or args.ciclos is not None):

--- a/job_hunter_agent/application/application_cli_dispatch.py
+++ b/job_hunter_agent/application/application_cli_dispatch.py
@@ -9,6 +9,7 @@ from job_hunter_agent.application.application_cli import (
     JOB_STATUS_ALIASES,
 )
 from job_hunter_agent.application.collector_worker import run_collector_worker_once
+from job_hunter_agent.application.domain_events_cli import render_domain_events
 from job_hunter_agent.application.matching_worker import run_matching_worker_once
 from job_hunter_agent.application.worker_catalog import render_worker_catalog
 from job_hunter_agent.application.cli_bootstrap import (
@@ -39,6 +40,9 @@ def execute_cli_command(args: Namespace) -> bool:
         return True
     if args.command == "applications":
         _run_applications_command(args)
+        return True
+    if args.command == "domain-events":
+        _run_domain_events_command(args)
         return True
     if args.command == "candidate-profile":
         _run_candidate_profile_command(args)
@@ -121,6 +125,12 @@ def _run_applications_command(args: Namespace) -> None:
             print(app.show_application_submit_dry_run(args.id))
             return
         print(asyncio.run(app.handle_application_submit(args.id)))
+
+
+def _run_domain_events_command(args: Namespace) -> None:
+    settings = load_settings()
+    path = args.path or settings.domain_events_path
+    print(render_domain_events(path=path, limit=args.limit))
 
 
 def _run_candidate_profile_command(args: Namespace) -> None:

--- a/job_hunter_agent/application/domain_events_cli.py
+++ b/job_hunter_agent/application/domain_events_cli.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from job_hunter_agent.core.event_bus import LocalNdjsonEventBus
+from job_hunter_agent.core.events import (
+    ApplicationAuthorizedV1,
+    ApplicationBlockedV1,
+    ApplicationSubmittedV1,
+    DomainEvent,
+    JobCollectedV1,
+    JobReviewRequestedV1,
+    JobReviewedV1,
+    JobScoredV1,
+)
+
+
+def render_domain_events(*, path: Path, limit: int = 20) -> str:
+    events = LocalNdjsonEventBus(path).read_all()
+    if not events:
+        return f"Nenhum evento de dominio encontrado em {path}"
+    bounded_limit = max(1, limit)
+    selected = tuple(events[-bounded_limit:])
+    lines = [f"Eventos de dominio: {len(selected)} de {len(events)} arquivo={path}"]
+    for event in selected:
+        lines.append(_render_event_line(event))
+    return "\n".join(lines)
+
+
+def _render_event_line(event: DomainEvent) -> str:
+    base = (
+        f"- {event.occurred_at} {event.event_type} "
+        f"event_id={event.event_id} correlation_id={event.correlation_id or '-'}"
+    )
+    if isinstance(event, JobCollectedV1):
+        return (
+            f"{base} run_id={event.run_id} jobs_seen={event.jobs_seen} "
+            f"jobs_saved={event.jobs_saved} errors={event.errors}"
+        )
+    if isinstance(event, JobScoredV1):
+        return (
+            f"{base} run_id={event.run_id} external_key={event.external_key} "
+            f"accepted={event.accepted} relevance={event.relevance}"
+        )
+    if isinstance(event, JobReviewRequestedV1):
+        return (
+            f"{base} job_id={event.job_id} external_key={event.external_key} "
+            f"source_site={event.source_site} relevance={event.relevance} reason={event.reason or '-'}"
+        )
+    if isinstance(event, JobReviewedV1):
+        return (
+            f"{base} job_id={event.job_id} decision={event.decision} "
+            f"status={event.status} reviewed_by={event.reviewed_by or '-'}"
+        )
+    if isinstance(event, ApplicationAuthorizedV1):
+        return (
+            f"{base} application_id={event.application_id} job_id={event.job_id} "
+            f"authorized_by={event.authorized_by or '-'} source={event.authorization_source} status={event.status}"
+        )
+    if isinstance(event, ApplicationSubmittedV1):
+        return (
+            f"{base} application_id={event.application_id} job_id={event.job_id} "
+            f"portal={event.portal} confirmation={event.confirmation_reference or '-'}"
+        )
+    if isinstance(event, ApplicationBlockedV1):
+        return (
+            f"{base} application_id={event.application_id} job_id={event.job_id} "
+            f"reason={event.reason} retryable={event.retryable}"
+        )
+    return base

--- a/tests/test_domain_events_cli.py
+++ b/tests/test_domain_events_cli.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+from unittest import TestCase
+from unittest.mock import patch
+
+from job_hunter_agent.application.application_cli import parse_args
+from job_hunter_agent.application.domain_events_cli import render_domain_events
+from job_hunter_agent.core.event_bus import LocalNdjsonEventBus
+from job_hunter_agent.core.events import ApplicationBlockedV1, JobReviewedV1
+from tests.tmp_workspace import prepare_workspace_tmp_dir
+
+
+class DomainEventsCliTests(TestCase):
+    def setUp(self) -> None:
+        self.temp_dir = prepare_workspace_tmp_dir("domain-events-cli")
+        self.events_path = self.temp_dir / "domain-events.ndjson"
+
+    def tearDown(self) -> None:
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    def test_render_domain_events_reports_missing_or_empty_file(self) -> None:
+        rendered = render_domain_events(path=self.events_path, limit=10)
+
+        self.assertEqual(rendered, f"Nenhum evento de dominio encontrado em {self.events_path}")
+
+    def test_render_domain_events_lists_recent_events(self) -> None:
+        bus = LocalNdjsonEventBus(self.events_path)
+        bus.publish(
+            JobReviewedV1(
+                job_id=10,
+                decision="approve",
+                status="approved",
+                reviewed_by="command",
+                event_id="evt-reviewed",
+                occurred_at="2026-04-24T12:00:00+00:00",
+                correlation_id="job:10",
+            )
+        )
+        bus.publish(
+            ApplicationBlockedV1(
+                application_id=55,
+                job_id=10,
+                reason="preflight_not_ready",
+                retryable=True,
+                event_id="evt-blocked",
+                occurred_at="2026-04-24T12:01:00+00:00",
+                correlation_id="application:55",
+            )
+        )
+
+        rendered = render_domain_events(path=self.events_path, limit=1)
+
+        self.assertIn("Eventos de dominio: 1 de 2", rendered)
+        self.assertIn("ApplicationBlockedV1", rendered)
+        self.assertIn("application_id=55", rendered)
+        self.assertIn("reason=preflight_not_ready", rendered)
+        self.assertNotIn("JobReviewedV1", rendered)
+
+    def test_parse_args_accepts_domain_events_list_command(self) -> None:
+        with patch("sys.argv", ["main.py", "domain-events", "list", "--path", "logs/domain-events.ndjson", "--limit", "5"]):
+            args = parse_args()
+
+        self.assertEqual(args.command, "domain-events")
+        self.assertEqual(args.domain_events_command, "list")
+        self.assertEqual(args.path, Path("logs/domain-events.ndjson"))
+        self.assertEqual(args.limit, 5)
+
+    def test_parse_args_rejects_non_positive_domain_events_limit(self) -> None:
+        with patch("sys.argv", ["main.py", "domain-events", "list", "--limit", "0"]):
+            with self.assertRaises(SystemExit):
+                parse_args()


### PR DESCRIPTION
## Resumo

Adiciona um comando somente leitura para inspecionar eventos de dominio gravados em NDJSON.

## O que entrou

- Novo comando:
  - `python main.py domain-events list`
- Opcoes:
  - `--path` para apontar um NDJSON especifico
  - `--limit` para limitar eventos recentes
- Novo renderer em `job_hunter_agent/application/domain_events_cli.py`.
- Dispatch no CLI.
- Testes para:
  - arquivo ausente/vazio
  - renderizacao dos eventos recentes
  - parse do comando
  - validacao de `--limit > 0`

## Escopo consciente

- Somente leitura.
- Sem broker externo.
- Sem mudar runtime de publicacao.
- Sem migracao de banco.

## Uso esperado

```bash
python main.py domain-events list --limit 20
python main.py domain-events list --path logs/domain-events.ndjson --limit 50
```