### PR TITLE
Adiciona evento de domínio para preflight concluído

### DIFF
--- a/docs/DOMAIN_EVENTS.md
+++ b/docs/DOMAIN_EVENTS.md
@@ -101,6 +101,22 @@ Uso principal:
 - auditar gates humanos antes de submit real
 - identificar candidaturas que entraram no estado `authorized_submit`
 
+### `ApplicationPreflightCompletedV1`
+
+Emitido quando o preflight real de uma candidatura termina com qualquer resultado controlado.
+
+Exemplo:
+
+```text
+ApplicationPreflightCompletedV1 event_id=<uuid> correlation_id=application:31 application_id=31 job_id=128 outcome=ready status=confirmed
+```
+
+Uso principal:
+
+- auditar se o preflight terminou como `ready`, `blocked`, `manual_review`, `ignored` ou `error`
+- diagnosticar por que um submit posterior pode bloquear com `preflight_not_ready`
+- correlacionar a preparacao da candidatura com autorizacao e envio
+
 ### `ApplicationSubmittedV1`
 
 Emitido quando uma submissao real e concluida.
@@ -161,6 +177,19 @@ Esperado:
 
 ```text
 ApplicationAuthorizedV1 ... correlation_id=application:<application_id> ... status=authorized_submit
+```
+
+### Preflight De Candidatura
+
+```bash
+python main.py applications preflight --id <application_id>
+python main.py domain-events list --event-type ApplicationPreflightCompletedV1 --correlation-id application:<application_id> --limit 20
+```
+
+Esperado:
+
+```text
+ApplicationPreflightCompletedV1 ... correlation_id=application:<application_id> ... outcome=<resultado> ... status=<status>
 ```
 
 ### Submit Bloqueado Ou Enviado
@@ -254,13 +283,13 @@ Ativos hoje:
 
 - `JobReviewedV1`
 - `ApplicationAuthorizedV1`
+- `ApplicationPreflightCompletedV1`
 - `ApplicationSubmittedV1`
 - `ApplicationBlockedV1`
 
 Candidatos futuros:
 
 - `ApplicationDraftCreatedV1`
-- `ApplicationPreflightCompletedV1`
 - `JobPersistedV1`
 
 Nao adicionar novos eventos sem valor operacional claro.

--- a/job_hunter_agent/application/app.py
+++ b/job_hunter_agent/application/app.py
@@ -123,7 +123,11 @@ class JobHunterApplication:
         )
 
     def _initialize_flow_services(self) -> None:
-        self.application_preflight = create_application_preflight_service(self.repository, self.settings)
+        self.application_preflight = create_application_preflight_service(
+            self.repository,
+            self.settings,
+            event_bus=self.domain_event_bus,
+        )
         self.application_submission = create_application_submission_service(
             self.repository,
             self.settings,

--- a/job_hunter_agent/application/application_preflight.py
+++ b/job_hunter_agent/application/application_preflight.py
@@ -20,6 +20,8 @@ from job_hunter_agent.application.application_ports import (
     normalize_application_flow_inspection,
 )
 from job_hunter_agent.application.application_readiness import ApplicationReadinessCheckService
+from job_hunter_agent.core.event_bus import EventBusPort
+from job_hunter_agent.core.events import ApplicationPreflightCompletedV1
 from job_hunter_agent.core.portal_capabilities import get_portal_capabilities
 from job_hunter_agent.infrastructure.repository import JobRepository
 
@@ -37,11 +39,13 @@ class ApplicationPreflightService:
         repository: JobRepository,
         flow_inspector: InspectionPort | None = None,
         readiness_checker: ApplicationReadinessCheckService | None = None,
+        event_bus: EventBusPort | None = None,
     ) -> None:
         self.repository = repository
         self.flow_inspector = flow_inspector
         self.flow = ApplicationFlowCoordinator(repository)
         self.readiness_checker = readiness_checker
+        self.event_bus = event_bus
 
     def run_dry_run_for_application(self, application_id: int) -> ApplicationPreflightResult:
         context = load_application_context(self.repository, application_id)
@@ -99,6 +103,13 @@ class ApplicationPreflightService:
                 from_status=application.status,
                 to_status=application.status,
             )
+            self._publish_preflight_event(
+                application_id=application.id,
+                job_id=job.id or application.job_id,
+                outcome="ignored",
+                detail=detail,
+                application_status=application.status,
+            )
             return ApplicationPreflightResult(
                 outcome="ignored",
                 detail=detail,
@@ -114,6 +125,13 @@ class ApplicationPreflightService:
                 event_type="preflight_blocked",
                 status="error_submit",
                 clear_error=False,
+            )
+            self._publish_preflight_event(
+                application_id=application.id,
+                job_id=job.id or application.job_id,
+                outcome="blocked",
+                detail=detail,
+                application_status=application_status,
             )
             return ApplicationPreflightResult(
                 outcome="blocked",
@@ -134,6 +152,13 @@ class ApplicationPreflightService:
                     event_type="preflight_blocked",
                     status="error_submit",
                     clear_error=False,
+                )
+                self._publish_preflight_event(
+                    application_id=application.id,
+                    job_id=job.id or application.job_id,
+                    outcome="blocked",
+                    detail=detail,
+                    application_status=application_status,
                 )
                 return ApplicationPreflightResult(
                     outcome="blocked",
@@ -156,6 +181,13 @@ class ApplicationPreflightService:
                         status="confirmed",
                         clear_error=True,
                     )
+                    self._publish_preflight_event(
+                        application_id=application.id,
+                        job_id=job.id or application.job_id,
+                        outcome="error",
+                        detail=detail,
+                        application_status=application_status,
+                    )
                     return ApplicationPreflightResult(
                         outcome="error",
                         detail=detail,
@@ -171,6 +203,13 @@ class ApplicationPreflightService:
                             status="confirmed",
                             clear_error=True,
                         )
+                        self._publish_preflight_event(
+                            application_id=application.id,
+                            job_id=job.id or application.job_id,
+                            outcome="ready",
+                            detail=inspection.detail,
+                            application_status=application_status,
+                        )
                         return ApplicationPreflightResult(
                             outcome="ready",
                             detail=inspection.detail,
@@ -184,6 +223,13 @@ class ApplicationPreflightService:
                             event_type="preflight_manual_review",
                             status="confirmed",
                             clear_error=True,
+                        )
+                        self._publish_preflight_event(
+                            application_id=application.id,
+                            job_id=job.id or application.job_id,
+                            outcome="manual_review",
+                            detail=inspection.detail,
+                            application_status=application_status,
                         )
                         return ApplicationPreflightResult(
                             outcome="manual_review",
@@ -199,6 +245,13 @@ class ApplicationPreflightService:
                         status="error_submit",
                         clear_error=False,
                     )
+                    self._publish_preflight_event(
+                        application_id=application.id,
+                        job_id=job.id or application.job_id,
+                        outcome="blocked",
+                        detail=detail,
+                        application_status=application_status,
+                    )
                     return ApplicationPreflightResult(
                         outcome="blocked",
                         detail=detail,
@@ -212,6 +265,13 @@ class ApplicationPreflightService:
                 event_type="preflight_ready",
                 status="confirmed",
                 clear_error=True,
+            )
+            self._publish_preflight_event(
+                application_id=application.id,
+                job_id=job.id or application.job_id,
+                outcome="ready",
+                detail=detail,
+                application_status=application_status,
             )
             return ApplicationPreflightResult(
                 outcome="ready",
@@ -228,8 +288,37 @@ class ApplicationPreflightService:
             status="error_submit",
             clear_error=False,
         )
+        self._publish_preflight_event(
+            application_id=application.id,
+            job_id=job.id or application.job_id,
+            outcome="blocked",
+            detail=detail,
+            application_status=application_status,
+        )
         return ApplicationPreflightResult(
             outcome="blocked",
             detail=detail,
             application_status=application_status,
+        )
+
+    def _publish_preflight_event(
+        self,
+        *,
+        application_id: int | None,
+        job_id: int,
+        outcome: str,
+        detail: str,
+        application_status: str,
+    ) -> None:
+        if self.event_bus is None or application_id is None:
+            return
+        self.event_bus.publish(
+            ApplicationPreflightCompletedV1(
+                application_id=application_id,
+                job_id=job_id,
+                outcome=outcome,
+                application_status=application_status,
+                detail=detail,
+                correlation_id=f"application:{application_id}",
+            )
         )

--- a/job_hunter_agent/application/composition.py
+++ b/job_hunter_agent/application/composition.py
@@ -100,7 +100,11 @@ def create_application_preparation_service(repository: JobRepository, settings: 
     )
 
 
-def create_application_preflight_service(repository: JobRepository, settings: Settings) -> ApplicationPreflightService:
+def create_application_preflight_service(
+    repository: JobRepository,
+    settings: Settings,
+    event_bus: EventBusPort | None = None,
+) -> ApplicationPreflightService:
     return ApplicationPreflightService(
         repository,
         flow_inspector=create_linkedin_preflight_inspector(settings),
@@ -111,6 +115,7 @@ def create_application_preflight_service(repository: JobRepository, settings: Se
             phone=settings.application_phone,
             phone_country_code=settings.application_phone_country_code,
         ),
+        event_bus=event_bus,
     )
 
 

--- a/job_hunter_agent/application/domain_events_cli.py
+++ b/job_hunter_agent/application/domain_events_cli.py
@@ -7,6 +7,7 @@ from job_hunter_agent.core.event_bus import LocalNdjsonEventBus
 from job_hunter_agent.core.events import (
     ApplicationAuthorizedV1,
     ApplicationBlockedV1,
+    ApplicationPreflightCompletedV1,
     ApplicationSubmittedV1,
     DomainEvent,
     JobCollectedV1,
@@ -89,6 +90,11 @@ def _render_event_line(event: DomainEvent) -> str:
         return (
             f"{base} application_id={event.application_id} job_id={event.job_id} "
             f"authorized_by={event.authorized_by or '-'} source={event.authorization_source} status={event.status}"
+        )
+    if isinstance(event, ApplicationPreflightCompletedV1):
+        return (
+            f"{base} application_id={event.application_id} job_id={event.job_id} "
+            f"outcome={event.outcome} status={event.application_status}"
         )
     if isinstance(event, ApplicationSubmittedV1):
         return (

--- a/job_hunter_agent/core/event_bus.py
+++ b/job_hunter_agent/core/event_bus.py
@@ -6,6 +6,7 @@ from typing import Protocol
 from job_hunter_agent.core.events import (
     ApplicationAuthorizedV1,
     ApplicationBlockedV1,
+    ApplicationPreflightCompletedV1,
     ApplicationSubmittedV1,
     DomainEvent,
     JobCollectedV1,
@@ -64,6 +65,9 @@ class LocalNdjsonEventBus:
 
     def read_application_authorized(self) -> tuple[ApplicationAuthorizedV1, ...]:
         return tuple(event for event in self.read_all() if isinstance(event, ApplicationAuthorizedV1))
+
+    def read_application_preflight_completed(self) -> tuple[ApplicationPreflightCompletedV1, ...]:
+        return tuple(event for event in self.read_all() if isinstance(event, ApplicationPreflightCompletedV1))
 
     def read_application_submitted(self) -> tuple[ApplicationSubmittedV1, ...]:
         return tuple(event for event in self.read_all() if isinstance(event, ApplicationSubmittedV1))

--- a/job_hunter_agent/core/events.py
+++ b/job_hunter_agent/core/events.py
@@ -88,6 +88,20 @@ class ApplicationAuthorizedV1:
 
 
 @dataclass(frozen=True)
+class ApplicationPreflightCompletedV1:
+    application_id: int
+    job_id: int
+    outcome: str
+    application_status: str
+    detail: str = ""
+    event_id: str = field(default_factory=new_event_id)
+    event_type: str = "ApplicationPreflightCompletedV1"
+    event_version: int = 1
+    occurred_at: str = field(default_factory=utc_now_iso)
+    correlation_id: str = ""
+
+
+@dataclass(frozen=True)
 class ApplicationSubmittedV1:
     application_id: int
     job_id: int
@@ -121,6 +135,7 @@ DomainEvent = (
     | JobReviewRequestedV1
     | JobReviewedV1
     | ApplicationAuthorizedV1
+    | ApplicationPreflightCompletedV1
     | ApplicationSubmittedV1
     | ApplicationBlockedV1
 )
@@ -153,6 +168,8 @@ def event_from_dict(payload: dict[str, Any]) -> DomainEvent:
         return job_reviewed_from_dict(payload)
     if event_type == "ApplicationAuthorizedV1":
         return application_authorized_from_dict(payload)
+    if event_type == "ApplicationPreflightCompletedV1":
+        return application_preflight_completed_from_dict(payload)
     if event_type == "ApplicationSubmittedV1":
         return application_submitted_from_dict(payload)
     if event_type == "ApplicationBlockedV1":
@@ -232,6 +249,21 @@ def application_authorized_from_dict(payload: dict[str, Any]) -> ApplicationAuth
         status=_safe_str(payload.get("status")) or "authorized_submit",
         event_id=_safe_str(payload.get("event_id")) or new_event_id(),
         event_type="ApplicationAuthorizedV1",
+        event_version=_safe_int(payload.get("event_version")) or 1,
+        occurred_at=_safe_str(payload.get("occurred_at")) or utc_now_iso(),
+        correlation_id=_safe_str(payload.get("correlation_id")),
+    )
+
+
+def application_preflight_completed_from_dict(payload: dict[str, Any]) -> ApplicationPreflightCompletedV1:
+    return ApplicationPreflightCompletedV1(
+        application_id=_safe_int(payload.get("application_id")),
+        job_id=_safe_int(payload.get("job_id")),
+        outcome=_safe_str(payload.get("outcome")),
+        application_status=_safe_str(payload.get("application_status")),
+        detail=_safe_str(payload.get("detail")),
+        event_id=_safe_str(payload.get("event_id")) or new_event_id(),
+        event_type="ApplicationPreflightCompletedV1",
         event_version=_safe_int(payload.get("event_version")) or 1,
         occurred_at=_safe_str(payload.get("occurred_at")) or utc_now_iso(),
         correlation_id=_safe_str(payload.get("correlation_id")),

--- a/tests/test_domain_transition_events.py
+++ b/tests/test_domain_transition_events.py
@@ -6,12 +6,14 @@ from job_hunter_agent.application.application_commands import (
     ApplicationTransitionCommandService,
     JobReviewCommandService,
 )
+from job_hunter_agent.application.application_preflight import ApplicationPreflightService
 from job_hunter_agent.application.application_submission import ApplicationSubmissionService
-from job_hunter_agent.application.contracts import ApplicationSubmissionResult
+from job_hunter_agent.application.contracts import ApplicationFlowInspection, ApplicationSubmissionResult
 from job_hunter_agent.core.domain import JobApplication, JobPosting
 from job_hunter_agent.core.events import (
     ApplicationAuthorizedV1,
     ApplicationBlockedV1,
+    ApplicationPreflightCompletedV1,
     ApplicationSubmittedV1,
     DomainEvent,
     JobReviewedV1,
@@ -133,6 +135,64 @@ class DomainTransitionEventTests(TestCase):
         self.assertEqual(event.authorized_by, "command")
         self.assertEqual(event.status, "authorized_submit")
         self.assertEqual(event.correlation_id, "application:55")
+
+    def test_application_preflight_publishes_completed_event(self) -> None:
+        class _Repository:
+            def __init__(self) -> None:
+                self.marked: list[dict[str, object]] = []
+                self.events: list[dict[str, object]] = []
+
+            def get_application(self, application_id: int):
+                return JobApplication(id=application_id, job_id=10, status="confirmed")
+
+            def get_job(self, job_id: int):
+                return _job(job_id=job_id)
+
+            def mark_application_status(self, application_id: int, **kwargs) -> None:
+                self.marked.append({"application_id": application_id, **kwargs})
+
+            def record_application_event(self, application_id: int, **kwargs) -> None:
+                self.events.append({"application_id": application_id, **kwargs})
+
+        class _Inspector:
+            def inspect(self, job: JobPosting):
+                return ApplicationFlowInspection(
+                    outcome="ready",
+                    detail="preflight real ok | pronto_para_envio=sim",
+                )
+
+        event_bus = _EventBus()
+        service = ApplicationPreflightService(_Repository(), flow_inspector=_Inspector(), event_bus=event_bus)
+
+        result = service.run_for_application(55)
+
+        self.assertEqual(result.outcome, "ready")
+        self.assertEqual(result.application_status, "confirmed")
+        self.assertEqual(len(event_bus.events), 1)
+        event = event_bus.events[0]
+        self.assertIsInstance(event, ApplicationPreflightCompletedV1)
+        self.assertEqual(event.application_id, 55)
+        self.assertEqual(event.job_id, 10)
+        self.assertEqual(event.outcome, "ready")
+        self.assertEqual(event.application_status, "confirmed")
+        self.assertEqual(event.detail, "preflight real ok | pronto_para_envio=sim")
+        self.assertEqual(event.correlation_id, "application:55")
+
+    def test_application_preflight_dry_run_does_not_publish_event(self) -> None:
+        class _Repository:
+            def get_application(self, application_id: int):
+                return JobApplication(id=application_id, job_id=10, status="confirmed")
+
+            def get_job(self, job_id: int):
+                return _job(job_id=job_id)
+
+        event_bus = _EventBus()
+        service = ApplicationPreflightService(_Repository(), event_bus=event_bus)
+
+        result = service.run_dry_run_for_application(55)
+
+        self.assertEqual(result.outcome, "ready")
+        self.assertEqual(event_bus.events, [])
 
     def test_application_submission_publishes_submitted_event(self) -> None:
         class _Repository:

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -6,6 +6,7 @@ from job_hunter_agent.core.domain import JobPosting
 from job_hunter_agent.core.events import (
     ApplicationAuthorizedV1,
     ApplicationBlockedV1,
+    ApplicationPreflightCompletedV1,
     ApplicationSubmittedV1,
     JobCollectedV1,
     JobReviewRequestedV1,
@@ -152,6 +153,29 @@ class EventContractTests(TestCase):
         self.assertEqual(decoded.authorized_by, "cli")
         self.assertEqual(decoded.authorization_source, "manual")
         self.assertEqual(decoded.status, "authorized_submit")
+        self.assertEqual(decoded.correlation_id, "application:55")
+
+    def test_application_preflight_completed_round_trip_json_preserves_payload_and_metadata(self) -> None:
+        event = ApplicationPreflightCompletedV1(
+            application_id=55,
+            job_id=123,
+            outcome="ready",
+            application_status="confirmed",
+            detail="preflight real ok | pronto_para_envio=sim",
+            event_id="evt-preflight",
+            occurred_at="2026-04-24T12:04:30+00:00",
+            correlation_id="application:55",
+        )
+
+        decoded = event_from_json(event_to_json(event))
+
+        self.assertIsInstance(decoded, ApplicationPreflightCompletedV1)
+        self.assertEqual(decoded.event_type, "ApplicationPreflightCompletedV1")
+        self.assertEqual(decoded.application_id, 55)
+        self.assertEqual(decoded.job_id, 123)
+        self.assertEqual(decoded.outcome, "ready")
+        self.assertEqual(decoded.application_status, "confirmed")
+        self.assertEqual(decoded.detail, "preflight real ok | pronto_para_envio=sim")
         self.assertEqual(decoded.correlation_id, "application:55")
 
     def test_application_submitted_round_trip_json_preserves_payload_and_metadata(self) -> None:


### PR DESCRIPTION
## Resumo

Adiciona `ApplicationPreflightCompletedV1` para auditar o resultado do preflight real de candidaturas.

## O que entrou

- Novo contrato `ApplicationPreflightCompletedV1`.
- Desserialização/round-trip JSON do novo evento.
- `LocalNdjsonEventBus.read_application_preflight_completed()`.
- Renderização no `domain-events list`.
- `ApplicationPreflightService` publica o evento no fluxo real de preflight quando há `event_bus` injetado.
- Dry-run de preflight não publica evento.
- Injeção do event bus no preflight da aplicação.
- `docs/DOMAIN_EVENTS.md` atualizado.

## Escopo consciente

- Sem broker externo.
- Sem migração de banco.
- Sem alterar publicação quando `JOB_HUNTER_DOMAIN_EVENTS_ENABLED=false`.
- Sem novos workers.

Refs #27