### PR TITLE
feat: harden application report output handling

### DIFF
--- a/job_hunter_agent/application/app.py
+++ b/job_hunter_agent/application/app.py
@@ -214,8 +214,18 @@ class JobHunterApplication:
     def diagnose_application(self, application_id: int) -> str:
         return self._query_service().diagnose_application(application_id)
 
-    def generate_application_report(self, application_id: int) -> str:
-        return self._query_service().generate_application_report(application_id)
+    def generate_application_report(
+        self,
+        application_id: int,
+        *,
+        output_path: Path | None = None,
+        force: bool = False,
+    ) -> str:
+        return self._query_service().generate_application_report(
+            application_id,
+            output_path=output_path,
+            force=force,
+        )
 
     def transition_application(self, application_id: int, action: str) -> str:
         return self._application_transition_commands().transition_application(application_id, action)

--- a/job_hunter_agent/application/application_cli.py
+++ b/job_hunter_agent/application/application_cli.py
@@ -98,6 +98,17 @@ def parse_args() -> argparse.Namespace:
         help="Gera relatorio A-F deterministico de uma candidatura.",
     )
     applications_report_parser.add_argument("--id", type=int, required=True, help="ID da candidatura.")
+    applications_report_parser.add_argument(
+        "--output",
+        type=Path,
+        default=None,
+        help="Caminho customizado para salvar o relatorio Markdown.",
+    )
+    applications_report_parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Sobrescreve o relatorio de destino se ele ja existir.",
+    )
 
     applications_events_parser = applications_subparsers.add_parser(
         "events",

--- a/job_hunter_agent/application/application_cli_dispatch.py
+++ b/job_hunter_agent/application/application_cli_dispatch.py
@@ -87,7 +87,13 @@ def _run_applications_command(args: Namespace) -> None:
         return
     if args.applications_command == "report":
         app = create_query_app()
-        print(app.generate_application_report(args.id))
+        print(
+            app.generate_application_report(
+                args.id,
+                output_path=getattr(args, "output", None),
+                force=getattr(args, "force", False),
+            )
+        )
         return
     if args.applications_command == "events":
         app = create_query_app()

--- a/job_hunter_agent/application/application_queries.py
+++ b/job_hunter_agent/application/application_queries.py
@@ -14,7 +14,7 @@ from job_hunter_agent.application.application_cli_rendering import (
     render_status_overview,
     summarize_operational_counts,
 )
-from job_hunter_agent.application.application_report import write_application_report
+from job_hunter_agent.application.application_report import ApplicationReportAlreadyExistsError, write_application_report
 from job_hunter_agent.core.domain import VALID_APPLICATION_STATUSES, VALID_STATUSES
 from job_hunter_agent.core.event_bus import EventBusPort
 from job_hunter_agent.infrastructure.repository import JobRepository
@@ -123,7 +123,7 @@ class ApplicationQueryService:
             domain_events_enabled=self.domain_event_bus is not None,
         )
 
-    def generate_application_report(self, application_id: int) -> str:
+    def generate_application_report(self, application_id: int, *, output_path: Path | None = None, force: bool = False) -> str:
         application = self.repository.get_application(application_id)
         if application is None:
             return f"Candidatura nao encontrada: id={application_id}"
@@ -131,11 +131,16 @@ class ApplicationQueryService:
         if job is None:
             return f"Vaga associada nao encontrada: application_id={application_id} job_id={application.job_id}"
         events = self.repository.list_application_events(application_id, limit=10)
-        report_path = write_application_report(
-            application=application,
-            job=job,
-            events=events,
-        )
+        try:
+            report_path = write_application_report(
+                application=application,
+                job=job,
+                events=events,
+                output_path=output_path,
+                force=force,
+            )
+        except ApplicationReportAlreadyExistsError as error:
+            return f"Relatorio ja existe: {error.path}. Use --force para sobrescrever."
         return f"Relatorio gerado: {report_path}"
 
     def show_latest_failure_artifacts(self, *, artifacts_dir: Path, limit: int = 5) -> str:

--- a/job_hunter_agent/application/application_report.py
+++ b/job_hunter_agent/application/application_report.py
@@ -7,6 +7,12 @@ from pathlib import Path
 DEFAULT_APPLICATION_REPORTS_DIR = Path("artifacts/reports")
 
 
+class ApplicationReportAlreadyExistsError(Exception):
+    def __init__(self, path: Path) -> None:
+        self.path = path
+        super().__init__(str(path))
+
+
 def build_application_report_path(application_id: int, *, reports_dir: Path = DEFAULT_APPLICATION_REPORTS_DIR) -> Path:
     return reports_dir / f"application-{application_id}.md"
 
@@ -17,9 +23,13 @@ def write_application_report(
     job: object,
     events: list[object],
     reports_dir: Path = DEFAULT_APPLICATION_REPORTS_DIR,
+    output_path: Path | None = None,
+    force: bool = False,
 ) -> Path:
-    reports_dir.mkdir(parents=True, exist_ok=True)
-    path = build_application_report_path(application.id, reports_dir=reports_dir)
+    path = output_path or build_application_report_path(application.id, reports_dir=reports_dir)
+    if path.exists() and not force:
+        raise ApplicationReportAlreadyExistsError(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(
         render_application_evaluation_report(application=application, job=job, events=events),
         encoding="utf-8",

--- a/tests/test_application_cli_dispatch.py
+++ b/tests/test_application_cli_dispatch.py
@@ -1,4 +1,5 @@
 from argparse import Namespace
+from pathlib import Path
 from unittest import TestCase
 from unittest.mock import Mock, patch
 
@@ -90,7 +91,9 @@ class ApplicationCliDispatchTests(TestCase):
             "FakeApp",
             (),
             {
-                "generate_application_report": lambda self, application_id: f"report={application_id}",
+                "generate_application_report": lambda self, application_id, output_path=None, force=False: (
+                    f"report={application_id}|output={output_path}|force={force}"
+                ),
             },
         )()
 
@@ -99,6 +102,8 @@ class ApplicationCliDispatchTests(TestCase):
             command="applications",
             applications_command="report",
             id=35,
+            output=None,
+            force=False,
             sem_telegram=False,
         )
 
@@ -110,7 +115,38 @@ class ApplicationCliDispatchTests(TestCase):
 
         self.assertTrue(handled)
         app_factory.assert_called_once_with()
-        print_mock.assert_called_once_with("report=35")
+        print_mock.assert_called_once_with("report=35|output=None|force=False")
+
+    def test_execute_cli_command_dispatches_application_report_output_and_force(self) -> None:
+        fake_app = type(
+            "FakeApp",
+            (),
+            {
+                "generate_application_report": lambda self, application_id, output_path=None, force=False: (
+                    f"report={application_id}|output={output_path}|force={force}"
+                ),
+            },
+        )()
+
+        args = Namespace(
+            bootstrap_linkedin_session=False,
+            command="applications",
+            applications_command="report",
+            id=35,
+            output=Path("custom/report.md"),
+            force=True,
+            sem_telegram=False,
+        )
+
+        with patch(
+            "job_hunter_agent.application.application_cli_dispatch.create_query_app",
+            return_value=fake_app,
+        ) as app_factory, patch("builtins.print") as print_mock:
+            handled = execute_cli_command(args)
+
+        self.assertTrue(handled)
+        app_factory.assert_called_once_with()
+        print_mock.assert_called_once_with("report=35|output=custom/report.md|force=True")
 
     def test_execute_cli_command_dispatches_application_preflight_with_flow_app(self) -> None:
         fake_app = type(

--- a/tests/test_application_cli_parse.py
+++ b/tests/test_application_cli_parse.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from unittest import TestCase
 from unittest.mock import patch
 
@@ -20,6 +21,30 @@ class ApplicationCliParseTests(TestCase):
         self.assertEqual(args.command, "applications")
         self.assertEqual(args.applications_command, "report")
         self.assertEqual(args.id, 32)
+        self.assertIsNone(args.output)
+        self.assertFalse(args.force)
+
+    def test_parse_args_accepts_applications_report_output_and_force(self) -> None:
+        with patch(
+            "sys.argv",
+            [
+                "main.py",
+                "applications",
+                "report",
+                "--id",
+                "32",
+                "--output",
+                "custom/report.md",
+                "--force",
+            ],
+        ):
+            args = parse_args()
+
+        self.assertEqual(args.command, "applications")
+        self.assertEqual(args.applications_command, "report")
+        self.assertEqual(args.id, 32)
+        self.assertEqual(args.output, Path("custom/report.md"))
+        self.assertTrue(args.force)
 
     def test_parse_args_rejects_negative_cycle_interval_with_portuguese_message(self) -> None:
         with patch("sys.argv", ["main.py", "--ciclos", "2", "--intervalo-ciclos-segundos", "-1"]):

--- a/tests/test_application_queries_report.py
+++ b/tests/test_application_queries_report.py
@@ -1,6 +1,8 @@
+from pathlib import Path
 from unittest import TestCase
 from unittest.mock import patch
 
+from job_hunter_agent.application.application_report import ApplicationReportAlreadyExistsError
 from job_hunter_agent.application.application_queries import ApplicationQueryService
 from job_hunter_agent.core.domain import JobApplication, JobApplicationEvent, JobPosting
 
@@ -74,6 +76,34 @@ class ApplicationQueryServiceReportTests(TestCase):
         self.assertEqual(kwargs["application"].id, 32)
         self.assertEqual(kwargs["job"].id, 10)
         self.assertEqual(len(kwargs["events"]), 1)
+        self.assertIsNone(kwargs["output_path"])
+        self.assertFalse(kwargs["force"])
+
+    def test_generate_application_report_passes_output_path_and_force(self) -> None:
+        service = ApplicationQueryService(repository=_RepositoryStub())
+        output_path = Path("custom/report.md")
+
+        with patch(
+            "job_hunter_agent.application.application_queries.write_application_report",
+            return_value=output_path,
+        ) as write_report:
+            rendered = service.generate_application_report(32, output_path=output_path, force=True)
+
+        self.assertEqual(rendered, "Relatorio gerado: custom/report.md")
+        kwargs = write_report.call_args.kwargs
+        self.assertEqual(kwargs["output_path"], output_path)
+        self.assertTrue(kwargs["force"])
+
+    def test_generate_application_report_reports_existing_file_without_force(self) -> None:
+        service = ApplicationQueryService(repository=_RepositoryStub())
+
+        with patch(
+            "job_hunter_agent.application.application_queries.write_application_report",
+            side_effect=ApplicationReportAlreadyExistsError(Path("custom/report.md")),
+        ):
+            rendered = service.generate_application_report(32)
+
+        self.assertEqual(rendered, "Relatorio ja existe: custom/report.md. Use --force para sobrescrever.")
 
     def test_generate_application_report_reports_missing_application(self) -> None:
         service = ApplicationQueryService(repository=_RepositoryStub())

--- a/tests/test_application_report_writer.py
+++ b/tests/test_application_report_writer.py
@@ -1,0 +1,86 @@
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest import TestCase
+
+from job_hunter_agent.application.application_report import (
+    ApplicationReportAlreadyExistsError,
+    build_application_report_path,
+    write_application_report,
+)
+from job_hunter_agent.core.domain import JobApplication, JobPosting
+
+
+def _application() -> JobApplication:
+    return JobApplication(id=32, job_id=10, status="confirmed", support_level="manual_review")
+
+
+def _job() -> JobPosting:
+    return JobPosting(
+        id=10,
+        title="Backend Java",
+        company="ACME",
+        location="Brasil",
+        work_mode="remoto",
+        salary_text="Nao informado",
+        url="https://example.com/job",
+        source_site="LinkedIn",
+        summary="Resumo",
+        relevance=8,
+        rationale="Boa aderencia",
+        external_key="job-10",
+        status="approved",
+    )
+
+
+class ApplicationReportWriterTests(TestCase):
+    def test_build_application_report_path_uses_deterministic_name(self) -> None:
+        self.assertEqual(
+            str(build_application_report_path(32)),
+            "artifacts/reports/application-32.md",
+        )
+
+    def test_write_application_report_blocks_existing_file_without_force(self) -> None:
+        with TemporaryDirectory() as temp_dir:
+            output = Path(temp_dir) / "report.md"
+            output.write_text("existing", encoding="utf-8")
+
+            with self.assertRaises(ApplicationReportAlreadyExistsError) as raised:
+                write_application_report(
+                    application=_application(),
+                    job=_job(),
+                    events=[],
+                    output_path=output,
+                )
+
+            self.assertEqual(raised.exception.path, output)
+            self.assertEqual(output.read_text(encoding="utf-8"), "existing")
+
+    def test_write_application_report_overwrites_existing_file_with_force(self) -> None:
+        with TemporaryDirectory() as temp_dir:
+            output = Path(temp_dir) / "report.md"
+            output.write_text("existing", encoding="utf-8")
+
+            written = write_application_report(
+                application=_application(),
+                job=_job(),
+                events=[],
+                output_path=output,
+                force=True,
+            )
+
+            self.assertEqual(written, output)
+            self.assertIn("# Relatorio Da Candidatura 32", output.read_text(encoding="utf-8"))
+
+    def test_write_application_report_creates_custom_parent_directory(self) -> None:
+        with TemporaryDirectory() as temp_dir:
+            output = Path(temp_dir) / "nested" / "custom.md"
+
+            written = write_application_report(
+                application=_application(),
+                job=_job(),
+                events=[],
+                output_path=output,
+            )
+
+            self.assertEqual(written, output)
+            self.assertTrue(output.exists())


### PR DESCRIPTION
## Resumo
- adiciona `--output` e `--force` ao comando `applications report`
- bloqueia sobrescrita de relatorio existente quando `--force` nao for usado
- permite caminho customizado para o Markdown gerado
- mantem o comando read-only em relacao a status/transicoes
- cobre parser, dispatch, query service e writer com testes

## Testes
- CI deve rodar `pytest`

Closes #82