### PR TITLE
feat: add application report JSON manifest

### DIFF
--- a/job_hunter_agent/application/application_queries.py
+++ b/job_hunter_agent/application/application_queries.py
@@ -132,7 +132,7 @@ class ApplicationQueryService:
             return f"Vaga associada nao encontrada: application_id={application_id} job_id={application.job_id}"
         events = self.repository.list_application_events(application_id, limit=10)
         try:
-            report_path = write_application_report(
+            artifacts = write_application_report(
                 application=application,
                 job=job,
                 events=events,
@@ -141,7 +141,7 @@ class ApplicationQueryService:
             )
         except ApplicationReportAlreadyExistsError as error:
             return f"Relatorio ja existe: {error.path}. Use --force para sobrescrever."
-        return f"Relatorio gerado: {report_path}"
+        return f"Relatorio gerado: {artifacts.report_path}\nManifesto gerado: {artifacts.manifest_path}"
 
     def show_latest_failure_artifacts(self, *, artifacts_dir: Path, limit: int = 5) -> str:
         files = sorted(

--- a/job_hunter_agent/application/application_report.py
+++ b/job_hunter_agent/application/application_report.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
+import json
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
+from typing import Any
 
 
 DEFAULT_APPLICATION_REPORTS_DIR = Path("artifacts/reports")
@@ -13,8 +16,26 @@ class ApplicationReportAlreadyExistsError(Exception):
         super().__init__(str(path))
 
 
+@dataclass(frozen=True)
+class ApplicationReportArtifacts:
+    report_path: Path
+    manifest_path: Path
+
+
 def build_application_report_path(application_id: int, *, reports_dir: Path = DEFAULT_APPLICATION_REPORTS_DIR) -> Path:
     return reports_dir / f"application-{application_id}.md"
+
+
+def build_application_report_manifest_path(
+    application_id: int,
+    *,
+    reports_dir: Path = DEFAULT_APPLICATION_REPORTS_DIR,
+) -> Path:
+    return reports_dir / f"application-{application_id}.json"
+
+
+def build_application_report_manifest_path_for_report(report_path: Path) -> Path:
+    return report_path.with_suffix(".json")
 
 
 def write_application_report(
@@ -25,20 +46,99 @@ def write_application_report(
     reports_dir: Path = DEFAULT_APPLICATION_REPORTS_DIR,
     output_path: Path | None = None,
     force: bool = False,
-) -> Path:
-    path = output_path or build_application_report_path(application.id, reports_dir=reports_dir)
-    if path.exists() and not force:
-        raise ApplicationReportAlreadyExistsError(path)
-    path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(
-        render_application_evaluation_report(application=application, job=job, events=events),
+) -> ApplicationReportArtifacts:
+    report_path = output_path or build_application_report_path(application.id, reports_dir=reports_dir)
+    manifest_path = (
+        build_application_report_manifest_path_for_report(report_path)
+        if output_path is not None
+        else build_application_report_manifest_path(application.id, reports_dir=reports_dir)
+    )
+    for path in (report_path, manifest_path):
+        if path.exists() and not force:
+            raise ApplicationReportAlreadyExistsError(path)
+
+    generated_at_utc = datetime.now(timezone.utc).isoformat(timespec="seconds")
+    report_path.parent.mkdir(parents=True, exist_ok=True)
+    manifest_path.parent.mkdir(parents=True, exist_ok=True)
+    report_path.write_text(
+        render_application_evaluation_report(
+            application=application,
+            job=job,
+            events=events,
+            generated_at_utc=generated_at_utc,
+        ),
         encoding="utf-8",
     )
-    return path
+    manifest_path.write_text(
+        json.dumps(
+            build_application_report_manifest(
+                application=application,
+                job=job,
+                report_path=report_path,
+                manifest_path=manifest_path,
+                generated_at_utc=generated_at_utc,
+            ),
+            ensure_ascii=False,
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    return ApplicationReportArtifacts(report_path=report_path, manifest_path=manifest_path)
 
 
-def render_application_evaluation_report(*, application: object, job: object, events: list[object]) -> str:
-    generated_at = datetime.now(timezone.utc).isoformat(timespec="seconds")
+def build_application_report_manifest(
+    *,
+    application: object,
+    job: object,
+    report_path: Path,
+    manifest_path: Path,
+    generated_at_utc: str,
+) -> dict[str, Any]:
+    return {
+        "application": {
+            "id": getattr(application, "id", None),
+            "job_id": getattr(application, "job_id", None),
+            "status": _raw_value(getattr(application, "status", None)),
+        },
+        "generated_at_utc": generated_at_utc,
+        "job": {
+            "id": getattr(job, "id", None),
+            "title": _raw_value(getattr(job, "title", None)),
+            "company": _raw_value(getattr(job, "company", None)),
+            "source_site": _raw_value(getattr(job, "source_site", None)),
+            "url": _raw_value(getattr(job, "url", None)),
+            "status": _raw_value(getattr(job, "status", None)),
+        },
+        "manifest_path": str(manifest_path),
+        "report_path": str(report_path),
+        "safety": {
+            "changes_status": False,
+            "read_only": True,
+            "runs_preflight": False,
+            "runs_submit": False,
+            "uses_llm": False,
+        },
+        "status": {
+            "application": _raw_value(getattr(application, "status", None)),
+            "job": _raw_value(getattr(job, "status", None)),
+        },
+        "support": {
+            "level": _raw_value(getattr(application, "support_level", None)),
+            "rationale": _raw_value(getattr(application, "support_rationale", None)),
+        },
+    }
+
+
+def render_application_evaluation_report(
+    *,
+    application: object,
+    job: object,
+    events: list[object],
+    generated_at_utc: str | None = None,
+) -> str:
+    generated_at = generated_at_utc or datetime.now(timezone.utc).isoformat(timespec="seconds")
     recent_events = _render_recent_events(events)
     return "\n".join(
         [
@@ -150,3 +250,10 @@ def _value(value: object) -> str:
         return "-"
     text = str(value).strip()
     return text if text else "-"
+
+
+def _raw_value(value: object) -> str | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None

--- a/tests/test_application_queries_report.py
+++ b/tests/test_application_queries_report.py
@@ -2,7 +2,10 @@ from pathlib import Path
 from unittest import TestCase
 from unittest.mock import patch
 
-from job_hunter_agent.application.application_report import ApplicationReportAlreadyExistsError
+from job_hunter_agent.application.application_report import (
+    ApplicationReportAlreadyExistsError,
+    ApplicationReportArtifacts,
+)
 from job_hunter_agent.application.application_queries import ApplicationQueryService
 from job_hunter_agent.core.domain import JobApplication, JobApplicationEvent, JobPosting
 
@@ -61,16 +64,23 @@ class _RepositoryStub:
 
 
 class ApplicationQueryServiceReportTests(TestCase):
-    def test_generate_application_report_writes_markdown_and_returns_path(self) -> None:
+    def test_generate_application_report_writes_markdown_and_manifest_and_returns_paths(self) -> None:
         service = ApplicationQueryService(repository=_RepositoryStub())
 
         with patch(
             "job_hunter_agent.application.application_queries.write_application_report",
-            return_value="artifacts/reports/application-32.md",
+            return_value=ApplicationReportArtifacts(
+                report_path=Path("artifacts/reports/application-32.md"),
+                manifest_path=Path("artifacts/reports/application-32.json"),
+            ),
         ) as write_report:
             rendered = service.generate_application_report(32)
 
-        self.assertEqual(rendered, "Relatorio gerado: artifacts/reports/application-32.md")
+        self.assertEqual(
+            rendered,
+            "Relatorio gerado: artifacts/reports/application-32.md\n"
+            "Manifesto gerado: artifacts/reports/application-32.json",
+        )
         write_report.assert_called_once()
         kwargs = write_report.call_args.kwargs
         self.assertEqual(kwargs["application"].id, 32)
@@ -85,11 +95,14 @@ class ApplicationQueryServiceReportTests(TestCase):
 
         with patch(
             "job_hunter_agent.application.application_queries.write_application_report",
-            return_value=output_path,
+            return_value=ApplicationReportArtifacts(
+                report_path=output_path,
+                manifest_path=Path("custom/report.json"),
+            ),
         ) as write_report:
             rendered = service.generate_application_report(32, output_path=output_path, force=True)
 
-        self.assertEqual(rendered, "Relatorio gerado: custom/report.md")
+        self.assertEqual(rendered, "Relatorio gerado: custom/report.md\nManifesto gerado: custom/report.json")
         kwargs = write_report.call_args.kwargs
         self.assertEqual(kwargs["output_path"], output_path)
         self.assertTrue(kwargs["force"])
@@ -99,11 +112,11 @@ class ApplicationQueryServiceReportTests(TestCase):
 
         with patch(
             "job_hunter_agent.application.application_queries.write_application_report",
-            side_effect=ApplicationReportAlreadyExistsError(Path("custom/report.md")),
+            side_effect=ApplicationReportAlreadyExistsError(Path("custom/report.json")),
         ):
             rendered = service.generate_application_report(32)
 
-        self.assertEqual(rendered, "Relatorio ja existe: custom/report.md. Use --force para sobrescrever.")
+        self.assertEqual(rendered, "Relatorio ja existe: custom/report.json. Use --force para sobrescrever.")
 
     def test_generate_application_report_reports_missing_application(self) -> None:
         service = ApplicationQueryService(repository=_RepositoryStub())

--- a/tests/test_application_report_writer.py
+++ b/tests/test_application_report_writer.py
@@ -1,9 +1,12 @@
+import json
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from unittest import TestCase
 
 from job_hunter_agent.application.application_report import (
     ApplicationReportAlreadyExistsError,
+    build_application_report_manifest_path,
+    build_application_report_manifest_path_for_report,
     build_application_report_path,
     write_application_report,
 )
@@ -11,7 +14,13 @@ from job_hunter_agent.core.domain import JobApplication, JobPosting
 
 
 def _application() -> JobApplication:
-    return JobApplication(id=32, job_id=10, status="confirmed", support_level="manual_review")
+    return JobApplication(
+        id=32,
+        job_id=10,
+        status="confirmed",
+        support_level="manual_review",
+        support_rationale="portal exige revisao",
+    )
 
 
 def _job() -> JobPosting:
@@ -33,15 +42,70 @@ def _job() -> JobPosting:
 
 
 class ApplicationReportWriterTests(TestCase):
-    def test_build_application_report_path_uses_deterministic_name(self) -> None:
+    def test_build_application_report_paths_use_deterministic_names(self) -> None:
         self.assertEqual(
             str(build_application_report_path(32)),
             "artifacts/reports/application-32.md",
         )
+        self.assertEqual(
+            str(build_application_report_manifest_path(32)),
+            "artifacts/reports/application-32.json",
+        )
+        self.assertEqual(
+            build_application_report_manifest_path_for_report(Path("custom/report.md")),
+            Path("custom/report.json"),
+        )
 
-    def test_write_application_report_blocks_existing_file_without_force(self) -> None:
+    def test_write_application_report_writes_markdown_and_manifest(self) -> None:
+        with TemporaryDirectory() as temp_dir:
+            reports_dir = Path(temp_dir) / "reports"
+
+            artifacts = write_application_report(
+                application=_application(),
+                job=_job(),
+                events=[],
+                reports_dir=reports_dir,
+            )
+
+            self.assertEqual(artifacts.report_path, reports_dir / "application-32.md")
+            self.assertEqual(artifacts.manifest_path, reports_dir / "application-32.json")
+            self.assertIn("# Relatorio Da Candidatura 32", artifacts.report_path.read_text(encoding="utf-8"))
+            manifest = json.loads(artifacts.manifest_path.read_text(encoding="utf-8"))
+            self.assertEqual(manifest["application"]["id"], 32)
+            self.assertEqual(manifest["application"]["status"], "confirmed")
+            self.assertEqual(manifest["job"]["id"], 10)
+            self.assertEqual(manifest["job"]["company"], "ACME")
+            self.assertEqual(manifest["status"]["application"], "confirmed")
+            self.assertEqual(manifest["support"]["level"], "manual_review")
+            self.assertEqual(manifest["report_path"], str(artifacts.report_path))
+            self.assertEqual(manifest["manifest_path"], str(artifacts.manifest_path))
+            self.assertTrue(manifest["safety"]["read_only"])
+            self.assertFalse(manifest["safety"]["uses_llm"])
+            self.assertFalse(manifest["safety"]["runs_preflight"])
+            self.assertFalse(manifest["safety"]["runs_submit"])
+            self.assertFalse(manifest["safety"]["changes_status"])
+            self.assertIn("generated_at_utc", manifest)
+
+    def test_write_application_report_uses_custom_manifest_path_from_output(self) -> None:
+        with TemporaryDirectory() as temp_dir:
+            output = Path(temp_dir) / "nested" / "custom.md"
+
+            artifacts = write_application_report(
+                application=_application(),
+                job=_job(),
+                events=[],
+                output_path=output,
+            )
+
+            self.assertEqual(artifacts.report_path, output)
+            self.assertEqual(artifacts.manifest_path, Path(temp_dir) / "nested" / "custom.json")
+            self.assertTrue(artifacts.report_path.exists())
+            self.assertTrue(artifacts.manifest_path.exists())
+
+    def test_write_application_report_blocks_existing_markdown_without_force(self) -> None:
         with TemporaryDirectory() as temp_dir:
             output = Path(temp_dir) / "report.md"
+            manifest = Path(temp_dir) / "report.json"
             output.write_text("existing", encoding="utf-8")
 
             with self.assertRaises(ApplicationReportAlreadyExistsError) as raised:
@@ -54,13 +118,34 @@ class ApplicationReportWriterTests(TestCase):
 
             self.assertEqual(raised.exception.path, output)
             self.assertEqual(output.read_text(encoding="utf-8"), "existing")
+            self.assertFalse(manifest.exists())
 
-    def test_write_application_report_overwrites_existing_file_with_force(self) -> None:
+    def test_write_application_report_blocks_existing_manifest_without_force(self) -> None:
         with TemporaryDirectory() as temp_dir:
             output = Path(temp_dir) / "report.md"
-            output.write_text("existing", encoding="utf-8")
+            manifest = Path(temp_dir) / "report.json"
+            manifest.write_text("existing", encoding="utf-8")
 
-            written = write_application_report(
+            with self.assertRaises(ApplicationReportAlreadyExistsError) as raised:
+                write_application_report(
+                    application=_application(),
+                    job=_job(),
+                    events=[],
+                    output_path=output,
+                )
+
+            self.assertEqual(raised.exception.path, manifest)
+            self.assertFalse(output.exists())
+            self.assertEqual(manifest.read_text(encoding="utf-8"), "existing")
+
+    def test_write_application_report_overwrites_existing_files_with_force(self) -> None:
+        with TemporaryDirectory() as temp_dir:
+            output = Path(temp_dir) / "report.md"
+            manifest = Path(temp_dir) / "report.json"
+            output.write_text("existing", encoding="utf-8")
+            manifest.write_text("existing", encoding="utf-8")
+
+            artifacts = write_application_report(
                 application=_application(),
                 job=_job(),
                 events=[],
@@ -68,19 +153,7 @@ class ApplicationReportWriterTests(TestCase):
                 force=True,
             )
 
-            self.assertEqual(written, output)
+            self.assertEqual(artifacts.report_path, output)
+            self.assertEqual(artifacts.manifest_path, manifest)
             self.assertIn("# Relatorio Da Candidatura 32", output.read_text(encoding="utf-8"))
-
-    def test_write_application_report_creates_custom_parent_directory(self) -> None:
-        with TemporaryDirectory() as temp_dir:
-            output = Path(temp_dir) / "nested" / "custom.md"
-
-            written = write_application_report(
-                application=_application(),
-                job=_job(),
-                events=[],
-                output_path=output,
-            )
-
-            self.assertEqual(written, output)
-            self.assertTrue(output.exists())
+            self.assertEqual(json.loads(manifest.read_text(encoding="utf-8"))["application"]["id"], 32)


### PR DESCRIPTION
## Resumo
- gera manifesto JSON sidecar junto do Markdown do `applications report`
- usa `artifacts/reports/application-<id>.json` no destino padrao
- usa `<output>.json` quando `--output custom/report.md` for informado
- aplica a mesma regra de sobrescrita para Markdown e JSON com `--force`
- inclui metadados de candidatura, vaga, status, suporte, paths e flags de safety
- mantem a operacao read-only

## Testes
- CI deve rodar `pytest`

Closes #84