### PR TITLE
Fix: refinar matching do gate de precisao do LinkedIn

### DIFF
--- a/job_hunter_agent/collectors/collector.py
+++ b/job_hunter_agent/collectors/collector.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import hashlib
 import logging
+import re
 from typing import Protocol
 
 from job_hunter_agent.core.browser_support import (
@@ -269,13 +270,30 @@ class JobCollectionService:
         combined_text = f"{raw_job.title} {raw_job.summary} {raw_job.description}".strip().lower()
         if not combined_text:
             return "precision_gate_texto_indisponivel"
-        if any(term in combined_text for term in gate.blocked_terms):
-            return "precision_gate_termo_negocio"
-        if not all(term in combined_text for term in gate.required_terms):
+        if contains_any_precision_term(combined_text, gate.blocked_terms):
+            return "precision_gate_termo_bloqueado"
+        if not contains_all_precision_terms(combined_text, gate.required_terms):
             return "precision_gate_stack_fora_do_alvo"
-        if gate.any_terms and not any(term in combined_text for term in gate.any_terms):
+        if gate.any_terms and not contains_any_precision_term(combined_text, gate.any_terms):
             return "precision_gate_perfil_fora_do_alvo"
         return None
+
+
+def contains_any_precision_term(text: str, terms: tuple[str, ...]) -> bool:
+    return any(contains_precision_term(text, term) for term in terms)
+
+
+def contains_all_precision_terms(text: str, terms: tuple[str, ...]) -> bool:
+    return all(contains_precision_term(text, term) for term in terms)
+
+
+def contains_precision_term(text: str, term: str) -> bool:
+    normalized_text = text.strip().lower()
+    normalized_term = term.strip().lower()
+    if not normalized_text or not normalized_term:
+        return False
+    pattern = rf"(?<![0-9a-z]){re.escape(normalized_term)}(?![0-9a-z])"
+    return re.search(pattern, normalized_text) is not None
 
 
 def build_external_key(raw_job: RawJob) -> str:

--- a/tests/test_job_collector.py
+++ b/tests/test_job_collector.py
@@ -14,6 +14,7 @@ from job_hunter_agent.collectors.collector import (
     clean_linkedin_title,
     JobCollectionService,
     build_external_key,
+    contains_precision_term,
     extract_json_object,
     load_playwright_storage_state,
     merge_linkedin_card_with_detail,
@@ -575,6 +576,61 @@ class JobCollectionServiceTests(IsolatedAsyncioTestCase):
 
         self.assertEqual(len(jobs), 1)
         self.assertEqual(jobs[0].title, "Python Backend Developer")
+
+    async def test_collect_new_jobs_precision_gate_does_not_match_short_terms_inside_words(self) -> None:
+        class _Collector:
+            async def collect(self, site: SiteConfig, max_jobs: int) -> list[RawJob]:
+                return [
+                    RawJob(
+                        title="Django Backend Developer",
+                        company="ACME",
+                        location="Brasil",
+                        work_mode="remoto",
+                        salary_text="Nao informado",
+                        url="https://www.linkedin.com/jobs/view/1001/",
+                        source_site="LinkedIn",
+                        summary="Cargo backend com Django.",
+                        description="Desenvolvimento de APIs.",
+                    )
+                ]
+
+        gate_settings = Settings(
+            telegram_token="token",
+            telegram_chat_id="chat",
+            linkedin_precision_gate_enabled=True,
+            sites=(SiteConfig(name="LinkedIn", search_url="https://example.com"),),
+        )
+        service = JobCollectionService(
+            settings=gate_settings,
+            runtime_matching_profile=RuntimeMatchingProfile(
+                candidate_summary="Go backend",
+                include_keywords=("go",),
+                exclude_keywords=(),
+                accepted_work_modes=(),
+                minimum_salary_brl=0,
+                minimum_relevance=6,
+                linkedin_precision_gate=RuntimeLinkedInPrecisionGate(any_terms=("go",)),
+            ),
+            repository=self.repository,
+            site_collector=_Collector(),
+            scorer=FailingIfCalledScorer(),
+        )
+
+        jobs = await service.collect_new_jobs()
+
+        self.assertEqual(jobs, [])
+
+
+class PrecisionTermMatchingTests(TestCase):
+    def test_contains_precision_term_matches_whole_short_token(self) -> None:
+        self.assertTrue(contains_precision_term("Go backend developer", "go"))
+
+    def test_contains_precision_term_does_not_match_inside_larger_words(self) -> None:
+        self.assertFalse(contains_precision_term("Django backend cargo", "go"))
+
+    def test_contains_precision_term_preserves_phrase_matching(self) -> None:
+        self.assertTrue(contains_precision_term("Senior software engineer backend", "software engineer"))
+        self.assertTrue(contains_precision_term("Business development manager", "business development"))
 
 
 class ExternalKeyTests(TestCase):


### PR DESCRIPTION
## Resumo

- Troca o matching do `linkedin_precision_gate` de substring simples para helper com fronteiras alfanumericas.
- Evita falso positivo de termos curtos, como `go` dentro de `django` ou `cargo`.
- Preserva match de frases como `software engineer` e `business development`.
- Renomeia o motivo de blocked terms para `precision_gate_termo_bloqueado`.
- Adiciona testes unitarios e de fluxo do coletor.

Closes #54

## Validacao

- `pytest tests/test_job_collector.py -q` -> 70 passed
- `pytest -q` -> 520 passed
