### PR TITLE
Fix: exigir autorizacao explicita no auto apply

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Documentacao historica:
 - apoiar fluxo de candidatura assistido por comandos, diagnostico operacional e gates humanos de revisao/autorizacao
 
 Submit real sem revisao humana e autorizacao explicita continua fora do caminho critico desta versao.
+Mesmo com `JOB_HUNTER_AUTO_EASY_APPLY_ENABLED=true`, o submit real so considera candidaturas em `authorized_submit`; candidaturas apenas `confirmed` exigem autorizacao humana explicita antes de qualquer submissao.
 
 ## Setup
 

--- a/job_hunter_agent/application/auto_easy_apply.py
+++ b/job_hunter_agent/application/auto_easy_apply.py
@@ -123,49 +123,11 @@ class AutoEasyApplyService:
                 details.append(f"app_id={application.id} gate={gate_reason}")
                 continue
 
-            final_application = application
-            if application.status == "confirmed":
-                preflight_result = self.preflight.run_for_application(application.id)
-                if preflight_result.outcome != "ready":
-                    blocked += 1
-                    reason_code = f"preflight:{preflight_result.outcome}"
-                    blocked_by_reason[reason_code] += 1
-                    details.append(
-                        f"app_id={application.id} preflight_bloqueou={preflight_result.detail}"
-                    )
-                    consecutive_errors = 0
-                    if self._should_stop_for_repeated_block(blocked_by_reason):
-                        details.append(
-                            f"parada por bloqueio repetido: {reason_code}={blocked_by_reason[reason_code]}"
-                        )
-                        break
-                    continue
-                if not _preflight_indicates_easy_apply(preflight_result.detail):
-                    blocked += 1
-                    reason_code = "preflight:sem_easy_apply_explicito"
-                    blocked_by_reason[reason_code] += 1
-                    details.append(
-                        f"app_id={application.id} preflight_sem_easy_apply={preflight_result.detail}"
-                    )
-                    if self._should_stop_for_repeated_block(blocked_by_reason):
-                        details.append(
-                            f"parada por bloqueio repetido: {reason_code}={blocked_by_reason[reason_code]}"
-                        )
-                        break
-                    continue
-                self.transitions.authorize_application(application.id)
-                refreshed = self.repository.get_application(application.id)
-                if refreshed is None:
-                    blocked += 1
-                    details.append(f"app_id={application.id} nao encontrada apos autorizar")
-                    continue
-                final_application = refreshed
-
-            submit_result = self.submission.run_for_application(final_application.id)
+            submit_result = self.submission.run_for_application(application.id)
             if submit_result.outcome == "submitted":
                 submitted += 1
                 consecutive_errors = 0
-                details.append(f"app_id={final_application.id} enviada com sucesso")
+                details.append(f"app_id={application.id} enviada com sucesso")
                 if (
                     submitted < self.settings.auto_easy_apply_max_submits_per_cycle
                     and self.settings.auto_easy_apply_cooldown_seconds > 0
@@ -178,7 +140,7 @@ class AutoEasyApplyService:
             reason_code = f"submit:{submit_result.outcome}"
             blocked_by_reason[reason_code] += 1
             details.append(
-                f"app_id={final_application.id} submit_{submit_result.outcome}={submit_result.detail}"
+                f"app_id={application.id} submit_{submit_result.outcome}={submit_result.detail}"
             )
             if self._should_stop_for_repeated_block(blocked_by_reason):
                 details.append(
@@ -197,18 +159,17 @@ class AutoEasyApplyService:
 
     def _load_candidates(self) -> list[tuple[JobApplication, JobPosting]]:
         ordered: list[tuple[JobApplication, JobPosting]] = []
-        for status in ("authorized_submit", "confirmed"):
-            for application in self.repository.list_applications_by_status(status):
-                job = self.repository.get_job(application.job_id)
-                if job is None:
-                    continue
-                ordered.append((application, job))
+        for application in self.repository.list_applications_by_status("authorized_submit"):
+            job = self.repository.get_job(application.job_id)
+            if job is None:
+                continue
+            ordered.append((application, job))
         ordered.sort(key=lambda item: item[1].relevance, reverse=True)
         return ordered
 
     def _evaluate_gates(self, *, application: JobApplication, job: JobPosting) -> str | None:
-        if application.status not in {"confirmed", "authorized_submit"}:
-            return "status_invalido"
+        if application.status != "authorized_submit":
+            return "submit_sem_autorizacao_explicita"
         if job.status != "approved":
             return "vaga_nao_aprovada"
         if job.relevance < self.settings.auto_easy_apply_min_score:
@@ -228,9 +189,7 @@ class AutoEasyApplyService:
         for denied in self.settings.auto_easy_apply_denylist_url_terms:
             if denied and denied in url_text:
                 return "url_na_denylist"
-        if application.status == "authorized_submit" and not _preflight_indicates_easy_apply(
-            application.last_preflight_detail
-        ):
+        if not _preflight_indicates_easy_apply(application.last_preflight_detail):
             return "preflight_sem_easy_apply_explicito"
         return None
 

--- a/tests/test_auto_easy_apply.py
+++ b/tests/test_auto_easy_apply.py
@@ -58,12 +58,20 @@ class _FakeRepository:
 
 
 class _FakePreflight:
+    def __init__(self) -> None:
+        self.called: list[int] = []
+
     def run_for_application(self, application_id: int):
+        self.called.append(application_id)
         return type("Result", (), {"outcome": "ready", "detail": "ok"})()
 
 
 class _FakeTransitions:
+    def __init__(self) -> None:
+        self.called: list[int] = []
+
     def authorize_application(self, application_id: int) -> str:
+        self.called.append(application_id)
         return f"autorizada {application_id}"
 
 
@@ -114,6 +122,49 @@ class AutoEasyApplyServiceTests(TestCase):
         self.assertEqual(report.blocked, 0)
         self.assertEqual(report.skipped, 0)
         self.assertEqual(submission.called, [1])
+
+    def test_run_once_does_not_submit_confirmed_without_explicit_authorization(self) -> None:
+        repository = _FakeRepository(
+            applications=[_application(app_id=1, job_id=10, status="confirmed")],
+            jobs={10: _job(job_id=10, relevance=9)},
+        )
+        preflight = _FakePreflight()
+        transitions = _FakeTransitions()
+        submission = _FakeSubmission()
+        service = AutoEasyApplyService(
+            repository=repository,
+            preflight=preflight,
+            submission=submission,
+            transitions=transitions,
+            settings=self._settings(auto_easy_apply_cooldown_seconds=0),
+        )
+
+        report = service.run_once()
+
+        self.assertEqual(report.analyzed, 0)
+        self.assertEqual(report.submitted, 0)
+        self.assertEqual(report.blocked, 0)
+        self.assertEqual(report.skipped, 0)
+        self.assertEqual(preflight.called, [])
+        self.assertEqual(transitions.called, [])
+        self.assertEqual(submission.called, [])
+
+    def test_run_once_rejects_non_authorized_application_in_gate(self) -> None:
+        repository = _FakeRepository(applications=[], jobs={})
+        service = AutoEasyApplyService(
+            repository=repository,
+            preflight=_FakePreflight(),
+            submission=_FakeSubmission(),
+            transitions=_FakeTransitions(),
+            settings=self._settings(),
+        )
+
+        reason = service._evaluate_gates(
+            application=_application(app_id=1, job_id=10, status="confirmed"),
+            job=_job(job_id=10, relevance=9),
+        )
+
+        self.assertEqual(reason, "submit_sem_autorizacao_explicita")
 
     def test_run_once_skips_below_min_score(self) -> None:
         repository = _FakeRepository(


### PR DESCRIPTION
## Resumo

- Faz o `AutoEasyApplyService` considerar apenas candidaturas em `authorized_submit`.
- Remove a autoautorizacao de candidaturas apenas `confirmed` dentro do ciclo automatico.
- Mantem o gate de preflight/Easy Apply explicito para candidaturas ja autorizadas.
- Documenta que, mesmo com `JOB_HUNTER_AUTO_EASY_APPLY_ENABLED=true`, submit real exige `authorized_submit`.
- Adiciona testes cobrindo que `confirmed` nao roda preflight, nao autoriza e nao submete automaticamente.

## Contexto

Fecha a ambiguidade entre o README e o comportamento do runtime: `confirmed` significa candidatura confirmada para revisao/preflight, mas nao autorizacao explicita para submissao real.

## Validacao

Nao executei a suite localmente neste ambiente. Testes adicionados/ajustados:

- `tests/test_auto_easy_apply.py`
