### PR TITLE
feat: generate deterministic application evaluation report

### DIFF
--- a/job_hunter_agent/application/app.py
+++ b/job_hunter_agent/application/app.py
@@ -214,6 +214,9 @@ class JobHunterApplication:
     def diagnose_application(self, application_id: int) -> str:
         return self._query_service().diagnose_application(application_id)
 
+    def generate_application_report(self, application_id: int) -> str:
+        return self._query_service().generate_application_report(application_id)
+
     def transition_application(self, application_id: int, action: str) -> str:
         return self._application_transition_commands().transition_application(application_id, action)
 

--- a/job_hunter_agent/application/application_cli.py
+++ b/job_hunter_agent/application/application_cli.py
@@ -93,6 +93,12 @@ def parse_args() -> argparse.Namespace:
     )
     applications_diagnose_parser.add_argument("--id", type=int, required=True, help="ID da candidatura.")
 
+    applications_report_parser = applications_subparsers.add_parser(
+        "report",
+        help="Gera relatorio A-F deterministico de uma candidatura.",
+    )
+    applications_report_parser.add_argument("--id", type=int, required=True, help="ID da candidatura.")
+
     applications_events_parser = applications_subparsers.add_parser(
         "events",
         help="Lista eventos recentes de uma candidatura.",

--- a/job_hunter_agent/application/application_cli_dispatch.py
+++ b/job_hunter_agent/application/application_cli_dispatch.py
@@ -85,6 +85,10 @@ def _run_applications_command(args: Namespace) -> None:
         app = create_query_app()
         print(app.diagnose_application(args.id))
         return
+    if args.applications_command == "report":
+        app = create_query_app()
+        print(app.generate_application_report(args.id))
+        return
     if args.applications_command == "events":
         app = create_query_app()
         print(app.show_application_events(args.id, limit=args.limit))

--- a/job_hunter_agent/application/application_queries.py
+++ b/job_hunter_agent/application/application_queries.py
@@ -14,6 +14,7 @@ from job_hunter_agent.application.application_cli_rendering import (
     render_status_overview,
     summarize_operational_counts,
 )
+from job_hunter_agent.application.application_report import write_application_report
 from job_hunter_agent.core.domain import VALID_APPLICATION_STATUSES, VALID_STATUSES
 from job_hunter_agent.core.event_bus import EventBusPort
 from job_hunter_agent.infrastructure.repository import JobRepository
@@ -121,6 +122,21 @@ class ApplicationQueryService:
             domain_events=domain_events,
             domain_events_enabled=self.domain_event_bus is not None,
         )
+
+    def generate_application_report(self, application_id: int) -> str:
+        application = self.repository.get_application(application_id)
+        if application is None:
+            return f"Candidatura nao encontrada: id={application_id}"
+        job = self.repository.get_job(application.job_id)
+        if job is None:
+            return f"Vaga associada nao encontrada: application_id={application_id} job_id={application.job_id}"
+        events = self.repository.list_application_events(application_id, limit=10)
+        report_path = write_application_report(
+            application=application,
+            job=job,
+            events=events,
+        )
+        return f"Relatorio gerado: {report_path}"
 
     def show_latest_failure_artifacts(self, *, artifacts_dir: Path, limit: int = 5) -> str:
         files = sorted(

--- a/job_hunter_agent/application/application_report.py
+++ b/job_hunter_agent/application/application_report.py
@@ -1,0 +1,142 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+DEFAULT_APPLICATION_REPORTS_DIR = Path("artifacts/reports")
+
+
+def build_application_report_path(application_id: int, *, reports_dir: Path = DEFAULT_APPLICATION_REPORTS_DIR) -> Path:
+    return reports_dir / f"application-{application_id}.md"
+
+
+def write_application_report(
+    *,
+    application: object,
+    job: object,
+    events: list[object],
+    reports_dir: Path = DEFAULT_APPLICATION_REPORTS_DIR,
+) -> Path:
+    reports_dir.mkdir(parents=True, exist_ok=True)
+    path = build_application_report_path(application.id, reports_dir=reports_dir)
+    path.write_text(
+        render_application_evaluation_report(application=application, job=job, events=events),
+        encoding="utf-8",
+    )
+    return path
+
+
+def render_application_evaluation_report(*, application: object, job: object, events: list[object]) -> str:
+    generated_at = datetime.now(timezone.utc).isoformat(timespec="seconds")
+    recent_events = _render_recent_events(events)
+    return "\n".join(
+        [
+            f"# Relatorio Da Candidatura {application.id}",
+            "",
+            "## Metadados",
+            "",
+            f"- Candidatura: {application.id}",
+            f"- Vaga: {job.id}",
+            f"- Empresa: {_value(job.company)}",
+            f"- Titulo: {_value(job.title)}",
+            f"- Status da candidatura: {_value(application.status)}",
+            f"- Status da vaga: {_value(job.status)}",
+            f"- Suporte operacional: {_value(application.support_level)}",
+            f"- Gerado em: {generated_at}",
+            "",
+            "## A. Resumo Da Vaga",
+            "",
+            f"- Empresa: {_value(job.company)}",
+            f"- Titulo: {_value(job.title)}",
+            f"- Localidade: {_value(job.location)}",
+            f"- Modalidade: {_value(job.work_mode)}",
+            f"- Fonte: {_value(job.source_site)}",
+            f"- Link: {_value(job.url)}",
+            f"- Resumo: {_value(job.summary)}",
+            "",
+            "## B. Match Com O Perfil",
+            "",
+            f"- Relevancia persistida: {_value(job.relevance)}",
+            f"- Rationale persistida: {_value(job.rationale)}",
+            f"- Salario informado: {_value(job.salary_text)}",
+            "- Observacao: este relatorio usa apenas dados ja persistidos; nao executa LLM.",
+            "",
+            "## C. Nivel, Estrategia E Posicionamento",
+            "",
+            f"- Status atual da candidatura: {_value(application.status)}",
+            f"- Notas operacionais: {_value(application.notes)}",
+            f"- Recomendacao deterministica: {_recommendation(application)}",
+            "",
+            "## D. Compensacao, Demanda E Sinais Operacionais",
+            "",
+            f"- Salario: {_value(job.salary_text)}",
+            f"- Suporte operacional: {_value(application.support_level)}",
+            f"- Rationale de suporte: {_value(application.support_rationale)}",
+            f"- Ultimo preflight: {_value(application.last_preflight_detail)}",
+            f"- Ultimo submit: {_value(application.last_submit_detail)}",
+            f"- Ultimo erro: {_value(application.last_error)}",
+            f"- Submitted at: {_value(application.submitted_at)}",
+            "",
+            "## E. Plano De Personalizacao",
+            "",
+            "- Revisar titulo, empresa, stack, senioridade e modalidade antes de gerar qualquer artefato externo.",
+            "- Usar rationale persistida como sinal inicial, nao como verdade final.",
+            "- Nao inventar metricas, experiencias, certificacoes ou senioridade.",
+            "- Dados faltantes devem ser marcados para revisao humana.",
+            "",
+            "## F. Plano De Entrevista",
+            "",
+            "- Preparar historias alinhadas aos requisitos explicitamente presentes na vaga.",
+            "- Validar gaps tecnicos antes de entrevista.",
+            "- Preparar perguntas sobre escopo, time, processo, modalidade e expectativas de entrega.",
+            "",
+            "## Incertezas E Revisao Humana",
+            "",
+            "- Relatorio gerado sem LLM e sem consulta externa.",
+            "- Relatorio nao altera status da candidatura.",
+            "- Relatorio nao executa preflight nem submit.",
+            "- Relatorio nao autoriza envio real.",
+            "",
+            "## Eventos Recentes Da Candidatura",
+            "",
+            recent_events,
+            "",
+        ]
+    )
+
+
+def _recommendation(application: object) -> str:
+    status = getattr(application, "status", "")
+    if status == "draft":
+        return "review — preparar candidatura antes de qualquer acao externa."
+    if status == "ready_for_review":
+        return "review — confirmar ou cancelar apos revisao humana."
+    if status == "confirmed":
+        return "review — rodar preflight antes de autorizar submit."
+    if status == "authorized_submit":
+        return "apply — submit pode ser considerado, mantendo gate humano e dry-run quando necessario."
+    if status == "submitted":
+        return "hold — candidatura ja enviada."
+    if status == "error_submit":
+        return "hold — investigar erro antes de nova tentativa."
+    if status == "cancelled":
+        return "skip — candidatura cancelada."
+    return "review — estado nao reconhecido."
+
+
+def _render_recent_events(events: list[object]) -> str:
+    if not events:
+        return "- nenhum"
+    return "\n".join(
+        f"- {_value(event.created_at)} | {_value(event.event_type)} | "
+        f"{_value(event.from_status)} -> {_value(event.to_status)} | {_value(event.detail)}"
+        for event in events
+    )
+
+
+def _value(value: object) -> str:
+    if value is None:
+        return "-"
+    text = str(value).strip()
+    return text if text else "-"

--- a/tests/test_application_cli_dispatch.py
+++ b/tests/test_application_cli_dispatch.py
@@ -85,6 +85,33 @@ class ApplicationCliDispatchTests(TestCase):
         app_factory.assert_called_once_with()
         print_mock.assert_called_once_with("diagnose=35")
 
+    def test_execute_cli_command_dispatches_application_report(self) -> None:
+        fake_app = type(
+            "FakeApp",
+            (),
+            {
+                "generate_application_report": lambda self, application_id: f"report={application_id}",
+            },
+        )()
+
+        args = Namespace(
+            bootstrap_linkedin_session=False,
+            command="applications",
+            applications_command="report",
+            id=35,
+            sem_telegram=False,
+        )
+
+        with patch(
+            "job_hunter_agent.application.application_cli_dispatch.create_query_app",
+            return_value=fake_app,
+        ) as app_factory, patch("builtins.print") as print_mock:
+            handled = execute_cli_command(args)
+
+        self.assertTrue(handled)
+        app_factory.assert_called_once_with()
+        print_mock.assert_called_once_with("report=35")
+
     def test_execute_cli_command_dispatches_application_preflight_with_flow_app(self) -> None:
         fake_app = type(
             "FakeApp",

--- a/tests/test_application_cli_parse.py
+++ b/tests/test_application_cli_parse.py
@@ -13,6 +13,14 @@ class ApplicationCliParseTests(TestCase):
         self.assertEqual(args.applications_command, "diagnose")
         self.assertEqual(args.id, 32)
 
+    def test_parse_args_accepts_applications_report_command(self) -> None:
+        with patch("sys.argv", ["main.py", "applications", "report", "--id", "32"]):
+            args = parse_args()
+
+        self.assertEqual(args.command, "applications")
+        self.assertEqual(args.applications_command, "report")
+        self.assertEqual(args.id, 32)
+
     def test_parse_args_rejects_negative_cycle_interval_with_portuguese_message(self) -> None:
         with patch("sys.argv", ["main.py", "--ciclos", "2", "--intervalo-ciclos-segundos", "-1"]):
             with self.assertRaises(SystemExit) as raised:

--- a/tests/test_application_queries_report.py
+++ b/tests/test_application_queries_report.py
@@ -1,0 +1,90 @@
+from unittest import TestCase
+from unittest.mock import patch
+
+from job_hunter_agent.application.application_queries import ApplicationQueryService
+from job_hunter_agent.core.domain import JobApplication, JobApplicationEvent, JobPosting
+
+
+class _RepositoryStub:
+    def __init__(self) -> None:
+        self.application = JobApplication(
+            id=32,
+            job_id=10,
+            status="confirmed",
+            support_level="manual_review",
+        )
+        self.job = JobPosting(
+            id=10,
+            title="Backend Java",
+            company="ACME",
+            location="Brasil",
+            work_mode="remoto",
+            salary_text="Nao informado",
+            url="https://example.com/job",
+            source_site="LinkedIn",
+            summary="Resumo",
+            relevance=8,
+            rationale="Boa aderencia",
+            external_key="job-10",
+            status="approved",
+        )
+        self.events = [
+            JobApplicationEvent(
+                id=1,
+                application_id=32,
+                event_type="status_changed",
+                from_status="ready_for_review",
+                to_status="confirmed",
+                detail="confirmada por humano",
+                created_at="2026-04-29T10:00:00",
+            )
+        ]
+
+    def get_application(self, application_id: int) -> JobApplication | None:
+        if application_id == 32:
+            return self.application
+        if application_id == 33:
+            return JobApplication(id=33, job_id=404, status="draft")
+        return None
+
+    def get_job(self, job_id: int) -> JobPosting | None:
+        if job_id == 10:
+            return self.job
+        return None
+
+    def list_application_events(self, application_id: int, *, limit: int) -> list[JobApplicationEvent]:
+        assert application_id == 32
+        assert limit == 10
+        return self.events
+
+
+class ApplicationQueryServiceReportTests(TestCase):
+    def test_generate_application_report_writes_markdown_and_returns_path(self) -> None:
+        service = ApplicationQueryService(repository=_RepositoryStub())
+
+        with patch(
+            "job_hunter_agent.application.application_queries.write_application_report",
+            return_value="artifacts/reports/application-32.md",
+        ) as write_report:
+            rendered = service.generate_application_report(32)
+
+        self.assertEqual(rendered, "Relatorio gerado: artifacts/reports/application-32.md")
+        write_report.assert_called_once()
+        kwargs = write_report.call_args.kwargs
+        self.assertEqual(kwargs["application"].id, 32)
+        self.assertEqual(kwargs["job"].id, 10)
+        self.assertEqual(len(kwargs["events"]), 1)
+
+    def test_generate_application_report_reports_missing_application(self) -> None:
+        service = ApplicationQueryService(repository=_RepositoryStub())
+
+        rendered = service.generate_application_report(404)
+
+        self.assertEqual(rendered, "Candidatura nao encontrada: id=404")
+
+    def test_generate_application_report_reports_missing_job(self) -> None:
+        service = ApplicationQueryService(repository=_RepositoryStub())
+
+        rendered = service.generate_application_report(33)
+
+        self.assertEqual(rendered, "Vaga associada nao encontrada: application_id=33 job_id=404")


### PR DESCRIPTION
## Resumo
- adiciona comando `python main.py applications report --id <application_id>`
- gera Markdown deterministico em `artifacts/reports/application-<id>.md`
- inclui blocos A-F conforme `docs/APPLICATION_EVALUATION_REPORT.md`
- mantem operacao read-only: nao altera status, nao roda preflight e nao executa submit
- cobre parser, dispatch, renderer e query service com testes

## Testes
- CI deve rodar `pytest`

Closes #80