### PR TITLE
docs: finalize SQLite schema and UTC checklists

### DIFF
--- a/docs/SQLITE_SCHEMA_AND_UTC_CHECKLIST.md
+++ b/docs/SQLITE_SCHEMA_AND_UTC_CHECKLIST.md
@@ -20,10 +20,20 @@ Esta checklist cobre dois eixos:
 - [x] Cobrir helper com testes de banco legado sem tabela de versao.
 - [x] Cobrir execucao idempotente de migracoes.
 - [x] Cobrir aplicacao ordenada de migracoes pendentes.
-- [ ] Mover migracoes ad-hoc de `job_applications` para migracoes versionadas.
-- [ ] Padronizar writes restantes que ainda usam `datetime.now().isoformat(...)` para `_utc_now_iso()`.
-- [ ] Padronizar writes SQL restantes que ainda usam `CURRENT_TIMESTAMP` quando forem tocados por migracoes futuras.
-- [ ] Validar suite completa em CI.
+- [x] Padronizar novos writes operacionais cobertos nesta frente para UTC explicito.
+- [x] Validar suite completa em CI.
+- [x] Validar Docker.
+- [x] Atualizar checklists ativos ao final.
+
+## Fora Do Escopo Desta Frente
+
+Os pontos abaixo continuam sendo evolucoes futuras e nao bloqueiam a conclusao da issue #34:
+
+- converter dados antigos em massa;
+- trocar SQLite por Postgres;
+- introduzir broker externo;
+- remover todos os defaults antigos com `CURRENT_TIMESTAMP` sem uma migracao segura;
+- mover todo ajuste legado/ad-hoc para migracoes versionadas quando houver necessidade real de alterar schema.
 
 ## Migracoes SQLite
 
@@ -74,13 +84,46 @@ Ou o helper ja existente:
 SqliteJobRepository._utc_now_iso()
 ```
 
+Writes operacionais cobertos por UTC explicito nesta frente:
+
+- `schema_migrations.applied_at_utc`;
+- `jobs.created_at` em novos jobs salvos pela aplicacao;
+- `job_status_events.created_at` em novos eventos de vaga;
+- `seen_jobs.first_seen_at` e `seen_jobs.last_seen_at` em novos writes da aplicacao;
+- `collection_logs.created_at` em novos logs de coleta;
+- `collection_cursors.updated_at` em novos writes de cursor;
+- `job_applications.created_at` e `job_applications.updated_at` em novos writes de candidatura;
+- `job_application_events.created_at` em novos eventos de candidatura.
+
 Criterio esperado:
 
 - novos timestamps gerados pela aplicacao devem conter `+00:00`;
 - migracoes devem registrar `applied_at_utc` com `+00:00`;
 - comparacoes operacionais devem continuar aceitando dados antigos que nao tenham offset.
 
-## Pontos Conhecidos Para Revisao
+## Rollback Manual Para Banco Local
+
+Esta frente nao altera dados antigos em massa. Ainda assim, antes de uma intervencao manual em banco local, faca backup do arquivo SQLite:
+
+```bash
+cp jobs.db jobs.db.backup-$(date -u +%Y%m%dT%H%M%SZ)
+```
+
+Para voltar ao backup:
+
+```bash
+cp jobs.db.backup-<timestamp> jobs.db
+```
+
+Se o problema estiver restrito ao registro de versao de schema, inspecione antes de apagar qualquer dado:
+
+```bash
+sqlite3 jobs.db "SELECT version, name, applied_at_utc FROM schema_migrations ORDER BY version;"
+```
+
+Evite remover linhas de `schema_migrations` manualmente sem tambem entender quais mudancas de schema ja foram aplicadas.
+
+## Pontos Conhecidos Para Revisao Futura
 
 Procurar ocorrencias de:
 
@@ -93,10 +136,8 @@ Ajustar apenas quando houver teste cobrindo o comportamento, para evitar migraca
 
 ## Criterio De Conclusao Da Issue #34
 
-A issue pode ser fechada quando:
-
-- `SqliteJobRepository` registra a versao baseline em bancos novos;
-- bancos legados sem `schema_migrations` recebem a tabela e preservam dados;
-- novos writes operacionais alterados nesta frente usam UTC explicito;
-- testes cobrem banco vazio, banco legado e idempotencia;
-- esta checklist reflete o estado final.
+- [x] `SqliteJobRepository` registra a versao baseline em bancos novos.
+- [x] Bancos legados sem `schema_migrations` recebem a tabela e preservam dados.
+- [x] Novos writes operacionais alterados nesta frente usam UTC explicito.
+- [x] Testes cobrem banco vazio, banco legado e idempotencia.
+- [x] Checklists refletem o que foi concluido.

--- a/docs/plans/SQLITE_SCHEMA_AND_UTC_CHECKLIST.md
+++ b/docs/plans/SQLITE_SCHEMA_AND_UTC_CHECKLIST.md
@@ -6,23 +6,24 @@ Planejar a evolucao de schema e timestamps antes de introduzir mais workers inde
 
 Esta frente deve ser tratada como etapa propria porque mexe em persistencia existente e pode afetar dados locais do usuario.
 
-## Decisao Para Esta PR
+## Decisao Para Esta Frente
 
-- [x] Nao executar migracao ampla de banco nesta frente de workers.
+- [x] Nao executar migracao ampla de banco nesta frente.
 - [x] Documentar estrategia antes de alterar tabelas existentes.
 - [x] Manter novos eventos e DLQ com timestamps UTC.
 - [x] Preservar compatibilidade com bancos locais existentes.
+- [x] Validar CI e Docker antes de mergear PRs de codigo.
 
 ## Problema Atual
 
-O repositorio ja usa UTC em alguns pontos operacionais, mas ainda existem timestamps gerados por `CURRENT_TIMESTAMP` do SQLite e chamadas locais de `datetime.now()`.
+O repositorio ja usa UTC em alguns pontos operacionais, mas ainda existem timestamps gerados por `CURRENT_TIMESTAMP` do SQLite e chamadas locais de `datetime.now()` em caminhos legados.
 
 Para workers separados, isso cria risco de:
 
-- limites diarios inconsistentes
-- ordenacao ambigua entre eventos
-- dificuldade de correlacionar logs, DLQ e eventos
-- migracoes futuras sem controle de versao
+- limites diarios inconsistentes;
+- ordenacao ambigua entre eventos;
+- dificuldade de correlacionar logs, DLQ e eventos;
+- migracoes futuras sem controle de versao.
 
 ## Schema Versionado
 
@@ -34,7 +35,7 @@ Plano recomendado:
 - [x] Rodar migracoes no startup do repositorio.
 - [x] Adicionar teste com banco vazio.
 - [x] Adicionar teste com banco legado sem tabela de versao.
-- [ ] Documentar rollback manual para banco local.
+- [x] Documentar rollback manual para banco local.
 
 Tabela implementada:
 
@@ -52,8 +53,8 @@ Plano recomendado:
 
 - [x] Criar helper unico `utc_now_iso()` para persistencia.
 - [x] Trocar novos writes operacionais cobertos nesta frente para UTC explicito.
-- [ ] Remover dependencias remanescentes de `CURRENT_TIMESTAMP` em definicoes antigas quando houver uma migracao segura de schema.
 - [x] Documentar que timestamps persistidos novos devem ser UTC explicito.
+- [ ] Remover dependencias remanescentes de `CURRENT_TIMESTAMP` em definicoes antigas quando houver uma migracao segura de schema.
 - [ ] Converter renderizacao local apenas na borda de UI/CLI/notifier.
 
 Writes operacionais cobertos por UTC explicito:
@@ -66,6 +67,28 @@ Writes operacionais cobertos por UTC explicito:
 - [x] `collection_cursors.updated_at` em novos writes de cursor
 - [x] `job_applications.created_at` e `job_applications.updated_at` em novos writes de candidatura
 - [x] `job_application_events.created_at` em novos eventos de candidatura
+
+## Rollback Manual Para Banco Local
+
+Antes de qualquer intervencao manual em banco local, faca backup do arquivo SQLite:
+
+```bash
+cp jobs.db jobs.db.backup-$(date -u +%Y%m%dT%H%M%SZ)
+```
+
+Para voltar ao backup:
+
+```bash
+cp jobs.db.backup-<timestamp> jobs.db
+```
+
+Para inspecionar as migracoes registradas:
+
+```bash
+sqlite3 jobs.db "SELECT version, name, applied_at_utc FROM schema_migrations ORDER BY version;"
+```
+
+Nao remova linhas de `schema_migrations` sem entender quais mudancas ja foram aplicadas.
 
 ## Ordem Segura De Execucao
 


### PR DESCRIPTION
## Resumo
- sincroniza `docs/SQLITE_SCHEMA_AND_UTC_CHECKLIST.md` com o estado final da frente #34
- atualiza `docs/plans/SQLITE_SCHEMA_AND_UTC_CHECKLIST.md` para refletir o mesmo progresso
- documenta rollback manual para banco local
- registra como fora de escopo desta frente a conversao em massa de dados antigos e a remocao de defaults legados com `CURRENT_TIMESTAMP`

## Testes
- documentacao apenas; sem testes locais

Closes #34