### PR TITLE
feat: add local operations report

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,14 @@ python main.py --bootstrap-linkedin-session
 - falhas por portal nao interrompem as demais fontes
 - o runtime informa quando cai no fallback legado de matching
 
+Resumo operacional local read-only:
+
+```bash
+python main.py operations report
+python main.py operations report --days 7
+python main.py operations report --date 2026-05-01
+```
+
 ## Testes
 
 ```bash

--- a/job_hunter_agent/application/app.py
+++ b/job_hunter_agent/application/app.py
@@ -198,6 +198,9 @@ class JobHunterApplication:
     def show_status_overview(self) -> str:
         return self._query_service().show_status_overview()
 
+    def show_operations_report(self, *, days: int | None = None, date: str | None = None) -> str:
+        return self._query_service().show_operations_report(days=days, date=date)
+
     def show_health_report(self) -> str:
         return render_application_health_report(build_application_health_report(self.settings))
 

--- a/job_hunter_agent/application/application_cli.py
+++ b/job_hunter_agent/application/application_cli.py
@@ -48,6 +48,25 @@ def parse_args() -> argparse.Namespace:
     subparsers = parser.add_subparsers(dest="command")
     subparsers.add_parser("status", help="Mostra um resumo operacional de vagas e candidaturas.")
     subparsers.add_parser("health", help="Mostra health checks operacionais locais.")
+
+    operations_parser = subparsers.add_parser("operations", help="Relatorios operacionais locais read-only.")
+    operations_subparsers = operations_parser.add_subparsers(dest="operations_command", required=True)
+    operations_report_parser = operations_subparsers.add_parser(
+        "report",
+        help="Mostra um relatorio resumido por janela operacional.",
+    )
+    operations_report_parser.add_argument(
+        "--days",
+        type=int,
+        default=None,
+        help="Quantidade de dias recentes a considerar. Padrao: 1.",
+    )
+    operations_report_parser.add_argument(
+        "--date",
+        default=None,
+        help="Data inicial da janela no formato YYYY-MM-DD.",
+    )
+
     jobs_parser = subparsers.add_parser("jobs", help="Operacoes de revisao de vagas.")
     jobs_subparsers = jobs_parser.add_subparsers(dest="jobs_command", required=True)
 
@@ -328,6 +347,8 @@ def parse_args() -> argparse.Namespace:
         parser.error("--intervalo-ciclos-segundos nao pode ser negativo")
     if getattr(args, "limit", 1) is not None and getattr(args, "limit", 1) <= 0:
         parser.error("--limit deve ser maior que zero")
+    if getattr(args, "days", None) is not None and getattr(args, "days", 1) <= 0:
+        parser.error("--days deve ser maior que zero")
     if args.agora and args.ciclos is not None:
         parser.error("use --agora ou --ciclos, nao ambos")
     if args.command is not None and (args.agora or args.ciclos is not None):

--- a/job_hunter_agent/application/application_cli_dispatch.py
+++ b/job_hunter_agent/application/application_cli_dispatch.py
@@ -35,6 +35,9 @@ def execute_cli_command(args: Namespace) -> bool:
         app = create_query_app()
         print(app.show_health_report())
         return True
+    if args.command == "operations":
+        _run_operations_command(args)
+        return True
     if args.command == "jobs":
         _run_jobs_command(args)
         return True
@@ -51,6 +54,12 @@ def execute_cli_command(args: Namespace) -> bool:
         _run_worker_command(args)
         return True
     return False
+
+
+def _run_operations_command(args: Namespace) -> None:
+    app = create_query_app()
+    if args.operations_command == "report":
+        print(app.show_operations_report(days=args.days, date=args.date))
 
 
 def _run_jobs_command(args: Namespace) -> None:

--- a/job_hunter_agent/application/application_cli_rendering.py
+++ b/job_hunter_agent/application/application_cli_rendering.py
@@ -103,6 +103,49 @@ def render_status_overview(
     return "\n".join(lines)
 
 
+def render_operations_report(
+    *,
+    since: str,
+    job_summary: dict[str, int],
+    application_summary: dict[str, int],
+    operational_counts: dict[str, int],
+    events: list[object],
+) -> str:
+    lines = [
+        "Relatorio operacional local:",
+        f"janela_desde={since}",
+        "snapshot_atual:",
+        "vagas:",
+        f"- total={job_summary['total']}",
+        f"- collected={job_summary['collected']}",
+        f"- approved={job_summary['approved']}",
+        f"- rejected={job_summary['rejected']}",
+        f"- error_collect={job_summary['error_collect']}",
+        "candidaturas:",
+        f"- total={application_summary['total']}",
+        f"- draft={application_summary['draft']}",
+        f"- ready_for_review={application_summary['ready_for_review']}",
+        f"- confirmed={application_summary['confirmed']}",
+        f"- authorized_submit={application_summary['authorized_submit']}",
+        f"- submitted={application_summary['submitted']}",
+        f"- error_submit={application_summary['error_submit']}",
+        f"- cancelled={application_summary['cancelled']}",
+    ]
+    if operational_counts:
+        lines.append("operacao_atual:")
+        for key in get_runtime_operational_policy().operational_summary_order:
+            if key in operational_counts:
+                lines.append(f"- {key}={operational_counts[key]}")
+    lines.append("resumo_da_janela:")
+    lines.extend(render_execution_summary(events=events).splitlines()[1:])
+    lines.append("eventos_recentes:")
+    if events:
+        lines.extend(_render_event_lines(events[-10:]))
+    else:
+        lines.append("- nenhum")
+    return "\n".join(lines)
+
+
 def render_application_events(*, application_id: int, events: list[object]) -> str:
     if not events:
         return f"Nenhum evento encontrado para candidatura: id={application_id}"

--- a/job_hunter_agent/application/application_queries.py
+++ b/job_hunter_agent/application/application_queries.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 from job_hunter_agent.application.application_cli_rendering import (
@@ -11,6 +12,7 @@ from job_hunter_agent.application.application_cli_rendering import (
     render_failure_artifacts,
     render_job_detail,
     render_job_list,
+    render_operations_report,
     render_status_overview,
     summarize_operational_counts,
 )
@@ -88,6 +90,21 @@ class ApplicationQueryService:
             operational_counts=operational_counts,
         )
 
+    def show_operations_report(self, *, days: int | None = None, date: str | None = None) -> str:
+        since = _resolve_operations_report_since(days=days, date=date)
+        job_summary = self.repository.summary()
+        application_summary = self.repository.application_summary()
+        tracked_applications = self._list_tracked_applications()
+        operational_counts = summarize_operational_counts(applications=tracked_applications)
+        events = self._list_recent_application_events_since(since)
+        return render_operations_report(
+            since=since,
+            job_summary=job_summary,
+            application_summary=application_summary,
+            operational_counts=operational_counts,
+            events=events,
+        )
+
     def show_application_events(self, application_id: int, *, limit: int = 10) -> str:
         application = self.repository.get_application(application_id)
         if application is None:
@@ -156,11 +173,14 @@ class ApplicationQueryService:
         )
 
     def build_execution_summary(self, since: str) -> str:
+        events = self._list_recent_application_events_since(since)
+        return render_execution_summary(events=events)
+
+    def _list_recent_application_events_since(self, since: str) -> list[object]:
         list_events_since = getattr(self.repository, "list_recent_application_events_since", None)
         if list_events_since is None:
-            return "Execucao operacional:\n- preflights_concluidos=0\n- submits_concluidos=0\n- bloqueios_por_tipo=nenhum"
-        events = list_events_since(since)
-        return render_execution_summary(events=events)
+            return []
+        return list_events_since(since)
 
     def _list_tracked_applications(self) -> list[object]:
         list_tracked = getattr(self.repository, "list_tracked_applications_with_jobs", None)
@@ -171,3 +191,14 @@ class ApplicationQueryService:
         for status in tracked_statuses:
             applications.extend(self.repository.list_applications_by_status(status))
         return applications
+
+
+def _resolve_operations_report_since(*, days: int | None, date: str | None) -> str:
+    if date:
+        try:
+            parsed = datetime.strptime(date, "%Y-%m-%d").replace(tzinfo=timezone.utc)
+        except ValueError:
+            return date
+        return parsed.isoformat(timespec="seconds")
+    window_days = days or 1
+    return (datetime.now(timezone.utc) - timedelta(days=window_days)).isoformat(timespec="seconds")

--- a/tests/test_application_cli_dispatch.py
+++ b/tests/test_application_cli_dispatch.py
@@ -32,6 +32,34 @@ class ApplicationCliDispatchTests(TestCase):
         app_factory.assert_called_once_with()
         print_mock.assert_called_once_with("resumo")
 
+    def test_execute_cli_command_dispatches_operations_report(self) -> None:
+        fake_app = type(
+            "FakeApp",
+            (),
+            {
+                "show_operations_report": lambda self, days=None, date=None: f"operations={days}|date={date}",
+            },
+        )()
+
+        args = Namespace(
+            bootstrap_linkedin_session=False,
+            command="operations",
+            operations_command="report",
+            days=7,
+            date="2026-05-01",
+            sem_telegram=True,
+        )
+
+        with patch(
+            "job_hunter_agent.application.application_cli_dispatch.create_query_app",
+            return_value=fake_app,
+        ) as app_factory, patch("builtins.print") as print_mock:
+            handled = execute_cli_command(args)
+
+        self.assertTrue(handled)
+        app_factory.assert_called_once_with()
+        print_mock.assert_called_once_with("operations=7|date=2026-05-01")
+
     def test_execute_cli_command_dispatches_application_list_alias(self) -> None:
         fake_app = type(
             "FakeApp",

--- a/tests/test_application_cli_rendering.py
+++ b/tests/test_application_cli_rendering.py
@@ -9,6 +9,7 @@ from job_hunter_agent.application.application_cli_rendering import (
     render_failure_artifacts,
     render_job_detail,
     render_job_list,
+    render_operations_report,
     render_status_overview,
     summarize_operational_counts,
 )
@@ -115,6 +116,42 @@ class ApplicationCliRenderingTests(unittest.TestCase):
         self.assertIn("Resumo operacional:", rendered)
         self.assertIn("- approved=1", rendered)
         self.assertIn("- similar_jobs=1", rendered)
+
+    def test_render_operations_report_combines_snapshot_and_window(self) -> None:
+        events = [
+            JobApplicationEvent(
+                id=1,
+                application_id=3,
+                event_type="preflight_blocked",
+                detail="readiness=no_apply_cta | motivo=a vaga so oferece candidatura externa no site da empresa",
+                created_at="2026-05-01T10:00:00",
+            )
+        ]
+
+        rendered = render_operations_report(
+            since="2026-05-01T00:00:00+00:00",
+            job_summary={"total": 2, "collected": 1, "approved": 1, "rejected": 0, "error_collect": 0},
+            application_summary={
+                "total": 1,
+                "draft": 0,
+                "ready_for_review": 0,
+                "confirmed": 1,
+                "authorized_submit": 0,
+                "submitted": 0,
+                "error_submit": 0,
+                "cancelled": 0,
+            },
+            operational_counts={"candidatura_externa": 1},
+            events=events,
+        )
+
+        self.assertIn("Relatorio operacional local:", rendered)
+        self.assertIn("janela_desde=2026-05-01T00:00:00+00:00", rendered)
+        self.assertIn("snapshot_atual:", rendered)
+        self.assertIn("resumo_da_janela:", rendered)
+        self.assertIn("candidatura_externa=1", rendered)
+        self.assertIn("eventos_recentes:", rendered)
+        self.assertIn("preflight_blocked", rendered)
 
     def test_render_application_events_handles_empty(self) -> None:
         rendered = render_application_events(application_id=2, events=[])


### PR DESCRIPTION
## Summary

- Add `python main.py operations report` as a read-only operational summary command.
- Support `--days` and `--date` windows for recent application events.
- Reuse existing SQLite summaries and application event summaries for snapshot + window reporting.
- Document the command in README.
- Add dispatch and renderer coverage.

Closes #92.

## Testing

- CI should run `pytest`.
- Docker workflow should validate compose/image/worker command.