### PR TITLE
feat: add application diagnose CLI

### DIFF
--- a/job_hunter_agent/application/app.py
+++ b/job_hunter_agent/application/app.py
@@ -108,7 +108,7 @@ class JobHunterApplication:
         )
 
     def _initialize_query_services(self) -> None:
-        self.query = ApplicationQueryService(self.repository)
+        self.query = ApplicationQueryService(self.repository, domain_event_bus=getattr(self, "domain_event_bus", None))
 
     def _initialize_review_services(self) -> None:
         self.application_preparation = create_application_preparation_service(self.repository, self.settings)
@@ -211,6 +211,9 @@ class JobHunterApplication:
     def show_application(self, application_id: int) -> str:
         return self._query_service().show_application(application_id)
 
+    def diagnose_application(self, application_id: int) -> str:
+        return self._query_service().diagnose_application(application_id)
+
     def transition_application(self, application_id: int, action: str) -> str:
         return self._application_transition_commands().transition_application(application_id, action)
 
@@ -291,7 +294,10 @@ class JobHunterApplication:
     def _query_service(self) -> ApplicationQueryService:
         query = getattr(self, "query", None)
         if query is None:
-            query = ApplicationQueryService(self.repository)
+            query = ApplicationQueryService(
+                self.repository,
+                domain_event_bus=getattr(self, "domain_event_bus", None),
+            )
             self.query = query
         return query
 

--- a/job_hunter_agent/application/application_cli.py
+++ b/job_hunter_agent/application/application_cli.py
@@ -87,6 +87,12 @@ def parse_args() -> argparse.Namespace:
     applications_show_parser = applications_subparsers.add_parser("show", help="Mostra uma candidatura.")
     applications_show_parser.add_argument("--id", type=int, required=True, help="ID da candidatura.")
 
+    applications_diagnose_parser = applications_subparsers.add_parser(
+        "diagnose",
+        help="Mostra diagnostico operacional agregado de uma candidatura.",
+    )
+    applications_diagnose_parser.add_argument("--id", type=int, required=True, help="ID da candidatura.")
+
     applications_events_parser = applications_subparsers.add_parser(
         "events",
         help="Lista eventos recentes de uma candidatura.",
@@ -261,7 +267,7 @@ def parse_args() -> argparse.Namespace:
     if args.ciclos is not None and args.ciclos <= 0:
         parser.error("--ciclos deve ser maior que zero")
     if args.intervalo_ciclos_segundos < 0:
-        parser.error("--intervalo-ciclos-segundos nao pode ser negativo")
+        parser.error("--intervalo-ciclos-segundos nao pode be negativo")
     if getattr(args, "limit", 1) is not None and getattr(args, "limit", 1) <= 0:
         parser.error("--limit deve ser maior que zero")
     if args.agora and args.ciclos is not None:

--- a/job_hunter_agent/application/application_cli.py
+++ b/job_hunter_agent/application/application_cli.py
@@ -267,7 +267,7 @@ def parse_args() -> argparse.Namespace:
     if args.ciclos is not None and args.ciclos <= 0:
         parser.error("--ciclos deve ser maior que zero")
     if args.intervalo_ciclos_segundos < 0:
-        parser.error("--intervalo-ciclos-segundos nao pode be negativo")
+        parser.error("--intervalo-ciclos-segundos nao pode ser negativo")
     if getattr(args, "limit", 1) is not None and getattr(args, "limit", 1) <= 0:
         parser.error("--limit deve ser maior que zero")
     if args.agora and args.ciclos is not None:

--- a/job_hunter_agent/application/application_cli_dispatch.py
+++ b/job_hunter_agent/application/application_cli_dispatch.py
@@ -81,6 +81,10 @@ def _run_applications_command(args: Namespace) -> None:
         app = create_query_app()
         print(app.show_application(args.id))
         return
+    if args.applications_command == "diagnose":
+        app = create_query_app()
+        print(app.diagnose_application(args.id))
+        return
     if args.applications_command == "events":
         app = create_query_app()
         print(app.show_application_events(args.id, limit=args.limit))

--- a/job_hunter_agent/application/application_cli_rendering.py
+++ b/job_hunter_agent/application/application_cli_rendering.py
@@ -8,6 +8,7 @@ from job_hunter_agent.core.application_insights import (
     classify_operational_detail,
     describe_manual_review_need,
 )
+from job_hunter_agent.core.events import DomainEvent, event_to_dict
 from job_hunter_agent.core.operational_policy import get_runtime_operational_policy
 
 
@@ -138,6 +139,62 @@ def render_application_detail(*, application: object, job: object | None, events
     return "\n".join(lines)
 
 
+def render_application_diagnosis(
+    *,
+    application: object,
+    job: object | None,
+    events: list[object],
+    domain_events: tuple[DomainEvent, ...] = (),
+    domain_events_enabled: bool = False,
+) -> str:
+    job_title = job.title if job is not None else "vaga nao encontrada"
+    job_company = job.company if job is not None else "-"
+    job_status = job.status if job is not None else "-"
+    job_source = job.source_site if job is not None else "-"
+    job_url = job.url if job is not None else "-"
+    insight = classify_application_operational_insight(application)
+    next_action = _recommend_application_next_action(application=application, insight_reason=insight.reason_code)
+    lines = [
+        f"Diagnostico da candidatura {application.id}",
+        "candidatura:",
+        f"- id={application.id}",
+        f"- status={application.status}",
+        f"- job_id={application.job_id}",
+        f"- suporte={application.support_level}",
+        f"- classificacao_operacional={insight.classification}",
+        f"- motivo_operacional={insight.reason_code}",
+        "vaga:",
+        f"- titulo={job_title}",
+        f"- empresa={job_company}",
+        f"- status={job_status}",
+        f"- fonte={job_source}",
+        f"- url={job_url}",
+        "preflight_submit:",
+        f"- last_preflight_detail={application.last_preflight_detail or '-'}",
+        f"- last_submit_detail={application.last_submit_detail or '-'}",
+        f"- last_error={application.last_error or '-'}",
+        f"- submitted_at={application.submitted_at or '-'}",
+        f"- notes={application.notes or '-'}",
+        "proxima_acao:",
+        f"- {next_action}",
+    ]
+    if application.support_level == "manual_review":
+        lines.extend(["revisao_manual:", f"- {describe_manual_review_need(application)}"])
+    lines.append("eventos_sqlite_recentes:")
+    if events:
+        lines.extend(_render_event_lines(events))
+    else:
+        lines.append("- nenhum")
+    lines.append("domain_events_recentes:")
+    if not domain_events_enabled:
+        lines.append("- indisponivel_ou_desabilitado")
+    elif domain_events:
+        lines.extend(_render_domain_event_lines(domain_events))
+    else:
+        lines.append("- nenhum")
+    return "\n".join(lines)
+
+
 def render_failure_artifacts(*, artifacts_dir: Path, files: list[Path], limit: int) -> str:
     if not artifacts_dir.exists():
         return f"Nenhum diretorio de artefatos encontrado: {artifacts_dir}"
@@ -200,6 +257,28 @@ def render_execution_summary(*, events: list[object]) -> str:
     return "\n".join(lines)
 
 
+def _recommend_application_next_action(*, application: object, insight_reason: str) -> str:
+    application_id = application.id
+    status = application.status
+    if status == "draft":
+        return f"preparar revisao: python main.py applications prepare --id {application_id}"
+    if status == "ready_for_review":
+        return f"confirmar ou cancelar apos revisao humana: python main.py applications confirm --id {application_id}"
+    if status == "confirmed":
+        if insight_reason == "pronto_para_envio":
+            return f"autorizar envio se revisao humana estiver ok: python main.py applications authorize --id {application_id}"
+        return f"rodar preflight real ou dry-run: python main.py applications preflight --id {application_id}"
+    if status == "authorized_submit":
+        return f"executar submit controlado ou dry-run: python main.py applications submit --id {application_id}"
+    if status == "error_submit":
+        return "investigar bloqueio: revisar last_error, artifacts e domain-events antes de tentar novamente"
+    if status == "submitted":
+        return "nenhuma acao operacional pendente: candidatura ja enviada"
+    if status == "cancelled":
+        return "nenhuma acao automatica: candidatura cancelada"
+    return "revisar estado manualmente antes de executar nova transicao"
+
+
 def _render_conversion_ratio(numerator: int, denominator: int) -> str:
     if denominator <= 0:
         return "n/a"
@@ -214,3 +293,28 @@ def _render_event_lines(events: list[object]) -> list[str]:
         f"{event.detail or '-'}"
         for event in events
     ]
+
+
+def _render_domain_event_lines(events: tuple[DomainEvent, ...]) -> list[str]:
+    lines: list[str] = []
+    for event in events:
+        payload = event_to_dict(event)
+        interesting_keys = [
+            "application_id",
+            "job_id",
+            "status",
+            "application_status",
+            "outcome",
+            "reason",
+            "retryable",
+            "portal",
+        ]
+        details = " ".join(
+            f"{key}={payload[key]}" for key in interesting_keys if key in payload and payload[key] not in {None, ""}
+        )
+        suffix = f" {details}" if details else ""
+        lines.append(
+            f"- {event.occurred_at} | {event.event_type} | "
+            f"correlation_id={event.correlation_id or '-'}{suffix}"
+        )
+    return lines

--- a/job_hunter_agent/application/application_queries.py
+++ b/job_hunter_agent/application/application_queries.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 from job_hunter_agent.application.application_cli_rendering import (
     render_application_detail,
+    render_application_diagnosis,
     render_application_events,
     render_application_list,
     render_execution_summary,
@@ -14,6 +15,7 @@ from job_hunter_agent.application.application_cli_rendering import (
     summarize_operational_counts,
 )
 from job_hunter_agent.core.domain import VALID_APPLICATION_STATUSES, VALID_STATUSES
+from job_hunter_agent.core.event_bus import EventBusPort
 from job_hunter_agent.infrastructure.repository import JobRepository
 
 
@@ -31,8 +33,9 @@ JOB_STATUS_ORDER = ("collected", "approved", "rejected", "error_collect")
 
 
 class ApplicationQueryService:
-    def __init__(self, repository: JobRepository) -> None:
+    def __init__(self, repository: JobRepository, domain_event_bus: EventBusPort | None = None) -> None:
         self.repository = repository
+        self.domain_event_bus = domain_event_bus
 
     def list_applications(self, *, status: str | None = None) -> str:
         requested_statuses = (
@@ -98,6 +101,26 @@ class ApplicationQueryService:
         job = self.repository.get_job(application.job_id)
         events = self.repository.list_application_events(application_id, limit=5)
         return render_application_detail(application=application, job=job, events=events)
+
+    def diagnose_application(self, application_id: int) -> str:
+        application = self.repository.get_application(application_id)
+        if application is None:
+            return f"Candidatura nao encontrada: id={application_id}"
+        job = self.repository.get_job(application.job_id)
+        events = self.repository.list_application_events(application_id, limit=10)
+        correlation_id = f"application:{application_id}"
+        domain_events = ()
+        if self.domain_event_bus is not None:
+            domain_events = tuple(
+                event for event in self.domain_event_bus.read_all() if event.correlation_id == correlation_id
+            )[-10:]
+        return render_application_diagnosis(
+            application=application,
+            job=job,
+            events=events,
+            domain_events=domain_events,
+            domain_events_enabled=self.domain_event_bus is not None,
+        )
 
     def show_latest_failure_artifacts(self, *, artifacts_dir: Path, limit: int = 5) -> str:
         files = sorted(

--- a/tests/test_application_cli_dispatch.py
+++ b/tests/test_application_cli_dispatch.py
@@ -58,6 +58,33 @@ class ApplicationCliDispatchTests(TestCase):
         app_factory.assert_called_once_with()
         print_mock.assert_called_once_with("status=authorized_submit")
 
+    def test_execute_cli_command_dispatches_application_diagnose(self) -> None:
+        fake_app = type(
+            "FakeApp",
+            (),
+            {
+                "diagnose_application": lambda self, application_id: f"diagnose={application_id}",
+            },
+        )()
+
+        args = Namespace(
+            bootstrap_linkedin_session=False,
+            command="applications",
+            applications_command="diagnose",
+            id=35,
+            sem_telegram=False,
+        )
+
+        with patch(
+            "job_hunter_agent.application.application_cli_dispatch.create_query_app",
+            return_value=fake_app,
+        ) as app_factory, patch("builtins.print") as print_mock:
+            handled = execute_cli_command(args)
+
+        self.assertTrue(handled)
+        app_factory.assert_called_once_with()
+        print_mock.assert_called_once_with("diagnose=35")
+
     def test_execute_cli_command_dispatches_application_preflight_with_flow_app(self) -> None:
         fake_app = type(
             "FakeApp",

--- a/tests/test_application_cli_parse.py
+++ b/tests/test_application_cli_parse.py
@@ -1,0 +1,21 @@
+from unittest import TestCase
+from unittest.mock import patch
+
+from job_hunter_agent.application.application_cli import parse_args
+
+
+class ApplicationCliParseTests(TestCase):
+    def test_parse_args_accepts_applications_diagnose_command(self) -> None:
+        with patch("sys.argv", ["main.py", "applications", "diagnose", "--id", "32"]):
+            args = parse_args()
+
+        self.assertEqual(args.command, "applications")
+        self.assertEqual(args.applications_command, "diagnose")
+        self.assertEqual(args.id, 32)
+
+    def test_parse_args_rejects_negative_cycle_interval_with_portuguese_message(self) -> None:
+        with patch("sys.argv", ["main.py", "--ciclos", "2", "--intervalo-ciclos-segundos", "-1"]):
+            with self.assertRaises(SystemExit) as raised:
+                parse_args()
+
+        self.assertNotEqual(raised.exception.code, 0)

--- a/tests/test_application_diagnosis_rendering.py
+++ b/tests/test_application_diagnosis_rendering.py
@@ -1,0 +1,95 @@
+from unittest import TestCase
+
+from job_hunter_agent.application.application_cli_rendering import render_application_diagnosis
+from job_hunter_agent.core.domain import JobApplication, JobApplicationEvent, JobPosting
+from job_hunter_agent.core.events import ApplicationBlockedV1
+
+
+def _sample_job(*, job_id: int = 10) -> JobPosting:
+    return JobPosting(
+        id=job_id,
+        title="Backend Java",
+        company="ACME",
+        location="Brasil",
+        work_mode="remoto",
+        salary_text="Nao informado",
+        url="https://example.com/job",
+        source_site="LinkedIn",
+        summary="Resumo",
+        relevance=8,
+        rationale="Boa aderencia",
+        external_key="linkedin-10",
+        status="approved",
+    )
+
+
+class ApplicationDiagnosisRenderingTests(TestCase):
+    def test_render_application_diagnosis_includes_aggregate_sections_and_next_action(self) -> None:
+        application = JobApplication(
+            id=32,
+            job_id=10,
+            status="error_submit",
+            support_level="manual_review",
+            last_preflight_detail="preflight real ok",
+            last_submit_detail="submit interrompido",
+            last_error="readiness=listing_redirect | motivo=a navegacao caiu em listagem",
+            notes="revisar antes de retentar",
+        )
+        sqlite_event = JobApplicationEvent(
+            id=1,
+            application_id=32,
+            event_type="submit_error",
+            from_status="authorized_submit",
+            to_status="error_submit",
+            detail="submit falhou",
+            created_at="2026-04-27T10:00:00",
+        )
+        domain_event = ApplicationBlockedV1(
+            application_id=32,
+            job_id=10,
+            reason="listing_redirect",
+            detail="navegacao caiu em listagem",
+            retryable=True,
+            occurred_at="2026-04-27T10:01:00+00:00",
+            correlation_id="application:32",
+        )
+
+        rendered = render_application_diagnosis(
+            application=application,
+            job=_sample_job(),
+            events=[sqlite_event],
+            domain_events=(domain_event,),
+            domain_events_enabled=True,
+        )
+
+        self.assertIn("Diagnostico da candidatura 32", rendered)
+        self.assertIn("candidatura:", rendered)
+        self.assertIn("vaga:", rendered)
+        self.assertIn("preflight_submit:", rendered)
+        self.assertIn("last_preflight_detail=preflight real ok", rendered)
+        self.assertIn("last_submit_detail=submit interrompido", rendered)
+        self.assertIn("last_error=readiness=listing_redirect", rendered)
+        self.assertIn("proxima_acao:", rendered)
+        self.assertIn("investigar bloqueio", rendered)
+        self.assertIn("eventos_sqlite_recentes:", rendered)
+        self.assertIn("submit_error", rendered)
+        self.assertIn("domain_events_recentes:", rendered)
+        self.assertIn("ApplicationBlockedV1", rendered)
+        self.assertIn("correlation_id=application:32", rendered)
+        self.assertIn("retryable=True", rendered)
+
+    def test_render_application_diagnosis_reports_disabled_domain_events(self) -> None:
+        application = JobApplication(id=33, job_id=11, status="draft", support_level="manual_review")
+
+        rendered = render_application_diagnosis(
+            application=application,
+            job=None,
+            events=[],
+            domain_events=(),
+            domain_events_enabled=False,
+        )
+
+        self.assertIn("vaga nao encontrada", rendered)
+        self.assertIn("preparar revisao: python main.py applications prepare --id 33", rendered)
+        self.assertIn("eventos_sqlite_recentes:\n- nenhum", rendered)
+        self.assertIn("domain_events_recentes:\n- indisponivel_ou_desabilitado", rendered)

--- a/tests/test_application_queries_diagnosis.py
+++ b/tests/test_application_queries_diagnosis.py
@@ -1,0 +1,103 @@
+from unittest import TestCase
+
+from job_hunter_agent.application.application_queries import ApplicationQueryService
+from job_hunter_agent.core.domain import JobApplication, JobApplicationEvent, JobPosting
+from job_hunter_agent.core.events import ApplicationBlockedV1, ApplicationSubmittedV1
+
+
+class _RepositoryStub:
+    def __init__(self) -> None:
+        self.application = JobApplication(
+            id=32,
+            job_id=10,
+            status="error_submit",
+            support_level="manual_review",
+            last_error="readiness=listing_redirect",
+        )
+        self.job = JobPosting(
+            id=10,
+            title="Backend Java",
+            company="ACME",
+            location="Brasil",
+            work_mode="remoto",
+            salary_text="Nao informado",
+            url="https://example.com/job",
+            source_site="LinkedIn",
+            summary="Resumo",
+            relevance=8,
+            rationale="Boa aderencia",
+            external_key="linkedin-10",
+            status="approved",
+        )
+        self.events = [
+            JobApplicationEvent(
+                id=1,
+                application_id=32,
+                event_type="submit_error",
+                from_status="authorized_submit",
+                to_status="error_submit",
+                detail="submit falhou",
+                created_at="2026-04-27T10:00:00",
+            )
+        ]
+
+    def get_application(self, application_id: int) -> JobApplication | None:
+        if application_id == 32:
+            return self.application
+        return None
+
+    def get_job(self, job_id: int) -> JobPosting | None:
+        if job_id == 10:
+            return self.job
+        return None
+
+    def list_application_events(self, application_id: int, *, limit: int) -> list[JobApplicationEvent]:
+        assert application_id == 32
+        assert limit == 10
+        return self.events
+
+
+class _DomainEventBusStub:
+    def read_all(self) -> tuple[object, ...]:
+        return (
+            ApplicationSubmittedV1(
+                application_id=99,
+                job_id=99,
+                portal="LinkedIn",
+                occurred_at="2026-04-27T09:00:00+00:00",
+                correlation_id="application:99",
+            ),
+            ApplicationBlockedV1(
+                application_id=32,
+                job_id=10,
+                reason="listing_redirect",
+                detail="navegacao caiu em listagem",
+                retryable=True,
+                occurred_at="2026-04-27T10:01:00+00:00",
+                correlation_id="application:32",
+            ),
+        )
+
+
+class ApplicationQueryServiceDiagnosisTests(TestCase):
+    def test_diagnose_application_aggregates_repository_and_matching_domain_events(self) -> None:
+        service = ApplicationQueryService(
+            repository=_RepositoryStub(),
+            domain_event_bus=_DomainEventBusStub(),
+        )
+
+        rendered = service.diagnose_application(32)
+
+        self.assertIn("Diagnostico da candidatura 32", rendered)
+        self.assertIn("titulo=Backend Java", rendered)
+        self.assertIn("submit_error", rendered)
+        self.assertIn("ApplicationBlockedV1", rendered)
+        self.assertIn("correlation_id=application:32", rendered)
+        self.assertNotIn("application:99", rendered)
+
+    def test_diagnose_application_reports_missing_application(self) -> None:
+        service = ApplicationQueryService(repository=_RepositoryStub())
+
+        rendered = service.diagnose_application(404)
+
+        self.assertEqual("Candidatura nao encontrada: id=404", rendered)


### PR DESCRIPTION
## Resumo
- adiciona `python main.py applications diagnose --id <application_id>` como comando de leitura pura
- agrega candidatura, vaga, status/suporte, detalhes de preflight/submit/erro e eventos SQLite recentes
- inclui domain-events recentes filtrados por `correlation_id=application:<id>` quando o bus está disponível
- renderiza próxima ação recomendada para o estado operacional atual

## Testes
- adiciona cobertura de parse CLI para `applications diagnose --id`
- adiciona cobertura do dispatch do comando
- adiciona cobertura do renderer `render_application_diagnosis`
- adiciona cobertura de `ApplicationQueryService.diagnose_application`

Closes #32