### PR TITLE
Adiciona evento de domínio para draft de candidatura

### DIFF
--- a/docs/DOMAIN_EVENTS.md
+++ b/docs/DOMAIN_EVENTS.md
@@ -101,6 +101,22 @@ Uso principal:
 - auditar gates humanos antes de submit real
 - identificar candidaturas que entraram no estado `authorized_submit`
 
+### `ApplicationDraftCreatedV1`
+
+Emitido quando uma vaga aprovada gera um novo rascunho de candidatura.
+
+Exemplo:
+
+```text
+ApplicationDraftCreatedV1 event_id=<uuid> correlation_id=application:77 application_id=77 job_id=238 status=draft support_level=supported created_by=command
+```
+
+Uso principal:
+
+- auditar quando uma vaga aprovada vira candidatura
+- diferenciar criacao real de draft de tentativas ignoradas porque ja existia candidatura
+- correlacionar o inicio da candidatura com preflight, autorizacao e envio
+
 ### `ApplicationPreflightCompletedV1`
 
 Emitido quando o preflight real de uma candidatura termina com qualquer resultado controlado.
@@ -164,6 +180,21 @@ Esperado:
 ```text
 JobReviewedV1 ... correlation_id=job:<job_id> ... decision=approve ... status=approved
 ```
+
+### Criacao De Draft De Candidatura
+
+```bash
+python main.py applications create --job-id <job_id>
+python main.py domain-events list --event-type ApplicationDraftCreatedV1 --limit 20
+```
+
+Esperado quando um novo draft for criado:
+
+```text
+ApplicationDraftCreatedV1 ... application_id=<application_id> ... job_id=<job_id> ... status=draft
+```
+
+Se ja existir candidatura para a vaga, o comando deve ser ignorado e nenhum `ApplicationDraftCreatedV1` novo deve ser emitido.
 
 ### Autorizacao De Candidatura
 
@@ -265,6 +296,8 @@ Confirme se a transicao realmente mudou estado.
 
 Exemplo: aprovar uma vaga ja aprovada pode ser ignorado e nao publicar novo evento.
 
+Criar candidatura para uma vaga que ja tem candidatura tambem e ignorado e nao publica novo `ApplicationDraftCreatedV1`.
+
 ### `ApplicationBlockedV1` apareceu no submit
 
 Isso nem sempre e erro. Pode indicar bloqueio seguro esperado, como:
@@ -283,13 +316,13 @@ Ativos hoje:
 
 - `JobReviewedV1`
 - `ApplicationAuthorizedV1`
+- `ApplicationDraftCreatedV1`
 - `ApplicationPreflightCompletedV1`
 - `ApplicationSubmittedV1`
 - `ApplicationBlockedV1`
 
 Candidatos futuros:
 
-- `ApplicationDraftCreatedV1`
 - `JobPersistedV1`
 
 Nao adicionar novos eventos sem valor operacional claro.

--- a/job_hunter_agent/application/app.py
+++ b/job_hunter_agent/application/app.py
@@ -116,6 +116,7 @@ class JobHunterApplication:
         self.application_draft_commands = ApplicationDraftCommandService(
             self.repository,
             self.application_preparation,
+            event_bus=self.domain_event_bus,
         )
         self.application_transition_commands = ApplicationTransitionCommandService(
             self.repository,
@@ -304,7 +305,11 @@ class JobHunterApplication:
     def _application_draft_commands(self) -> ApplicationDraftCommandService:
         service = getattr(self, "application_draft_commands", None)
         if service is None:
-            service = ApplicationDraftCommandService(self.repository, self.application_preparation)
+            service = ApplicationDraftCommandService(
+                self.repository,
+                self.application_preparation,
+                event_bus=getattr(self, "domain_event_bus", None),
+            )
             self.application_draft_commands = service
         return service
 

--- a/job_hunter_agent/application/application_commands.py
+++ b/job_hunter_agent/application/application_commands.py
@@ -8,7 +8,7 @@ from job_hunter_agent.application.application_messages import (
 from job_hunter_agent.application.contracts import PreparationPort
 from job_hunter_agent.application.review_workflow import resolve_application_action, resolve_review_action
 from job_hunter_agent.core.event_bus import EventBusPort
-from job_hunter_agent.core.events import ApplicationAuthorizedV1, JobReviewedV1
+from job_hunter_agent.core.events import ApplicationAuthorizedV1, ApplicationDraftCreatedV1, JobReviewedV1
 from job_hunter_agent.infrastructure.repository import JobRepository
 
 
@@ -45,9 +45,11 @@ class ApplicationDraftCommandService:
         self,
         repository: JobRepository,
         preparation_service: PreparationPort,
+        event_bus: EventBusPort | None = None,
     ) -> None:
         self.repository = repository
         self.preparation_service = preparation_service
+        self.event_bus = event_bus
 
     def create_application_draft_for_job(self, job_id: int) -> str:
         job = self.repository.get_job(job_id)
@@ -66,6 +68,17 @@ class ApplicationDraftCommandService:
         if not drafts:
             return format_job_not_approved_for_draft(job_id=job_id)
         draft = drafts[0]
+        if self.event_bus is not None:
+            self.event_bus.publish(
+                ApplicationDraftCreatedV1(
+                    application_id=draft.id or 0,
+                    job_id=job_id,
+                    status=draft.status,
+                    support_level=draft.support_level,
+                    created_by="command",
+                    correlation_id=f"application:{draft.id}" if draft.id is not None else f"job:{job_id}",
+                )
+            )
         return format_created_application_draft(
             application_id=draft.id,
             job_id=job_id,

--- a/job_hunter_agent/application/domain_events_cli.py
+++ b/job_hunter_agent/application/domain_events_cli.py
@@ -7,6 +7,7 @@ from job_hunter_agent.core.event_bus import LocalNdjsonEventBus
 from job_hunter_agent.core.events import (
     ApplicationAuthorizedV1,
     ApplicationBlockedV1,
+    ApplicationDraftCreatedV1,
     ApplicationPreflightCompletedV1,
     ApplicationSubmittedV1,
     DomainEvent,
@@ -90,6 +91,11 @@ def _render_event_line(event: DomainEvent) -> str:
         return (
             f"{base} application_id={event.application_id} job_id={event.job_id} "
             f"authorized_by={event.authorized_by or '-'} source={event.authorization_source} status={event.status}"
+        )
+    if isinstance(event, ApplicationDraftCreatedV1):
+        return (
+            f"{base} application_id={event.application_id} job_id={event.job_id} "
+            f"status={event.status} support_level={event.support_level or '-'} created_by={event.created_by or '-'}"
         )
     if isinstance(event, ApplicationPreflightCompletedV1):
         return (

--- a/job_hunter_agent/core/event_bus.py
+++ b/job_hunter_agent/core/event_bus.py
@@ -6,6 +6,7 @@ from typing import Protocol
 from job_hunter_agent.core.events import (
     ApplicationAuthorizedV1,
     ApplicationBlockedV1,
+    ApplicationDraftCreatedV1,
     ApplicationPreflightCompletedV1,
     ApplicationSubmittedV1,
     DomainEvent,
@@ -65,6 +66,9 @@ class LocalNdjsonEventBus:
 
     def read_application_authorized(self) -> tuple[ApplicationAuthorizedV1, ...]:
         return tuple(event for event in self.read_all() if isinstance(event, ApplicationAuthorizedV1))
+
+    def read_application_draft_created(self) -> tuple[ApplicationDraftCreatedV1, ...]:
+        return tuple(event for event in self.read_all() if isinstance(event, ApplicationDraftCreatedV1))
 
     def read_application_preflight_completed(self) -> tuple[ApplicationPreflightCompletedV1, ...]:
         return tuple(event for event in self.read_all() if isinstance(event, ApplicationPreflightCompletedV1))

--- a/job_hunter_agent/core/events.py
+++ b/job_hunter_agent/core/events.py
@@ -88,6 +88,20 @@ class ApplicationAuthorizedV1:
 
 
 @dataclass(frozen=True)
+class ApplicationDraftCreatedV1:
+    application_id: int
+    job_id: int
+    status: str
+    support_level: str = ""
+    created_by: str = "command"
+    event_id: str = field(default_factory=new_event_id)
+    event_type: str = "ApplicationDraftCreatedV1"
+    event_version: int = 1
+    occurred_at: str = field(default_factory=utc_now_iso)
+    correlation_id: str = ""
+
+
+@dataclass(frozen=True)
 class ApplicationPreflightCompletedV1:
     application_id: int
     job_id: int
@@ -135,6 +149,7 @@ DomainEvent = (
     | JobReviewRequestedV1
     | JobReviewedV1
     | ApplicationAuthorizedV1
+    | ApplicationDraftCreatedV1
     | ApplicationPreflightCompletedV1
     | ApplicationSubmittedV1
     | ApplicationBlockedV1
@@ -168,6 +183,8 @@ def event_from_dict(payload: dict[str, Any]) -> DomainEvent:
         return job_reviewed_from_dict(payload)
     if event_type == "ApplicationAuthorizedV1":
         return application_authorized_from_dict(payload)
+    if event_type == "ApplicationDraftCreatedV1":
+        return application_draft_created_from_dict(payload)
     if event_type == "ApplicationPreflightCompletedV1":
         return application_preflight_completed_from_dict(payload)
     if event_type == "ApplicationSubmittedV1":
@@ -249,6 +266,21 @@ def application_authorized_from_dict(payload: dict[str, Any]) -> ApplicationAuth
         status=_safe_str(payload.get("status")) or "authorized_submit",
         event_id=_safe_str(payload.get("event_id")) or new_event_id(),
         event_type="ApplicationAuthorizedV1",
+        event_version=_safe_int(payload.get("event_version")) or 1,
+        occurred_at=_safe_str(payload.get("occurred_at")) or utc_now_iso(),
+        correlation_id=_safe_str(payload.get("correlation_id")),
+    )
+
+
+def application_draft_created_from_dict(payload: dict[str, Any]) -> ApplicationDraftCreatedV1:
+    return ApplicationDraftCreatedV1(
+        application_id=_safe_int(payload.get("application_id")),
+        job_id=_safe_int(payload.get("job_id")),
+        status=_safe_str(payload.get("status")),
+        support_level=_safe_str(payload.get("support_level")),
+        created_by=_safe_str(payload.get("created_by")) or "command",
+        event_id=_safe_str(payload.get("event_id")) or new_event_id(),
+        event_type="ApplicationDraftCreatedV1",
         event_version=_safe_int(payload.get("event_version")) or 1,
         occurred_at=_safe_str(payload.get("occurred_at")) or utc_now_iso(),
         correlation_id=_safe_str(payload.get("correlation_id")),

--- a/tests/test_domain_transition_events.py
+++ b/tests/test_domain_transition_events.py
@@ -116,7 +116,7 @@ class DomainTransitionEventTests(TestCase):
 
         rendered = service.create_application_draft_for_job(10)
 
-        self.assertIn("Candidatura criada", rendered)
+        self.assertIn("Rascunho criado", rendered)
         self.assertEqual(len(event_bus.events), 1)
         event = event_bus.events[0]
         self.assertIsInstance(event, ApplicationDraftCreatedV1)
@@ -144,7 +144,7 @@ class DomainTransitionEventTests(TestCase):
 
         rendered = service.create_application_draft_for_job(10)
 
-        self.assertIn("Ja existe candidatura", rendered)
+        self.assertIn("Candidatura ja existe", rendered)
         self.assertEqual(event_bus.events, [])
 
     def test_authorize_application_publishes_application_authorized(self) -> None:

--- a/tests/test_domain_transition_events.py
+++ b/tests/test_domain_transition_events.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from unittest import TestCase
 
 from job_hunter_agent.application.application_commands import (
+    ApplicationDraftCommandService,
     ApplicationTransitionCommandService,
     JobReviewCommandService,
 )
@@ -13,6 +14,7 @@ from job_hunter_agent.core.domain import JobApplication, JobPosting
 from job_hunter_agent.core.events import (
     ApplicationAuthorizedV1,
     ApplicationBlockedV1,
+    ApplicationDraftCreatedV1,
     ApplicationPreflightCompletedV1,
     ApplicationSubmittedV1,
     DomainEvent,
@@ -95,6 +97,54 @@ class DomainTransitionEventTests(TestCase):
         detail = service.review_job(10, "approve")
 
         self.assertEqual(detail, "Vaga ja estava aprovada: Backend Java - ACME")
+        self.assertEqual(event_bus.events, [])
+
+    def test_application_draft_creation_publishes_draft_created(self) -> None:
+        class _Repository:
+            def get_job(self, job_id: int):
+                return _job(job_id=job_id)
+
+            def get_application_by_job(self, job_id: int):
+                return None
+
+        class _Preparation:
+            def create_drafts_for_approved_jobs(self, job_ids: list[int], notes: str = ""):
+                return [JobApplication(id=77, job_id=job_ids[0], status="draft", support_level="supported")]
+
+        event_bus = _EventBus()
+        service = ApplicationDraftCommandService(_Repository(), _Preparation(), event_bus=event_bus)
+
+        rendered = service.create_application_draft_for_job(10)
+
+        self.assertIn("Candidatura criada", rendered)
+        self.assertEqual(len(event_bus.events), 1)
+        event = event_bus.events[0]
+        self.assertIsInstance(event, ApplicationDraftCreatedV1)
+        self.assertEqual(event.application_id, 77)
+        self.assertEqual(event.job_id, 10)
+        self.assertEqual(event.status, "draft")
+        self.assertEqual(event.support_level, "supported")
+        self.assertEqual(event.created_by, "command")
+        self.assertEqual(event.correlation_id, "application:77")
+
+    def test_application_draft_creation_does_not_publish_when_application_exists(self) -> None:
+        class _Repository:
+            def get_job(self, job_id: int):
+                return _job(job_id=job_id)
+
+            def get_application_by_job(self, job_id: int):
+                return JobApplication(id=77, job_id=job_id, status="draft")
+
+        class _Preparation:
+            def create_drafts_for_approved_jobs(self, job_ids: list[int], notes: str = ""):
+                raise AssertionError("should not create a new draft")
+
+        event_bus = _EventBus()
+        service = ApplicationDraftCommandService(_Repository(), _Preparation(), event_bus=event_bus)
+
+        rendered = service.create_application_draft_for_job(10)
+
+        self.assertIn("Ja existe candidatura", rendered)
         self.assertEqual(event_bus.events, [])
 
     def test_authorize_application_publishes_application_authorized(self) -> None:

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -6,6 +6,7 @@ from job_hunter_agent.core.domain import JobPosting
 from job_hunter_agent.core.events import (
     ApplicationAuthorizedV1,
     ApplicationBlockedV1,
+    ApplicationDraftCreatedV1,
     ApplicationPreflightCompletedV1,
     ApplicationSubmittedV1,
     JobCollectedV1,
@@ -153,6 +154,29 @@ class EventContractTests(TestCase):
         self.assertEqual(decoded.authorized_by, "cli")
         self.assertEqual(decoded.authorization_source, "manual")
         self.assertEqual(decoded.status, "authorized_submit")
+        self.assertEqual(decoded.correlation_id, "application:55")
+
+    def test_application_draft_created_round_trip_json_preserves_payload_and_metadata(self) -> None:
+        event = ApplicationDraftCreatedV1(
+            application_id=55,
+            job_id=123,
+            status="draft",
+            support_level="supported",
+            created_by="command",
+            event_id="evt-draft",
+            occurred_at="2026-04-24T12:04:15+00:00",
+            correlation_id="application:55",
+        )
+
+        decoded = event_from_json(event_to_json(event))
+
+        self.assertIsInstance(decoded, ApplicationDraftCreatedV1)
+        self.assertEqual(decoded.event_type, "ApplicationDraftCreatedV1")
+        self.assertEqual(decoded.application_id, 55)
+        self.assertEqual(decoded.job_id, 123)
+        self.assertEqual(decoded.status, "draft")
+        self.assertEqual(decoded.support_level, "supported")
+        self.assertEqual(decoded.created_by, "command")
         self.assertEqual(decoded.correlation_id, "application:55")
 
     def test_application_preflight_completed_round_trip_json_preserves_payload_and_metadata(self) -> None:


### PR DESCRIPTION
## Resumo

Adiciona `ApplicationDraftCreatedV1` para auditar quando uma vaga aprovada gera um novo rascunho de candidatura.

## O que entrou

- Novo contrato `ApplicationDraftCreatedV1`.
- Desserialização/round-trip JSON do novo evento.
- `LocalNdjsonEventBus.read_application_draft_created()`.
- Renderização no `domain-events list`.
- `ApplicationDraftCommandService` publica o evento somente quando cria um draft novo.
- Nenhum evento é emitido quando já existe candidatura para a vaga.
- Injeção do event bus no comando de draft da aplicação.
- `docs/DOMAIN_EVENTS.md` atualizado.

## Escopo consciente

- Sem broker externo.
- Sem migração de banco.
- Sem alterar publicação quando `JOB_HUNTER_DOMAIN_EVENTS_ENABLED=false`.
- Sem novos workers.

Refs #27