### PR TITLE
docs: clarify application scope in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,9 @@ Documentacao historica:
 - persistir vagas relevantes em SQLite
 - enviar vagas para revisao humana via Telegram
 - registrar aprovacao ou rejeicao manual
+- apoiar fluxo de candidatura assistido por comandos, diagnostico operacional e gates humanos de revisao/autorizacao
 
-Candidatura automatica continua fora do caminho critico desta versao.
+Submit real sem revisao humana e autorizacao explicita continua fora do caminho critico desta versao.
 
 ## Setup
 


### PR DESCRIPTION
## Resumo
- atualiza o escopo da v1 no README
- deixa claro que existe fluxo de candidatura assistido por comandos e gates humanos
- preserva a restricao de que submit real sem revisao/autorizacao explicita continua fora do caminho critico

## Testes
- documentacao apenas

Closes #51