### PR TITLE
feat: add SQLite migration helper

### DIFF
--- a/job_hunter_agent/infrastructure/sqlite_migrations.py
+++ b/job_hunter_agent/infrastructure/sqlite_migrations.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import sqlite3
+from collections.abc import Callable, Iterable
+from dataclasses import dataclass
+from datetime import datetime, timezone
+
+
+CURRENT_SCHEMA_VERSION = 1
+
+
+@dataclass(frozen=True)
+class SqliteMigration:
+    version: int
+    name: str
+    apply: Callable[[sqlite3.Connection], None]
+
+
+def _utc_now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+def _baseline_current_schema(_connection: sqlite3.Connection) -> None:
+    """Registers the current SQLite schema as the first managed baseline."""
+
+
+SQLITE_MIGRATIONS: tuple[SqliteMigration, ...] = (
+    SqliteMigration(
+        version=CURRENT_SCHEMA_VERSION,
+        name="baseline_current_schema",
+        apply=_baseline_current_schema,
+    ),
+)
+
+
+def ensure_schema_migrations_table(connection: sqlite3.Connection) -> None:
+    connection.execute(
+        """
+        CREATE TABLE IF NOT EXISTS schema_migrations (
+            version INTEGER PRIMARY KEY,
+            name TEXT NOT NULL,
+            applied_at TEXT NOT NULL
+        )
+        """
+    )
+
+
+def applied_schema_versions(connection: sqlite3.Connection) -> set[int]:
+    ensure_schema_migrations_table(connection)
+    return {
+        int(row[0])
+        for row in connection.execute("SELECT version FROM schema_migrations").fetchall()
+    }
+
+
+def current_schema_version(connection: sqlite3.Connection) -> int:
+    ensure_schema_migrations_table(connection)
+    row = connection.execute("SELECT MAX(version) FROM schema_migrations").fetchone()
+    return int((row[0] if row else 0) or 0)
+
+
+def run_sqlite_migrations(
+    connection: sqlite3.Connection,
+    migrations: Iterable[SqliteMigration] = SQLITE_MIGRATIONS,
+) -> None:
+    """Runs pending SQLite schema migrations idempotently.
+
+    The first migration is a no-op baseline for the schema that existed before
+    migration tracking. Future migrations should be additive and idempotent so
+    they can run safely on both empty and legacy local SQLite databases.
+    """
+    ensure_schema_migrations_table(connection)
+    applied_versions = applied_schema_versions(connection)
+    for migration in sorted(migrations, key=lambda item: item.version):
+        if migration.version in applied_versions:
+            continue
+        migration.apply(connection)
+        connection.execute(
+            """
+            INSERT INTO schema_migrations (version, name, applied_at)
+            VALUES (?, ?, ?)
+            """,
+            (migration.version, migration.name, _utc_now_iso()),
+        )
+        applied_versions.add(migration.version)

--- a/tests/test_sqlite_migrations.py
+++ b/tests/test_sqlite_migrations.py
@@ -1,0 +1,67 @@
+import sqlite3
+import unittest
+
+from job_hunter_agent.infrastructure.sqlite_migrations import (
+    CURRENT_SCHEMA_VERSION,
+    SqliteMigration,
+    current_schema_version,
+    run_sqlite_migrations,
+)
+
+
+class SqliteMigrationTests(unittest.TestCase):
+    def test_run_sqlite_migrations_registers_baseline_on_empty_database(self) -> None:
+        connection = sqlite3.connect(":memory:")
+
+        run_sqlite_migrations(connection)
+
+        row = connection.execute(
+            "SELECT version, name, applied_at FROM schema_migrations WHERE version = ?",
+            (CURRENT_SCHEMA_VERSION,),
+        ).fetchone()
+        self.assertEqual(row[0], CURRENT_SCHEMA_VERSION)
+        self.assertEqual(row[1], "baseline_current_schema")
+        self.assertIn("+00:00", row[2])
+        self.assertEqual(current_schema_version(connection), CURRENT_SCHEMA_VERSION)
+
+    def test_run_sqlite_migrations_is_idempotent(self) -> None:
+        connection = sqlite3.connect(":memory:")
+
+        run_sqlite_migrations(connection)
+        run_sqlite_migrations(connection)
+
+        row = connection.execute("SELECT COUNT(*) FROM schema_migrations").fetchone()
+        self.assertEqual(row[0], 1)
+
+    def test_run_sqlite_migrations_preserves_legacy_tables(self) -> None:
+        connection = sqlite3.connect(":memory:")
+        connection.execute("CREATE TABLE jobs (id INTEGER PRIMARY KEY, title TEXT NOT NULL)")
+        connection.execute("INSERT INTO jobs (id, title) VALUES (1, 'Backend Java')")
+
+        run_sqlite_migrations(connection)
+
+        legacy_row = connection.execute("SELECT id, title FROM jobs WHERE id = 1").fetchone()
+        self.assertEqual(legacy_row, (1, "Backend Java"))
+        self.assertEqual(current_schema_version(connection), CURRENT_SCHEMA_VERSION)
+
+    def test_run_sqlite_migrations_applies_pending_versions_in_order(self) -> None:
+        applied: list[int] = []
+
+        def apply_v2(connection: sqlite3.Connection) -> None:
+            applied.append(2)
+            connection.execute("CREATE TABLE example_v2 (id INTEGER PRIMARY KEY)")
+
+        def apply_v3(connection: sqlite3.Connection) -> None:
+            applied.append(3)
+            connection.execute("CREATE TABLE example_v3 (id INTEGER PRIMARY KEY)")
+
+        connection = sqlite3.connect(":memory:")
+        migrations = (
+            SqliteMigration(version=3, name="third", apply=apply_v3),
+            SqliteMigration(version=2, name="second", apply=apply_v2),
+        )
+
+        run_sqlite_migrations(connection, migrations=migrations)
+
+        self.assertEqual(applied, [2, 3])
+        self.assertEqual(current_schema_version(connection), 3)


### PR DESCRIPTION
## Resumo
- adiciona helper central `sqlite_migrations.py` para rastrear versoes de schema SQLite
- cria tabela `schema_migrations` idempotente
- registra a versao baseline do schema atual com timestamp UTC explicito
- adiciona testes para banco vazio, execucao idempotente, banco legado e aplicacao ordenada de migracoes pendentes

## Testes
- adiciona `tests/test_sqlite_migrations.py`
- nao executei a suite localmente neste ambiente

Refs #34

## Proximo passo
- integrar `run_sqlite_migrations` no startup do `SqliteJobRepository`
- substituir migracoes ad-hoc existentes pelo helper central quando seguro
- atualizar o checklist/documentacao da frente