### PR TITLE
Adiciona filtros ao CLI de domain-events

### DIFF
--- a/docs/DOMAIN_EVENTS.md
+++ b/docs/DOMAIN_EVENTS.md
@@ -43,7 +43,31 @@ Ou aponte para um arquivo especifico:
 python main.py domain-events list --path logs/domain-events.ndjson --limit 50
 ```
 
-Se o arquivo nao existir ou estiver vazio, o comando deve responder que nenhum evento foi encontrado.
+Filtre por tipo de evento:
+
+```bash
+python main.py domain-events list --event-type ApplicationBlockedV1 --limit 20
+```
+
+Filtre por correlation id:
+
+```bash
+python main.py domain-events list --correlation-id application:31 --limit 20
+```
+
+Combine filtros:
+
+```bash
+python main.py domain-events list --event-type ApplicationBlockedV1 --correlation-id application:31 --limit 20
+```
+
+Renderize como JSON para scripts locais:
+
+```bash
+python main.py domain-events list --event-type ApplicationBlockedV1 --json
+```
+
+Se o arquivo nao existir ou estiver vazio, o comando deve responder que nenhum evento foi encontrado. Em modo `--json`, o retorno vazio e `[]`.
 
 ## Eventos Ativos
 
@@ -193,6 +217,7 @@ Possiveis causas:
 - path diferente do esperado
 - nenhuma transicao real executada desde que a flag foi habilitada
 - comando executado em outro diretorio de trabalho
+- filtros `--event-type` ou `--correlation-id` nao encontraram eventos correspondentes
 
 ### `domain-events.ndjson` nao e criado
 

--- a/job_hunter_agent/application/application_cli.py
+++ b/job_hunter_agent/application/application_cli.py
@@ -176,6 +176,21 @@ def parse_args() -> argparse.Namespace:
         default=20,
         help="Quantidade maxima de eventos exibidos.",
     )
+    domain_events_list_parser.add_argument(
+        "--event-type",
+        default="",
+        help="Filtra pelo event_type exato, como JobReviewedV1.",
+    )
+    domain_events_list_parser.add_argument(
+        "--correlation-id",
+        default="",
+        help="Filtra pelo correlation_id exato, como application:31.",
+    )
+    domain_events_list_parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Renderiza os eventos selecionados como JSON.",
+    )
 
     candidate_profile_parser = subparsers.add_parser(
         "candidate-profile",

--- a/job_hunter_agent/application/application_cli_dispatch.py
+++ b/job_hunter_agent/application/application_cli_dispatch.py
@@ -130,7 +130,15 @@ def _run_applications_command(args: Namespace) -> None:
 def _run_domain_events_command(args: Namespace) -> None:
     settings = load_settings()
     path = args.path or settings.domain_events_path
-    print(render_domain_events(path=path, limit=args.limit))
+    print(
+        render_domain_events(
+            path=path,
+            limit=args.limit,
+            event_type=args.event_type,
+            correlation_id=args.correlation_id,
+            as_json=args.json,
+        )
+    )
 
 
 def _run_candidate_profile_command(args: Namespace) -> None:

--- a/job_hunter_agent/application/domain_events_cli.py
+++ b/job_hunter_agent/application/domain_events_cli.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 from job_hunter_agent.core.event_bus import LocalNdjsonEventBus
@@ -12,19 +13,51 @@ from job_hunter_agent.core.events import (
     JobReviewRequestedV1,
     JobReviewedV1,
     JobScoredV1,
+    event_to_dict,
 )
 
 
-def render_domain_events(*, path: Path, limit: int = 20) -> str:
-    events = LocalNdjsonEventBus(path).read_all()
+def render_domain_events(
+    *,
+    path: Path,
+    limit: int = 20,
+    event_type: str = "",
+    correlation_id: str = "",
+    as_json: bool = False,
+) -> str:
+    events = _filter_events(
+        LocalNdjsonEventBus(path).read_all(),
+        event_type=event_type,
+        correlation_id=correlation_id,
+    )
     if not events:
+        if as_json:
+            return "[]"
         return f"Nenhum evento de dominio encontrado em {path}"
     bounded_limit = max(1, limit)
     selected = tuple(events[-bounded_limit:])
+    if as_json:
+        return json.dumps([event_to_dict(event) for event in selected], ensure_ascii=False, indent=2)
     lines = [f"Eventos de dominio: {len(selected)} de {len(events)} arquivo={path}"]
     for event in selected:
         lines.append(_render_event_line(event))
     return "\n".join(lines)
+
+
+def _filter_events(
+    events: tuple[DomainEvent, ...],
+    *,
+    event_type: str = "",
+    correlation_id: str = "",
+) -> tuple[DomainEvent, ...]:
+    normalized_event_type = event_type.strip()
+    normalized_correlation_id = correlation_id.strip()
+    filtered = events
+    if normalized_event_type:
+        filtered = tuple(event for event in filtered if event.event_type == normalized_event_type)
+    if normalized_correlation_id:
+        filtered = tuple(event for event in filtered if event.correlation_id == normalized_correlation_id)
+    return filtered
 
 
 def _render_event_line(event: DomainEvent) -> str:

--- a/tests/test_domain_events_cli.py
+++ b/tests/test_domain_events_cli.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import shutil
 from pathlib import Path
 from unittest import TestCase
@@ -25,7 +26,93 @@ class DomainEventsCliTests(TestCase):
 
         self.assertEqual(rendered, f"Nenhum evento de dominio encontrado em {self.events_path}")
 
+    def test_render_domain_events_returns_empty_json_for_missing_or_empty_file(self) -> None:
+        rendered = render_domain_events(path=self.events_path, limit=10, as_json=True)
+
+        self.assertEqual(rendered, "[]")
+
     def test_render_domain_events_lists_recent_events(self) -> None:
+        self._publish_sample_events()
+
+        rendered = render_domain_events(path=self.events_path, limit=1)
+
+        self.assertIn("Eventos de dominio: 1 de 2", rendered)
+        self.assertIn("ApplicationBlockedV1", rendered)
+        self.assertIn("application_id=55", rendered)
+        self.assertIn("reason=preflight_not_ready", rendered)
+        self.assertNotIn("JobReviewedV1", rendered)
+
+    def test_render_domain_events_filters_by_event_type(self) -> None:
+        self._publish_sample_events()
+
+        rendered = render_domain_events(path=self.events_path, limit=20, event_type="JobReviewedV1")
+
+        self.assertIn("Eventos de dominio: 1 de 1", rendered)
+        self.assertIn("JobReviewedV1", rendered)
+        self.assertIn("job_id=10", rendered)
+        self.assertNotIn("ApplicationBlockedV1", rendered)
+
+    def test_render_domain_events_filters_by_correlation_id(self) -> None:
+        self._publish_sample_events()
+
+        rendered = render_domain_events(path=self.events_path, limit=20, correlation_id="application:55")
+
+        self.assertIn("Eventos de dominio: 1 de 1", rendered)
+        self.assertIn("ApplicationBlockedV1", rendered)
+        self.assertIn("correlation_id=application:55", rendered)
+        self.assertNotIn("JobReviewedV1", rendered)
+
+    def test_render_domain_events_outputs_json_for_selected_events(self) -> None:
+        self._publish_sample_events()
+
+        rendered = render_domain_events(
+            path=self.events_path,
+            limit=20,
+            event_type="ApplicationBlockedV1",
+            as_json=True,
+        )
+
+        payload = json.loads(rendered)
+        self.assertEqual(len(payload), 1)
+        self.assertEqual(payload[0]["event_type"], "ApplicationBlockedV1")
+        self.assertEqual(payload[0]["application_id"], 55)
+        self.assertEqual(payload[0]["correlation_id"], "application:55")
+
+    def test_parse_args_accepts_domain_events_list_command(self) -> None:
+        with patch("sys.argv", ["main.py", "domain-events", "list", "--path", "logs/domain-events.ndjson", "--limit", "5"]):
+            args = parse_args()
+
+        self.assertEqual(args.command, "domain-events")
+        self.assertEqual(args.domain_events_command, "list")
+        self.assertEqual(args.path, Path("logs/domain-events.ndjson"))
+        self.assertEqual(args.limit, 5)
+
+    def test_parse_args_accepts_domain_events_filters_and_json(self) -> None:
+        with patch(
+            "sys.argv",
+            [
+                "main.py",
+                "domain-events",
+                "list",
+                "--event-type",
+                "ApplicationBlockedV1",
+                "--correlation-id",
+                "application:55",
+                "--json",
+            ],
+        ):
+            args = parse_args()
+
+        self.assertEqual(args.event_type, "ApplicationBlockedV1")
+        self.assertEqual(args.correlation_id, "application:55")
+        self.assertTrue(args.json)
+
+    def test_parse_args_rejects_non_positive_domain_events_limit(self) -> None:
+        with patch("sys.argv", ["main.py", "domain-events", "list", "--limit", "0"]):
+            with self.assertRaises(SystemExit):
+                parse_args()
+
+    def _publish_sample_events(self) -> None:
         bus = LocalNdjsonEventBus(self.events_path)
         bus.publish(
             JobReviewedV1(
@@ -49,25 +136,3 @@ class DomainEventsCliTests(TestCase):
                 correlation_id="application:55",
             )
         )
-
-        rendered = render_domain_events(path=self.events_path, limit=1)
-
-        self.assertIn("Eventos de dominio: 1 de 2", rendered)
-        self.assertIn("ApplicationBlockedV1", rendered)
-        self.assertIn("application_id=55", rendered)
-        self.assertIn("reason=preflight_not_ready", rendered)
-        self.assertNotIn("JobReviewedV1", rendered)
-
-    def test_parse_args_accepts_domain_events_list_command(self) -> None:
-        with patch("sys.argv", ["main.py", "domain-events", "list", "--path", "logs/domain-events.ndjson", "--limit", "5"]):
-            args = parse_args()
-
-        self.assertEqual(args.command, "domain-events")
-        self.assertEqual(args.domain_events_command, "list")
-        self.assertEqual(args.path, Path("logs/domain-events.ndjson"))
-        self.assertEqual(args.limit, 5)
-
-    def test_parse_args_rejects_non_positive_domain_events_limit(self) -> None:
-        with patch("sys.argv", ["main.py", "domain-events", "list", "--limit", "0"]):
-            with self.assertRaises(SystemExit):
-                parse_args()


### PR DESCRIPTION
## Resumo

Melhora o comando `domain-events list` com filtros úteis e saída JSON para inspeção local.

## O que entrou

- Novas opções:
  - `--event-type`
  - `--correlation-id`
  - `--json`
- Filtros combináveis por tipo de evento e correlation id.
- Saída JSON para scripts locais.
- Testes cobrindo filtros, JSON e parse dos novos argumentos.
- `docs/DOMAIN_EVENTS.md` atualizado com exemplos.

## Escopo consciente

- Sem alterar runtime de publicação.
- Sem novos eventos.
- Sem broker externo.
- Sem migração de banco.

Refs #27