### PR TITLE
Fix: inicializar domain_event_bus no bootstrap CLI (issue #25)

### DIFF
--- a/job_hunter_agent/application/cli_bootstrap.py
+++ b/job_hunter_agent/application/cli_bootstrap.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from job_hunter_agent.application.app import JobHunterApplication
-from job_hunter_agent.application.composition import create_repository
+from job_hunter_agent.application.composition import create_domain_event_bus, create_repository
 from job_hunter_agent.core.settings import load_settings
 
 
@@ -38,4 +38,5 @@ def _create_cli_app_base() -> JobHunterApplication:
     app.enable_telegram = False
     app.settings = load_settings()
     app.repository = create_repository(app.settings)
+    app.domain_event_bus = create_domain_event_bus(app.settings)
     return app

--- a/tests/test_app_bootstrap.py
+++ b/tests/test_app_bootstrap.py
@@ -18,7 +18,10 @@ class JobHunterApplicationBootstrapTests(TestCase):
         with patch("job_hunter_agent.application.cli_bootstrap.load_settings", return_value=settings) as load_settings_mock, patch(
             "job_hunter_agent.application.cli_bootstrap.create_repository",
             return_value=repository,
-        ) as create_repository_mock, patch.object(
+        ) as create_repository_mock, patch(
+            "job_hunter_agent.application.cli_bootstrap.create_domain_event_bus",
+            return_value=object(),
+        ) as create_event_bus_mock, patch.object(
             JobHunterApplication,
             "_initialize_query_services",
         ) as initialize_query_mock, patch.object(
@@ -32,6 +35,7 @@ class JobHunterApplicationBootstrapTests(TestCase):
 
         load_settings_mock.assert_called_once_with()
         create_repository_mock.assert_called_once_with(settings)
+        create_event_bus_mock.assert_called_once_with(settings)
         initialize_query_mock.assert_called_once_with()
         initialize_review_mock.assert_not_called()
         initialize_flow_mock.assert_not_called()
@@ -45,6 +49,9 @@ class JobHunterApplicationBootstrapTests(TestCase):
         with patch("job_hunter_agent.application.cli_bootstrap.load_settings", return_value=settings), patch(
             "job_hunter_agent.application.cli_bootstrap.create_repository",
             return_value=repository,
+        ), patch(
+            "job_hunter_agent.application.cli_bootstrap.create_domain_event_bus",
+            return_value=object(),
         ), patch.object(
             JobHunterApplication,
             "_initialize_query_services",
@@ -70,6 +77,9 @@ class JobHunterApplicationBootstrapTests(TestCase):
         with patch("job_hunter_agent.application.cli_bootstrap.load_settings", return_value=settings), patch(
             "job_hunter_agent.application.cli_bootstrap.create_repository",
             return_value=repository,
+        ), patch(
+            "job_hunter_agent.application.cli_bootstrap.create_domain_event_bus",
+            return_value=object(),
         ), patch.object(
             JobHunterApplication,
             "_initialize_query_services",
@@ -95,6 +105,9 @@ class JobHunterApplicationBootstrapTests(TestCase):
         with patch("job_hunter_agent.application.cli_bootstrap.load_settings", return_value=settings), patch(
             "job_hunter_agent.application.cli_bootstrap.create_repository",
             return_value=repository,
+        ), patch(
+            "job_hunter_agent.application.cli_bootstrap.create_domain_event_bus",
+            return_value=object(),
         ), patch.object(
             JobHunterApplication,
             "_initialize_query_services",


### PR DESCRIPTION
## Contexto
Durante a validação da issue #25, o fluxo `jobs approve` com `JOB_HUNTER_DOMAIN_EVENTS_ENABLED=true` falhava no modo CLI com:

`AttributeError: 'JobHunterApplication' object has no attribute 'domain_event_bus'`

## Causa
`cli_bootstrap._create_cli_app_base()` criava a instância parcial sem inicializar `domain_event_bus`, mas os serviços de review/transition/submission já esperam esse atributo.

## Correção
- Inicializa `app.domain_event_bus = create_domain_event_bus(app.settings)` no bootstrap CLI.
- Atualiza testes de bootstrap para cobrir a criação do event bus.

## Validação manual da issue #25
Com essa correção aplicada, executei o checklist completo:

1. **Review de vaga**
- `jobs approve --id 238`
- `domain-events list --limit 20`
- Evento observado: `JobReviewedV1` com `correlation_id=job:238`, `decision=approve`, `status=approved`.

2. **Autorização de candidatura**
- `applications authorize --id 31`
- `domain-events list --limit 20`
- Evento observado: `ApplicationAuthorizedV1` com `application_id=31`, `job_id=128`, `status=authorized_submit`, `correlation_id=application:31`.

3. **Submit bloqueado/enviado**
- `applications submit --id 31`
- Evento observado: `ApplicationBlockedV1` (`reason=preflight_not_ready`, `retryable=True`).

4. **Regressão com eventos desabilitados**
- `JOB_HUNTER_DOMAIN_EVENTS_ENABLED=false`
- Runtime continuou funcional (`status`, `jobs approve --id 239`) sem exigir `domain-events.ndjson`.

## Testes
- `pytest tests/test_app_bootstrap.py tests/test_domain_events_cli.py tests/test_domain_event_bus_config.py tests/test_domain_transition_events.py tests/test_event_bus.py -q`
- Resultado: `20 passed`

Closes #25