### PR TITLE
feat: validate generated application reports

### DIFF
--- a/job_hunter_agent/application/app.py
+++ b/job_hunter_agent/application/app.py
@@ -25,6 +25,7 @@ from job_hunter_agent.application.application_messages import (
 )
 from job_hunter_agent.application.application_queries import ApplicationQueryService
 from job_hunter_agent.application.application_report_listing import render_application_reports_list
+from job_hunter_agent.application.application_report_validation import render_application_reports_validation
 from job_hunter_agent.application.application_cli_rendering import render_failure_artifacts
 from job_hunter_agent.application.composition import (
     create_application_preflight_service,
@@ -230,6 +231,9 @@ class JobHunterApplication:
 
     def list_application_reports(self, *, reports_dir: Path, limit: int = 20) -> str:
         return render_application_reports_list(reports_dir=reports_dir, limit=limit)
+
+    def validate_application_reports(self, *, reports_dir: Path, strict: bool = False) -> str:
+        return render_application_reports_validation(reports_dir=reports_dir, strict=strict)
 
     def transition_application(self, application_id: int, action: str) -> str:
         return self._application_transition_commands().transition_application(application_id, action)

--- a/job_hunter_agent/application/application_cli.py
+++ b/job_hunter_agent/application/application_cli.py
@@ -135,6 +135,21 @@ def parse_args() -> argparse.Namespace:
         default=DEFAULT_APPLICATION_REPORTS_DIR,
         help="Diretorio de relatorios A-F.",
     )
+    applications_reports_validate_parser = applications_reports_subparsers.add_parser(
+        "validate",
+        help="Valida integridade dos relatorios A-F gerados.",
+    )
+    applications_reports_validate_parser.add_argument(
+        "--dir",
+        type=Path,
+        default=DEFAULT_APPLICATION_REPORTS_DIR,
+        help="Diretorio de relatorios A-F.",
+    )
+    applications_reports_validate_parser.add_argument(
+        "--strict",
+        action="store_true",
+        help="Trata pares Markdown/JSON ausentes como erro em vez de warning.",
+    )
 
     applications_events_parser = applications_subparsers.add_parser(
         "events",

--- a/job_hunter_agent/application/application_cli_dispatch.py
+++ b/job_hunter_agent/application/application_cli_dispatch.py
@@ -96,10 +96,13 @@ def _run_applications_command(args: Namespace) -> None:
         )
         return
     if args.applications_command == "reports":
+        app = create_query_app()
         if args.applications_reports_command == "list":
-            app = create_query_app()
             print(app.list_application_reports(reports_dir=args.dir, limit=args.limit))
-        return
+            return
+        if args.applications_reports_command == "validate":
+            print(app.validate_application_reports(reports_dir=args.dir, strict=args.strict))
+            return
     if args.applications_command == "events":
         app = create_query_app()
         print(app.show_application_events(args.id, limit=args.limit))

--- a/job_hunter_agent/application/application_report_validation.py
+++ b/job_hunter_agent/application/application_report_validation.py
@@ -1,0 +1,181 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from job_hunter_agent.application.application_report import DEFAULT_APPLICATION_REPORTS_DIR
+
+
+REQUIRED_MANIFEST_FIELDS = (
+    "application",
+    "job",
+    "status",
+    "support",
+    "report_path",
+    "manifest_path",
+    "safety",
+    "generated_at_utc",
+)
+
+EXPECTED_SAFETY_FLAGS = {
+    "read_only": True,
+    "uses_llm": False,
+    "runs_preflight": False,
+    "runs_submit": False,
+    "changes_status": False,
+}
+
+
+@dataclass(frozen=True)
+class ApplicationReportValidationIssue:
+    level: str
+    path: Path
+    message: str
+
+
+@dataclass(frozen=True)
+class ApplicationReportValidationResult:
+    reports_dir: Path
+    ok_count: int
+    warning_count: int
+    error_count: int
+    issues: tuple[ApplicationReportValidationIssue, ...]
+
+
+def validate_application_reports(
+    *,
+    reports_dir: Path = DEFAULT_APPLICATION_REPORTS_DIR,
+    strict: bool = False,
+) -> ApplicationReportValidationResult:
+    issues: list[ApplicationReportValidationIssue] = []
+    ok_count = 0
+    if not reports_dir.exists():
+        issues.append(ApplicationReportValidationIssue("warning", reports_dir, "diretorio de relatorios nao existe"))
+        return _build_result(reports_dir=reports_dir, ok_count=0, issues=issues)
+
+    markdown_paths = {path.with_suffix(""): path for path in reports_dir.glob("*.md") if path.is_file()}
+    manifest_paths = {path.with_suffix(""): path for path in reports_dir.glob("*.json") if path.is_file()}
+    all_stems = sorted(set(markdown_paths) | set(manifest_paths), key=lambda path: path.name)
+
+    for stem in all_stems:
+        report_path = markdown_paths.get(stem)
+        manifest_path = manifest_paths.get(stem)
+        if report_path is None and manifest_path is not None:
+            issues.append(
+                ApplicationReportValidationIssue(
+                    _pair_issue_level(strict),
+                    manifest_path,
+                    "manifesto JSON sem Markdown correspondente",
+                )
+            )
+            continue
+        if report_path is not None and manifest_path is None:
+            issues.append(
+                ApplicationReportValidationIssue(
+                    _pair_issue_level(strict),
+                    report_path,
+                    "Markdown sem manifesto JSON correspondente",
+                )
+            )
+            continue
+        if report_path is None or manifest_path is None:
+            continue
+        manifest_issues = _validate_manifest(report_path=report_path, manifest_path=manifest_path)
+        if manifest_issues:
+            issues.extend(manifest_issues)
+            continue
+        ok_count += 1
+
+    return _build_result(reports_dir=reports_dir, ok_count=ok_count, issues=issues)
+
+
+def render_application_reports_validation(
+    *,
+    reports_dir: Path = DEFAULT_APPLICATION_REPORTS_DIR,
+    strict: bool = False,
+) -> str:
+    result = validate_application_reports(reports_dir=reports_dir, strict=strict)
+    lines = [
+        f"Validacao de relatorios A-F em {result.reports_dir}:",
+        f"- ok={result.ok_count}",
+        f"- warnings={result.warning_count}",
+        f"- errors={result.error_count}",
+        f"- strict={str(strict).lower()}",
+    ]
+    if result.issues:
+        lines.append("Problemas:")
+        for issue in result.issues:
+            lines.append(f"- {issue.level}: {issue.path}: {issue.message}")
+    return "\n".join(lines)
+
+
+def _validate_manifest(*, report_path: Path, manifest_path: Path) -> list[ApplicationReportValidationIssue]:
+    issues: list[ApplicationReportValidationIssue] = []
+    try:
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        return [
+            ApplicationReportValidationIssue(
+                "error",
+                manifest_path,
+                f"manifesto JSON invalido: {error}",
+            )
+        ]
+    if not isinstance(manifest, dict):
+        return [ApplicationReportValidationIssue("error", manifest_path, "manifesto JSON deve ser um objeto")]
+
+    for field in REQUIRED_MANIFEST_FIELDS:
+        if field not in manifest:
+            issues.append(ApplicationReportValidationIssue("error", manifest_path, f"campo obrigatorio ausente: {field}"))
+
+    report_path_value = _str_value(manifest.get("report_path"))
+    manifest_path_value = _str_value(manifest.get("manifest_path"))
+    if report_path_value is not None and Path(report_path_value) != report_path:
+        issues.append(ApplicationReportValidationIssue("error", manifest_path, "report_path nao aponta para o Markdown validado"))
+    if manifest_path_value is not None and Path(manifest_path_value) != manifest_path:
+        issues.append(ApplicationReportValidationIssue("error", manifest_path, "manifest_path nao aponta para o JSON validado"))
+
+    safety = manifest.get("safety")
+    if not isinstance(safety, dict):
+        issues.append(ApplicationReportValidationIssue("error", manifest_path, "safety deve ser um objeto"))
+        return issues
+    for key, expected in EXPECTED_SAFETY_FLAGS.items():
+        if safety.get(key) is not expected:
+            issues.append(
+                ApplicationReportValidationIssue(
+                    "error",
+                    manifest_path,
+                    f"flag de safety invalida: {key}={safety.get(key)!r}, esperado {expected!r}",
+                )
+            )
+    return issues
+
+
+def _build_result(
+    *,
+    reports_dir: Path,
+    ok_count: int,
+    issues: list[ApplicationReportValidationIssue],
+) -> ApplicationReportValidationResult:
+    warning_count = sum(1 for issue in issues if issue.level == "warning")
+    error_count = sum(1 for issue in issues if issue.level == "error")
+    return ApplicationReportValidationResult(
+        reports_dir=reports_dir,
+        ok_count=ok_count,
+        warning_count=warning_count,
+        error_count=error_count,
+        issues=tuple(issues),
+    )
+
+
+def _pair_issue_level(strict: bool) -> str:
+    return "error" if strict else "warning"
+
+
+def _str_value(value: object) -> str | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None

--- a/tests/test_application_cli_dispatch.py
+++ b/tests/test_application_cli_dispatch.py
@@ -177,6 +177,37 @@ class ApplicationCliDispatchTests(TestCase):
         app_factory.assert_called_once_with()
         print_mock.assert_called_once_with("reports=custom/reports|limit=7")
 
+    def test_execute_cli_command_dispatches_application_reports_validate(self) -> None:
+        fake_app = type(
+            "FakeApp",
+            (),
+            {
+                "validate_application_reports": lambda self, reports_dir, strict=False: (
+                    f"validate={reports_dir}|strict={strict}"
+                ),
+            },
+        )()
+
+        args = Namespace(
+            bootstrap_linkedin_session=False,
+            command="applications",
+            applications_command="reports",
+            applications_reports_command="validate",
+            dir=Path("custom/reports"),
+            strict=True,
+            sem_telegram=False,
+        )
+
+        with patch(
+            "job_hunter_agent.application.application_cli_dispatch.create_query_app",
+            return_value=fake_app,
+        ) as app_factory, patch("builtins.print") as print_mock:
+            handled = execute_cli_command(args)
+
+        self.assertTrue(handled)
+        app_factory.assert_called_once_with()
+        print_mock.assert_called_once_with("validate=custom/reports|strict=True")
+
     def test_execute_cli_command_dispatches_application_preflight_with_flow_app(self) -> None:
         fake_app = type(
             "FakeApp",

--- a/tests/test_application_cli_parse.py
+++ b/tests/test_application_cli_parse.py
@@ -78,6 +78,36 @@ class ApplicationCliParseTests(TestCase):
         self.assertEqual(args.limit, 7)
         self.assertEqual(args.dir, Path("custom/reports"))
 
+    def test_parse_args_accepts_applications_reports_validate_defaults(self) -> None:
+        with patch("sys.argv", ["main.py", "applications", "reports", "validate"]):
+            args = parse_args()
+
+        self.assertEqual(args.command, "applications")
+        self.assertEqual(args.applications_command, "reports")
+        self.assertEqual(args.applications_reports_command, "validate")
+        self.assertEqual(args.dir, DEFAULT_APPLICATION_REPORTS_DIR)
+        self.assertFalse(args.strict)
+
+    def test_parse_args_accepts_applications_reports_validate_options(self) -> None:
+        with patch(
+            "sys.argv",
+            [
+                "main.py",
+                "applications",
+                "reports",
+                "validate",
+                "--dir",
+                "custom/reports",
+                "--strict",
+            ],
+        ):
+            args = parse_args()
+
+        self.assertEqual(args.applications_command, "reports")
+        self.assertEqual(args.applications_reports_command, "validate")
+        self.assertEqual(args.dir, Path("custom/reports"))
+        self.assertTrue(args.strict)
+
     def test_parse_args_rejects_reports_list_non_positive_limit(self) -> None:
         with patch("sys.argv", ["main.py", "applications", "reports", "list", "--limit", "0"]):
             with self.assertRaises(SystemExit) as raised:

--- a/tests/test_application_report_validation.py
+++ b/tests/test_application_report_validation.py
@@ -1,0 +1,166 @@
+import json
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest import TestCase
+
+from job_hunter_agent.application.application_report_validation import (
+    render_application_reports_validation,
+    validate_application_reports,
+)
+
+
+def _valid_manifest(report_path: Path, manifest_path: Path) -> dict[str, object]:
+    return {
+        "application": {"id": 32, "job_id": 10, "status": "confirmed"},
+        "generated_at_utc": "2026-04-30T10:00:00+00:00",
+        "job": {"id": 10, "title": "Backend Java", "company": "ACME", "status": "approved"},
+        "manifest_path": str(manifest_path),
+        "report_path": str(report_path),
+        "safety": {
+            "changes_status": False,
+            "read_only": True,
+            "runs_preflight": False,
+            "runs_submit": False,
+            "uses_llm": False,
+        },
+        "status": {"application": "confirmed", "job": "approved"},
+        "support": {"level": "manual_review", "rationale": "portal exige revisao"},
+    }
+
+
+class ApplicationReportValidationTests(TestCase):
+    def test_validate_application_reports_accepts_valid_pair(self) -> None:
+        with TemporaryDirectory() as temp_dir:
+            reports_dir = Path(temp_dir)
+            report = reports_dir / "application-32.md"
+            manifest = reports_dir / "application-32.json"
+            report.write_text("# Relatorio", encoding="utf-8")
+            manifest.write_text(json.dumps(_valid_manifest(report, manifest)), encoding="utf-8")
+
+            result = validate_application_reports(reports_dir=reports_dir)
+
+        self.assertEqual(result.ok_count, 1)
+        self.assertEqual(result.warning_count, 0)
+        self.assertEqual(result.error_count, 0)
+        self.assertEqual(result.issues, ())
+
+    def test_validate_application_reports_warns_for_markdown_without_manifest_by_default(self) -> None:
+        with TemporaryDirectory() as temp_dir:
+            reports_dir = Path(temp_dir)
+            (reports_dir / "application-32.md").write_text("# Relatorio", encoding="utf-8")
+
+            result = validate_application_reports(reports_dir=reports_dir)
+
+        self.assertEqual(result.ok_count, 0)
+        self.assertEqual(result.warning_count, 1)
+        self.assertEqual(result.error_count, 0)
+        self.assertEqual(result.issues[0].message, "Markdown sem manifesto JSON correspondente")
+
+    def test_validate_application_reports_errors_for_markdown_without_manifest_in_strict_mode(self) -> None:
+        with TemporaryDirectory() as temp_dir:
+            reports_dir = Path(temp_dir)
+            (reports_dir / "application-32.md").write_text("# Relatorio", encoding="utf-8")
+
+            result = validate_application_reports(reports_dir=reports_dir, strict=True)
+
+        self.assertEqual(result.ok_count, 0)
+        self.assertEqual(result.warning_count, 0)
+        self.assertEqual(result.error_count, 1)
+        self.assertEqual(result.issues[0].level, "error")
+
+    def test_validate_application_reports_warns_for_manifest_without_markdown_by_default(self) -> None:
+        with TemporaryDirectory() as temp_dir:
+            reports_dir = Path(temp_dir)
+            manifest = reports_dir / "application-32.json"
+            manifest.write_text("{}", encoding="utf-8")
+
+            result = validate_application_reports(reports_dir=reports_dir)
+
+        self.assertEqual(result.warning_count, 1)
+        self.assertEqual(result.error_count, 0)
+        self.assertEqual(result.issues[0].message, "manifesto JSON sem Markdown correspondente")
+
+    def test_validate_application_reports_reports_invalid_json(self) -> None:
+        with TemporaryDirectory() as temp_dir:
+            reports_dir = Path(temp_dir)
+            (reports_dir / "application-32.md").write_text("# Relatorio", encoding="utf-8")
+            (reports_dir / "application-32.json").write_text("{invalid", encoding="utf-8")
+
+            result = validate_application_reports(reports_dir=reports_dir)
+
+        self.assertEqual(result.ok_count, 0)
+        self.assertEqual(result.error_count, 1)
+        self.assertIn("manifesto JSON invalido", result.issues[0].message)
+
+    def test_validate_application_reports_reports_missing_required_field(self) -> None:
+        with TemporaryDirectory() as temp_dir:
+            reports_dir = Path(temp_dir)
+            report = reports_dir / "application-32.md"
+            manifest = reports_dir / "application-32.json"
+            report.write_text("# Relatorio", encoding="utf-8")
+            data = _valid_manifest(report, manifest)
+            del data["support"]
+            manifest.write_text(json.dumps(data), encoding="utf-8")
+
+            result = validate_application_reports(reports_dir=reports_dir)
+
+        self.assertEqual(result.ok_count, 0)
+        self.assertEqual(result.error_count, 1)
+        self.assertEqual(result.issues[0].message, "campo obrigatorio ausente: support")
+
+    def test_validate_application_reports_reports_wrong_safety_flag(self) -> None:
+        with TemporaryDirectory() as temp_dir:
+            reports_dir = Path(temp_dir)
+            report = reports_dir / "application-32.md"
+            manifest = reports_dir / "application-32.json"
+            report.write_text("# Relatorio", encoding="utf-8")
+            data = _valid_manifest(report, manifest)
+            data["safety"]["uses_llm"] = True  # type: ignore[index]
+            manifest.write_text(json.dumps(data), encoding="utf-8")
+
+            result = validate_application_reports(reports_dir=reports_dir)
+
+        self.assertEqual(result.ok_count, 0)
+        self.assertEqual(result.error_count, 1)
+        self.assertIn("flag de safety invalida: uses_llm=True", result.issues[0].message)
+
+    def test_validate_application_reports_reports_path_mismatch(self) -> None:
+        with TemporaryDirectory() as temp_dir:
+            reports_dir = Path(temp_dir)
+            report = reports_dir / "application-32.md"
+            manifest = reports_dir / "application-32.json"
+            report.write_text("# Relatorio", encoding="utf-8")
+            data = _valid_manifest(report, manifest)
+            data["report_path"] = "other.md"
+            manifest.write_text(json.dumps(data), encoding="utf-8")
+
+            result = validate_application_reports(reports_dir=reports_dir)
+
+        self.assertEqual(result.ok_count, 0)
+        self.assertEqual(result.error_count, 1)
+        self.assertEqual(result.issues[0].message, "report_path nao aponta para o Markdown validado")
+
+    def test_render_application_reports_validation_includes_summary_and_issues(self) -> None:
+        with TemporaryDirectory() as temp_dir:
+            reports_dir = Path(temp_dir)
+            (reports_dir / "application-32.md").write_text("# Relatorio", encoding="utf-8")
+
+            rendered = render_application_reports_validation(reports_dir=reports_dir, strict=True)
+
+        self.assertIn(f"Validacao de relatorios A-F em {reports_dir}", rendered)
+        self.assertIn("- ok=0", rendered)
+        self.assertIn("- warnings=0", rendered)
+        self.assertIn("- errors=1", rendered)
+        self.assertIn("- strict=true", rendered)
+        self.assertIn("Markdown sem manifesto JSON correspondente", rendered)
+
+    def test_validate_application_reports_warns_for_missing_directory(self) -> None:
+        with TemporaryDirectory() as temp_dir:
+            reports_dir = Path(temp_dir) / "missing"
+
+            result = validate_application_reports(reports_dir=reports_dir)
+
+        self.assertEqual(result.ok_count, 0)
+        self.assertEqual(result.warning_count, 1)
+        self.assertEqual(result.error_count, 0)
+        self.assertEqual(result.issues[0].message, "diretorio de relatorios nao existe")


### PR DESCRIPTION
## Resumo
- adiciona `python main.py applications reports validate`
- suporta `--dir` e `--strict`
- valida pares Markdown/JSON de relatorios A-F
- detecta JSON invalido, campos obrigatorios ausentes e flags de safety incorretas
- trata pares ausentes como warning por padrao e erro em modo strict
- mantem operacao read-only

## Testes
- CI deve rodar `pytest`

Closes #88