### PR TITLE
feat: list generated application reports

### DIFF
--- a/job_hunter_agent/application/app.py
+++ b/job_hunter_agent/application/app.py
@@ -24,6 +24,7 @@ from job_hunter_agent.application.application_messages import (
     format_submit_dry_run_cli_result,
 )
 from job_hunter_agent.application.application_queries import ApplicationQueryService
+from job_hunter_agent.application.application_report_listing import render_application_reports_list
 from job_hunter_agent.application.application_cli_rendering import render_failure_artifacts
 from job_hunter_agent.application.composition import (
     create_application_preflight_service,
@@ -226,6 +227,9 @@ class JobHunterApplication:
             output_path=output_path,
             force=force,
         )
+
+    def list_application_reports(self, *, reports_dir: Path, limit: int = 20) -> str:
+        return render_application_reports_list(reports_dir=reports_dir, limit=limit)
 
     def transition_application(self, application_id: int, action: str) -> str:
         return self._application_transition_commands().transition_application(application_id, action)

--- a/job_hunter_agent/application/application_cli.py
+++ b/job_hunter_agent/application/application_cli.py
@@ -5,6 +5,7 @@ import asyncio
 from pathlib import Path
 
 from job_hunter_agent.application.app import JobHunterApplication
+from job_hunter_agent.application.application_report import DEFAULT_APPLICATION_REPORTS_DIR
 from job_hunter_agent.core.domain import VALID_APPLICATION_STATUSES, VALID_STATUSES
 
 
@@ -108,6 +109,31 @@ def parse_args() -> argparse.Namespace:
         "--force",
         action="store_true",
         help="Sobrescreve o relatorio de destino se ele ja existir.",
+    )
+
+    applications_reports_parser = applications_subparsers.add_parser(
+        "reports",
+        help="Operacoes sobre relatorios A-F gerados.",
+    )
+    applications_reports_subparsers = applications_reports_parser.add_subparsers(
+        dest="applications_reports_command",
+        required=True,
+    )
+    applications_reports_list_parser = applications_reports_subparsers.add_parser(
+        "list",
+        help="Lista relatorios A-F gerados em disco.",
+    )
+    applications_reports_list_parser.add_argument(
+        "--limit",
+        type=int,
+        default=20,
+        help="Quantidade maxima de relatorios exibidos.",
+    )
+    applications_reports_list_parser.add_argument(
+        "--dir",
+        type=Path,
+        default=DEFAULT_APPLICATION_REPORTS_DIR,
+        help="Diretorio de relatorios A-F.",
     )
 
     applications_events_parser = applications_subparsers.add_parser(

--- a/job_hunter_agent/application/application_cli_dispatch.py
+++ b/job_hunter_agent/application/application_cli_dispatch.py
@@ -95,6 +95,11 @@ def _run_applications_command(args: Namespace) -> None:
             )
         )
         return
+    if args.applications_command == "reports":
+        if args.applications_reports_command == "list":
+            app = create_query_app()
+            print(app.list_application_reports(reports_dir=args.dir, limit=args.limit))
+        return
     if args.applications_command == "events":
         app = create_query_app()
         print(app.show_application_events(args.id, limit=args.limit))

--- a/job_hunter_agent/application/application_report_listing.py
+++ b/job_hunter_agent/application/application_report_listing.py
@@ -1,0 +1,154 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from job_hunter_agent.application.application_report import DEFAULT_APPLICATION_REPORTS_DIR
+
+
+@dataclass(frozen=True)
+class ApplicationReportListItem:
+    report_path: Path
+    manifest_path: Path | None
+    application_id: int | None
+    job_id: int | None
+    application_status: str | None
+    job_status: str | None
+    company: str | None
+    title: str | None
+    generated_at_utc: str | None
+    manifest_status: str
+    modified_at: float
+
+
+def list_application_reports(
+    *,
+    reports_dir: Path = DEFAULT_APPLICATION_REPORTS_DIR,
+    limit: int = 20,
+) -> list[ApplicationReportListItem]:
+    if limit <= 0:
+        raise ValueError("limit must be greater than zero")
+    if not reports_dir.exists():
+        return []
+    items = [_build_item_from_markdown(path) for path in reports_dir.glob("*.md") if path.is_file()]
+    items.sort(key=lambda item: item.modified_at, reverse=True)
+    return items[:limit]
+
+
+def render_application_reports_list(
+    *,
+    reports_dir: Path = DEFAULT_APPLICATION_REPORTS_DIR,
+    limit: int = 20,
+) -> str:
+    items = list_application_reports(reports_dir=reports_dir, limit=limit)
+    if not items:
+        return f"Nenhum relatorio encontrado em {reports_dir}"
+    lines = [f"Relatorios A-F em {reports_dir}:"]
+    for item in items:
+        lines.extend(
+            [
+                f"- application_id={_value(item.application_id)} job_id={_value(item.job_id)} "
+                f"status={_value(item.application_status)} job_status={_value(item.job_status)}",
+                f"  empresa={_value(item.company)} titulo={_value(item.title)}",
+                f"  gerado_em={_value(item.generated_at_utc)} manifesto={item.manifest_status}",
+                f"  markdown={item.report_path}",
+                f"  json={_value(item.manifest_path)}",
+            ]
+        )
+    return "\n".join(lines)
+
+
+def _build_item_from_markdown(report_path: Path) -> ApplicationReportListItem:
+    manifest_path = report_path.with_suffix(".json")
+    modified_at = report_path.stat().st_mtime
+    if manifest_path.exists() and manifest_path.is_file():
+        try:
+            manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            return ApplicationReportListItem(
+                report_path=report_path,
+                manifest_path=manifest_path,
+                application_id=_extract_application_id_from_name(report_path),
+                job_id=None,
+                application_status=None,
+                job_status=None,
+                company=None,
+                title=None,
+                generated_at_utc=None,
+                manifest_status="invalid",
+                modified_at=max(modified_at, manifest_path.stat().st_mtime),
+            )
+        return _build_item_from_manifest(report_path=report_path, manifest_path=manifest_path, manifest=manifest)
+    return ApplicationReportListItem(
+        report_path=report_path,
+        manifest_path=None,
+        application_id=_extract_application_id_from_name(report_path),
+        job_id=None,
+        application_status=None,
+        job_status=None,
+        company=None,
+        title=None,
+        generated_at_utc=None,
+        manifest_status="missing",
+        modified_at=modified_at,
+    )
+
+
+def _build_item_from_manifest(
+    *,
+    report_path: Path,
+    manifest_path: Path,
+    manifest: dict[str, Any],
+) -> ApplicationReportListItem:
+    application = _dict_value(manifest, "application")
+    job = _dict_value(manifest, "job")
+    status = _dict_value(manifest, "status")
+    return ApplicationReportListItem(
+        report_path=report_path,
+        manifest_path=manifest_path,
+        application_id=_int_value(application.get("id")),
+        job_id=_int_value(job.get("id") or application.get("job_id")),
+        application_status=_str_value(status.get("application") or application.get("status")),
+        job_status=_str_value(status.get("job") or job.get("status")),
+        company=_str_value(job.get("company")),
+        title=_str_value(job.get("title")),
+        generated_at_utc=_str_value(manifest.get("generated_at_utc")),
+        manifest_status="ok",
+        modified_at=max(report_path.stat().st_mtime, manifest_path.stat().st_mtime),
+    )
+
+
+def _extract_application_id_from_name(path: Path) -> int | None:
+    stem = path.stem
+    prefix = "application-"
+    if not stem.startswith(prefix):
+        return None
+    return _int_value(stem[len(prefix) :])
+
+
+def _dict_value(data: dict[str, Any], key: str) -> dict[str, Any]:
+    value = data.get(key)
+    return value if isinstance(value, dict) else {}
+
+
+def _int_value(value: object) -> int | None:
+    try:
+        return int(value)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return None
+
+
+def _str_value(value: object) -> str | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def _value(value: object) -> str:
+    if value is None:
+        return "-"
+    text = str(value).strip()
+    return text if text else "-"

--- a/tests/test_application_cli_dispatch.py
+++ b/tests/test_application_cli_dispatch.py
@@ -148,6 +148,35 @@ class ApplicationCliDispatchTests(TestCase):
         app_factory.assert_called_once_with()
         print_mock.assert_called_once_with("report=35|output=custom/report.md|force=True")
 
+    def test_execute_cli_command_dispatches_application_reports_list(self) -> None:
+        fake_app = type(
+            "FakeApp",
+            (),
+            {
+                "list_application_reports": lambda self, reports_dir, limit=20: f"reports={reports_dir}|limit={limit}",
+            },
+        )()
+
+        args = Namespace(
+            bootstrap_linkedin_session=False,
+            command="applications",
+            applications_command="reports",
+            applications_reports_command="list",
+            dir=Path("custom/reports"),
+            limit=7,
+            sem_telegram=False,
+        )
+
+        with patch(
+            "job_hunter_agent.application.application_cli_dispatch.create_query_app",
+            return_value=fake_app,
+        ) as app_factory, patch("builtins.print") as print_mock:
+            handled = execute_cli_command(args)
+
+        self.assertTrue(handled)
+        app_factory.assert_called_once_with()
+        print_mock.assert_called_once_with("reports=custom/reports|limit=7")
+
     def test_execute_cli_command_dispatches_application_preflight_with_flow_app(self) -> None:
         fake_app = type(
             "FakeApp",

--- a/tests/test_application_cli_parse.py
+++ b/tests/test_application_cli_parse.py
@@ -3,6 +3,7 @@ from unittest import TestCase
 from unittest.mock import patch
 
 from job_hunter_agent.application.application_cli import parse_args
+from job_hunter_agent.application.application_report import DEFAULT_APPLICATION_REPORTS_DIR
 
 
 class ApplicationCliParseTests(TestCase):
@@ -45,6 +46,44 @@ class ApplicationCliParseTests(TestCase):
         self.assertEqual(args.id, 32)
         self.assertEqual(args.output, Path("custom/report.md"))
         self.assertTrue(args.force)
+
+    def test_parse_args_accepts_applications_reports_list_defaults(self) -> None:
+        with patch("sys.argv", ["main.py", "applications", "reports", "list"]):
+            args = parse_args()
+
+        self.assertEqual(args.command, "applications")
+        self.assertEqual(args.applications_command, "reports")
+        self.assertEqual(args.applications_reports_command, "list")
+        self.assertEqual(args.limit, 20)
+        self.assertEqual(args.dir, DEFAULT_APPLICATION_REPORTS_DIR)
+
+    def test_parse_args_accepts_applications_reports_list_options(self) -> None:
+        with patch(
+            "sys.argv",
+            [
+                "main.py",
+                "applications",
+                "reports",
+                "list",
+                "--limit",
+                "7",
+                "--dir",
+                "custom/reports",
+            ],
+        ):
+            args = parse_args()
+
+        self.assertEqual(args.applications_command, "reports")
+        self.assertEqual(args.applications_reports_command, "list")
+        self.assertEqual(args.limit, 7)
+        self.assertEqual(args.dir, Path("custom/reports"))
+
+    def test_parse_args_rejects_reports_list_non_positive_limit(self) -> None:
+        with patch("sys.argv", ["main.py", "applications", "reports", "list", "--limit", "0"]):
+            with self.assertRaises(SystemExit) as raised:
+                parse_args()
+
+        self.assertNotEqual(raised.exception.code, 0)
 
     def test_parse_args_rejects_negative_cycle_interval_with_portuguese_message(self) -> None:
         with patch("sys.argv", ["main.py", "--ciclos", "2", "--intervalo-ciclos-segundos", "-1"]):

--- a/tests/test_application_report_listing.py
+++ b/tests/test_application_report_listing.py
@@ -1,0 +1,119 @@
+import json
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest import TestCase
+
+from job_hunter_agent.application.application_report_listing import (
+    list_application_reports,
+    render_application_reports_list,
+)
+
+
+class ApplicationReportListingTests(TestCase):
+    def test_list_application_reports_uses_manifest_when_available(self) -> None:
+        with TemporaryDirectory() as temp_dir:
+            reports_dir = Path(temp_dir)
+            report = reports_dir / "application-32.md"
+            manifest = reports_dir / "application-32.json"
+            report.write_text("# Relatorio", encoding="utf-8")
+            manifest.write_text(
+                json.dumps(
+                    {
+                        "application": {"id": 32, "job_id": 10, "status": "confirmed"},
+                        "generated_at_utc": "2026-04-30T10:00:00+00:00",
+                        "job": {
+                            "id": 10,
+                            "title": "Backend Java",
+                            "company": "ACME",
+                            "status": "approved",
+                        },
+                        "status": {"application": "confirmed", "job": "approved"},
+                        "support": {"level": "manual_review"},
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            items = list_application_reports(reports_dir=reports_dir)
+
+        self.assertEqual(len(items), 1)
+        self.assertEqual(items[0].application_id, 32)
+        self.assertEqual(items[0].job_id, 10)
+        self.assertEqual(items[0].application_status, "confirmed")
+        self.assertEqual(items[0].job_status, "approved")
+        self.assertEqual(items[0].company, "ACME")
+        self.assertEqual(items[0].title, "Backend Java")
+        self.assertEqual(items[0].generated_at_utc, "2026-04-30T10:00:00+00:00")
+        self.assertEqual(items[0].manifest_status, "ok")
+
+    def test_list_application_reports_falls_back_to_markdown_without_manifest(self) -> None:
+        with TemporaryDirectory() as temp_dir:
+            reports_dir = Path(temp_dir)
+            (reports_dir / "application-45.md").write_text("# Relatorio", encoding="utf-8")
+
+            items = list_application_reports(reports_dir=reports_dir)
+
+        self.assertEqual(len(items), 1)
+        self.assertEqual(items[0].application_id, 45)
+        self.assertIsNone(items[0].job_id)
+        self.assertEqual(items[0].manifest_status, "missing")
+
+    def test_list_application_reports_keeps_invalid_manifest_item(self) -> None:
+        with TemporaryDirectory() as temp_dir:
+            reports_dir = Path(temp_dir)
+            (reports_dir / "application-46.md").write_text("# Relatorio", encoding="utf-8")
+            (reports_dir / "application-46.json").write_text("{invalid", encoding="utf-8")
+
+            items = list_application_reports(reports_dir=reports_dir)
+
+        self.assertEqual(len(items), 1)
+        self.assertEqual(items[0].application_id, 46)
+        self.assertEqual(items[0].manifest_status, "invalid")
+
+    def test_list_application_reports_orders_by_modified_time_and_applies_limit(self) -> None:
+        with TemporaryDirectory() as temp_dir:
+            reports_dir = Path(temp_dir)
+            first = reports_dir / "application-1.md"
+            second = reports_dir / "application-2.md"
+            first.write_text("# 1", encoding="utf-8")
+            second.write_text("# 2", encoding="utf-8")
+            first.touch()
+            second.touch()
+
+            items = list_application_reports(reports_dir=reports_dir, limit=1)
+
+        self.assertEqual(len(items), 1)
+        self.assertIn(items[0].application_id, {1, 2})
+
+    def test_list_application_reports_returns_empty_for_missing_directory(self) -> None:
+        with TemporaryDirectory() as temp_dir:
+            missing = Path(temp_dir) / "missing"
+
+            items = list_application_reports(reports_dir=missing)
+
+        self.assertEqual(items, [])
+
+    def test_list_application_reports_rejects_non_positive_limit(self) -> None:
+        with TemporaryDirectory() as temp_dir:
+            with self.assertRaises(ValueError):
+                list_application_reports(reports_dir=Path(temp_dir), limit=0)
+
+    def test_render_application_reports_list(self) -> None:
+        with TemporaryDirectory() as temp_dir:
+            reports_dir = Path(temp_dir)
+            (reports_dir / "application-45.md").write_text("# Relatorio", encoding="utf-8")
+
+            rendered = render_application_reports_list(reports_dir=reports_dir)
+
+        self.assertIn(f"Relatorios A-F em {reports_dir}", rendered)
+        self.assertIn("application_id=45", rendered)
+        self.assertIn("manifesto=missing", rendered)
+        self.assertIn("markdown=", rendered)
+
+    def test_render_application_reports_list_handles_empty_directory(self) -> None:
+        with TemporaryDirectory() as temp_dir:
+            reports_dir = Path(temp_dir)
+
+            rendered = render_application_reports_list(reports_dir=reports_dir)
+
+        self.assertEqual(rendered, f"Nenhum relatorio encontrado em {reports_dir}")


### PR DESCRIPTION
## Resumo
- adiciona `python main.py applications reports list`
- suporta `--limit` e `--dir`
- lista relatorios A-F gerados em disco
- usa manifesto JSON quando disponivel
- faz fallback para Markdown sem manifesto
- tolera manifesto JSON invalido sem quebrar a listagem inteira
- mantem operacao read-only

## Testes
- CI deve rodar `pytest`

Closes #86