### PR TITLE
chore: add SQLite schema migration baseline helper

### DIFF
--- a/job_hunter_agent/infrastructure/__init__.py
+++ b/job_hunter_agent/infrastructure/__init__.py
@@ -1,2 +1,5 @@
 """Infrastructure adapters such as persistence and transport."""
 
+from job_hunter_agent.infrastructure.repository_schema_bootstrap import install_schema_migration_bootstrap
+
+install_schema_migration_bootstrap()

--- a/job_hunter_agent/infrastructure/repository_schema_bootstrap.py
+++ b/job_hunter_agent/infrastructure/repository_schema_bootstrap.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from typing import Any, Callable
+
+from job_hunter_agent.infrastructure.schema_migrations import ensure_current_schema_version
+
+
+def install_schema_migration_bootstrap() -> None:
+    """Ensure SqliteJobRepository records the current schema version on startup.
+
+    The repository module is currently large and central to local persistence. This
+    bootstrap keeps the migration registration isolated while preserving the
+    existing table-creation flow and user data compatibility.
+    """
+    from job_hunter_agent.infrastructure import repository as repository_module
+
+    repository_class = repository_module.SqliteJobRepository
+    if getattr(repository_class, "_schema_migration_bootstrap_installed", False):
+        return
+
+    original_create_tables: Callable[[Any], None] = repository_class._create_tables
+
+    def create_tables_and_register_schema(self: Any) -> None:
+        original_create_tables(self)
+        with self._connect() as connection:
+            ensure_current_schema_version(connection)
+
+    repository_class._create_tables = create_tables_and_register_schema
+    repository_class._schema_migration_bootstrap_installed = True

--- a/job_hunter_agent/infrastructure/schema_migrations.py
+++ b/job_hunter_agent/infrastructure/schema_migrations.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import sqlite3
+from dataclasses import dataclass
+from datetime import datetime, timezone
+
+CURRENT_SCHEMA_VERSION = 1
+CURRENT_SCHEMA_NAME = "initial_sqlite_schema"
+
+
+def utc_now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+@dataclass(frozen=True)
+class SchemaMigration:
+    version: int
+    name: str
+    applied_at_utc: str
+
+
+def ensure_schema_migrations_table(connection: sqlite3.Connection) -> None:
+    connection.execute(
+        """
+        CREATE TABLE IF NOT EXISTS schema_migrations (
+            version INTEGER PRIMARY KEY,
+            name TEXT NOT NULL,
+            applied_at_utc TEXT NOT NULL
+        )
+        """
+    )
+
+
+def ensure_current_schema_version(
+    connection: sqlite3.Connection,
+    *,
+    version: int = CURRENT_SCHEMA_VERSION,
+    name: str = CURRENT_SCHEMA_NAME,
+) -> None:
+    """Register the current SQLite schema version idempotently.
+
+    This helper is intentionally conservative: it creates only the migration
+    bookkeeping table and records the baseline version. It does not mutate user
+    tables or rewrite existing local data.
+    """
+    ensure_schema_migrations_table(connection)
+    connection.execute(
+        """
+        INSERT OR IGNORE INTO schema_migrations (version, name, applied_at_utc)
+        VALUES (?, ?, ?)
+        """,
+        (version, name, utc_now_iso()),
+    )
+
+
+def list_schema_migrations(connection: sqlite3.Connection) -> list[SchemaMigration]:
+    ensure_schema_migrations_table(connection)
+    rows = connection.execute(
+        """
+        SELECT version, name, applied_at_utc
+        FROM schema_migrations
+        ORDER BY version ASC
+        """
+    ).fetchall()
+    return [SchemaMigration(version=row[0], name=row[1], applied_at_utc=row[2]) for row in rows]

--- a/tests/test_repository_schema_bootstrap.py
+++ b/tests/test_repository_schema_bootstrap.py
@@ -1,14 +1,21 @@
-import sqlite3
+import shutil
 from unittest import TestCase
 
 from job_hunter_agent.infrastructure.repository import SqliteJobRepository
 from job_hunter_agent.infrastructure.schema_migrations import CURRENT_SCHEMA_VERSION
+from tests.tmp_workspace import prepare_workspace_tmp_dir
 
 
 class RepositorySchemaBootstrapTests(TestCase):
+    def setUp(self) -> None:
+        self.temp_dir = prepare_workspace_tmp_dir("schema-bootstrap")
+        self.db_path = self.temp_dir / "jobs.db"
+
+    def tearDown(self) -> None:
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
     def test_repository_startup_registers_current_schema_version(self) -> None:
-        connection = sqlite3.connect(":memory:")
-        repository = SqliteJobRepository(":memory:")
+        repository = SqliteJobRepository(self.db_path)
 
         # Use the repository connection helper so the assertion covers the
         # startup path installed by the infrastructure package bootstrap.

--- a/tests/test_repository_schema_bootstrap.py
+++ b/tests/test_repository_schema_bootstrap.py
@@ -1,0 +1,26 @@
+import sqlite3
+from unittest import TestCase
+
+from job_hunter_agent.infrastructure.repository import SqliteJobRepository
+from job_hunter_agent.infrastructure.schema_migrations import CURRENT_SCHEMA_VERSION
+
+
+class RepositorySchemaBootstrapTests(TestCase):
+    def test_repository_startup_registers_current_schema_version(self) -> None:
+        connection = sqlite3.connect(":memory:")
+        repository = SqliteJobRepository(":memory:")
+
+        # Use the repository connection helper so the assertion covers the
+        # startup path installed by the infrastructure package bootstrap.
+        with repository._connect() as connection:
+            rows = connection.execute(
+                """
+                SELECT version, name, applied_at_utc
+                FROM schema_migrations
+                ORDER BY version ASC
+                """
+            ).fetchall()
+
+        self.assertEqual(1, len(rows))
+        self.assertEqual(CURRENT_SCHEMA_VERSION, rows[0][0])
+        self.assertTrue(rows[0][2].endswith("+00:00"))

--- a/tests/test_schema_migrations.py
+++ b/tests/test_schema_migrations.py
@@ -1,0 +1,43 @@
+import sqlite3
+from unittest import TestCase
+
+from job_hunter_agent.infrastructure.schema_migrations import (
+    CURRENT_SCHEMA_NAME,
+    CURRENT_SCHEMA_VERSION,
+    ensure_current_schema_version,
+    list_schema_migrations,
+)
+
+
+class SchemaMigrationsTests(TestCase):
+    def test_ensure_current_schema_version_creates_bookkeeping_table(self) -> None:
+        connection = sqlite3.connect(":memory:")
+
+        ensure_current_schema_version(connection)
+
+        migrations = list_schema_migrations(connection)
+        self.assertEqual(1, len(migrations))
+        self.assertEqual(CURRENT_SCHEMA_VERSION, migrations[0].version)
+        self.assertEqual(CURRENT_SCHEMA_NAME, migrations[0].name)
+        self.assertTrue(migrations[0].applied_at_utc.endswith("+00:00"))
+
+    def test_ensure_current_schema_version_is_idempotent(self) -> None:
+        connection = sqlite3.connect(":memory:")
+
+        ensure_current_schema_version(connection)
+        first_migration = list_schema_migrations(connection)[0]
+        ensure_current_schema_version(connection)
+
+        migrations = list_schema_migrations(connection)
+        self.assertEqual([first_migration], migrations)
+
+    def test_ensure_current_schema_version_preserves_existing_legacy_tables(self) -> None:
+        connection = sqlite3.connect(":memory:")
+        connection.execute("CREATE TABLE jobs (id INTEGER PRIMARY KEY, title TEXT NOT NULL)")
+        connection.execute("INSERT INTO jobs (id, title) VALUES (1, 'Backend Java')")
+
+        ensure_current_schema_version(connection)
+
+        row = connection.execute("SELECT id, title FROM jobs").fetchone()
+        self.assertEqual((1, "Backend Java"), row)
+        self.assertEqual(1, len(list_schema_migrations(connection)))


### PR DESCRIPTION
## Resumo
- cria helper `schema_migrations.py` para registrar a versao inicial do schema SQLite de forma idempotente
- adiciona `utc_now_iso()` com timezone UTC explicito para metadados de migracao
- instala bootstrap no pacote `infrastructure` para registrar a versao de schema no startup do `SqliteJobRepository`
- adiciona testes com banco vazio, idempotencia, banco legado e startup real do repositorio

## Observacao
Este PR evita reescrever `repository.py` inteiro e isola o registro de schema em um bootstrap pequeno. A frente ainda pode continuar depois com padronizacao adicional de timestamps operacionais e atualizacao dos checklists.

Refs #34

## Testes
- `tests/test_schema_migrations.py`
- `tests/test_repository_schema_bootstrap.py`