### PR TITLE
feat: add operations next actions command

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,12 @@ python main.py operations report --days 7
 python main.py operations report --date 2026-05-01
 ```
 
+Proximas acoes operacionais sugeridas, sem executar nenhuma acao:
+
+```bash
+python main.py operations next-actions
+```
+
 Guia detalhado: `docs/OPERATIONS_REPORT.md`.
 
 ## Testes

--- a/job_hunter_agent/application/application_cli.py
+++ b/job_hunter_agent/application/application_cli.py
@@ -66,6 +66,10 @@ def parse_args() -> argparse.Namespace:
         default=None,
         help="Data inicial da janela no formato YYYY-MM-DD.",
     )
+    operations_subparsers.add_parser(
+        "next-actions",
+        help="Lista proximas acoes operacionais sugeridas sem executar nenhuma acao.",
+    )
 
     jobs_parser = subparsers.add_parser("jobs", help="Operacoes de revisao de vagas.")
     jobs_subparsers = jobs_parser.add_subparsers(dest="jobs_command", required=True)

--- a/job_hunter_agent/application/application_cli_dispatch.py
+++ b/job_hunter_agent/application/application_cli_dispatch.py
@@ -15,6 +15,10 @@ from job_hunter_agent.application.collection_operations_report import (
 from job_hunter_agent.application.collector_worker import run_collector_worker_once
 from job_hunter_agent.application.domain_events_cli import render_domain_events
 from job_hunter_agent.application.matching_worker import run_matching_worker_once
+from job_hunter_agent.application.operations_next_actions import (
+    build_operations_next_actions_from_repository,
+    render_operations_next_actions,
+)
 from job_hunter_agent.application.worker_catalog import render_worker_catalog
 from job_hunter_agent.application.cli_bootstrap import (
     create_application_flow_app,
@@ -70,6 +74,13 @@ def _run_operations_command(args: Namespace) -> None:
             collection_report = build_collection_operations_report(repository, since=since)
             report = "\n".join([report, render_collection_operations_report(collection_report)])
         print(report)
+        return
+    if args.operations_command == "next-actions":
+        repository = getattr(app, "repository", None)
+        if repository is None:
+            print("Nenhuma proxima acao operacional encontrada.")
+            return
+        print(render_operations_next_actions(build_operations_next_actions_from_repository(repository)))
 
 
 def _extract_report_since(report: str) -> str:

--- a/job_hunter_agent/application/operations_next_actions.py
+++ b/job_hunter_agent/application/operations_next_actions.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable
+
+from job_hunter_agent.core.application_insights import classify_application_operational_insight
+
+
+STATUS_PRIORITY = {
+    "error_submit": 10,
+    "authorized_submit": 20,
+    "confirmed": 30,
+    "ready_for_review": 40,
+    "draft": 50,
+}
+
+
+@dataclass(frozen=True)
+class OperationNextAction:
+    priority: int
+    application_id: int
+    job_id: int
+    status: str
+    title: str
+    company: str
+    reason_code: str
+    command: str
+    note: str
+
+
+def build_operations_next_actions(applications_with_jobs: Iterable[tuple[object, object | None]]) -> list[OperationNextAction]:
+    actions: list[OperationNextAction] = []
+    for application, job in applications_with_jobs:
+        status = str(getattr(application, "status", ""))
+        if status not in STATUS_PRIORITY:
+            continue
+        application_id = int(getattr(application, "id"))
+        job_id = int(getattr(application, "job_id"))
+        insight = classify_application_operational_insight(application)
+        actions.append(
+            OperationNextAction(
+                priority=STATUS_PRIORITY[status],
+                application_id=application_id,
+                job_id=job_id,
+                status=status,
+                title=str(getattr(job, "title", "vaga nao encontrada") if job is not None else "vaga nao encontrada"),
+                company=str(getattr(job, "company", "-") if job is not None else "-"),
+                reason_code=insight.reason_code,
+                command=_recommended_command(application_id=application_id, status=status),
+                note=_recommended_note(status=status, reason_code=insight.reason_code),
+            )
+        )
+    return sorted(actions, key=lambda action: (action.priority, action.application_id))
+
+
+def render_operations_next_actions(actions: list[OperationNextAction]) -> str:
+    if not actions:
+        return "Nenhuma proxima acao operacional encontrada."
+    lines = [f"Proximas acoes operacionais: {len(actions)}"]
+    for action in actions:
+        lines.extend(
+            [
+                f"- application_id={action.application_id} | job_id={action.job_id} | status={action.status}",
+                f"  vaga={action.title} | empresa={action.company}",
+                f"  motivo={action.reason_code}",
+                f"  acao={action.note}",
+                f"  comando={action.command}",
+            ]
+        )
+    return "\n".join(lines)
+
+
+def _recommended_command(*, application_id: int, status: str) -> str:
+    if status == "error_submit":
+        return f"python main.py applications diagnose --id {application_id}"
+    if status == "authorized_submit":
+        return f"python main.py applications submit --id {application_id} --dry-run"
+    if status == "confirmed":
+        return f"python main.py applications preflight --id {application_id} --dry-run"
+    if status == "ready_for_review":
+        return f"python main.py applications confirm --id {application_id}"
+    if status == "draft":
+        return f"python main.py applications prepare --id {application_id}"
+    return f"python main.py applications diagnose --id {application_id}"
+
+
+def _recommended_note(*, status: str, reason_code: str) -> str:
+    if status == "error_submit":
+        return "investigar erro antes de nova tentativa"
+    if status == "authorized_submit":
+        return "validar dry-run antes de submit real"
+    if status == "confirmed":
+        if reason_code == "pronto_para_envio":
+            return "avaliar autorizacao humana explicita apos preflight"
+        return "rodar preflight em dry-run antes de qualquer acao"
+    if status == "ready_for_review":
+        return "revisar manualmente antes de confirmar"
+    if status == "draft":
+        return "preparar candidatura para revisao humana"
+    return "revisar manualmente"

--- a/job_hunter_agent/application/operations_next_actions.py
+++ b/job_hunter_agent/application/operations_next_actions.py
@@ -14,6 +14,8 @@ STATUS_PRIORITY = {
     "draft": 50,
 }
 
+TRACKED_STATUSES = tuple(STATUS_PRIORITY)
+
 
 @dataclass(frozen=True)
 class OperationNextAction:
@@ -26,6 +28,18 @@ class OperationNextAction:
     reason_code: str
     command: str
     note: str
+
+
+def build_operations_next_actions_from_repository(repository: object) -> list[OperationNextAction]:
+    list_with_jobs = getattr(repository, "list_applications_with_jobs_by_status", None)
+    applications_with_jobs: list[tuple[object, object | None]] = []
+    for status in TRACKED_STATUSES:
+        if list_with_jobs is not None:
+            applications_with_jobs.extend(list_with_jobs(status))
+            continue
+        for application in repository.list_applications_by_status(status):
+            applications_with_jobs.append((application, repository.get_job(application.job_id)))
+    return build_operations_next_actions(applications_with_jobs)
 
 
 def build_operations_next_actions(applications_with_jobs: Iterable[tuple[object, object | None]]) -> list[OperationNextAction]:

--- a/tests/test_application_cli_dispatch.py
+++ b/tests/test_application_cli_dispatch.py
@@ -60,6 +60,37 @@ class ApplicationCliDispatchTests(TestCase):
         app_factory.assert_called_once_with()
         print_mock.assert_called_once_with("operations=7|date=2026-05-01")
 
+    def test_execute_cli_command_dispatches_operations_next_actions(self) -> None:
+        fake_repository = object()
+        fake_app = type(
+            "FakeApp",
+            (),
+            {
+                "repository": fake_repository,
+            },
+        )()
+
+        args = Namespace(
+            bootstrap_linkedin_session=False,
+            command="operations",
+            operations_command="next-actions",
+            sem_telegram=True,
+        )
+
+        with patch(
+            "job_hunter_agent.application.application_cli_dispatch.create_query_app",
+            return_value=fake_app,
+        ) as app_factory, patch(
+            "job_hunter_agent.application.application_cli_dispatch.build_operations_next_actions_from_repository",
+            return_value=[],
+        ) as build_actions, patch("builtins.print") as print_mock:
+            handled = execute_cli_command(args)
+
+        self.assertTrue(handled)
+        app_factory.assert_called_once_with()
+        build_actions.assert_called_once_with(fake_repository)
+        print_mock.assert_called_once_with("Nenhuma proxima acao operacional encontrada.")
+
     def test_execute_cli_command_dispatches_application_list_alias(self) -> None:
         fake_app = type(
             "FakeApp",

--- a/tests/test_operations_next_actions.py
+++ b/tests/test_operations_next_actions.py
@@ -1,0 +1,76 @@
+import unittest
+
+from job_hunter_agent.application.operations_next_actions import (
+    build_operations_next_actions,
+    render_operations_next_actions,
+)
+from job_hunter_agent.core.domain import JobApplication, JobPosting
+
+
+def _job(job_id: int, title: str = "Backend Java") -> JobPosting:
+    return JobPosting(
+        id=job_id,
+        title=title,
+        company="ACME",
+        location="Brasil",
+        work_mode="remoto",
+        salary_text="Nao informado",
+        url=f"https://example.com/{job_id}",
+        source_site="LinkedIn",
+        summary="Resumo",
+        relevance=8,
+        rationale="Boa aderencia",
+        external_key=f"key-{job_id}",
+        status="approved",
+    )
+
+
+class OperationsNextActionsTests(unittest.TestCase):
+    def test_build_operations_next_actions_orders_by_conservative_priority(self) -> None:
+        actions = build_operations_next_actions(
+            [
+                (JobApplication(id=5, job_id=50, status="draft", support_level="manual_review"), _job(50)),
+                (JobApplication(id=2, job_id=20, status="authorized_submit", support_level="manual_review"), _job(20)),
+                (JobApplication(id=1, job_id=10, status="error_submit", support_level="manual_review"), _job(10)),
+                (JobApplication(id=3, job_id=30, status="confirmed", support_level="manual_review"), _job(30)),
+                (JobApplication(id=4, job_id=40, status="ready_for_review", support_level="manual_review"), _job(40)),
+                (JobApplication(id=6, job_id=60, status="submitted", support_level="manual_review"), _job(60)),
+            ]
+        )
+
+        self.assertEqual([action.application_id for action in actions], [1, 2, 3, 4, 5])
+        self.assertEqual(actions[0].command, "python main.py applications diagnose --id 1")
+        self.assertEqual(actions[1].command, "python main.py applications submit --id 2 --dry-run")
+        self.assertEqual(actions[2].command, "python main.py applications preflight --id 3 --dry-run")
+        self.assertEqual(actions[3].command, "python main.py applications confirm --id 4")
+        self.assertEqual(actions[4].command, "python main.py applications prepare --id 5")
+
+    def test_render_operations_next_actions_handles_empty_list(self) -> None:
+        self.assertEqual(
+            render_operations_next_actions([]),
+            "Nenhuma proxima acao operacional encontrada.",
+        )
+
+    def test_render_operations_next_actions_includes_reason_and_command(self) -> None:
+        actions = build_operations_next_actions(
+            [
+                (
+                    JobApplication(
+                        id=7,
+                        job_id=70,
+                        status="confirmed",
+                        support_level="manual_review",
+                        last_preflight_detail="preflight real | pronto_para_envio=sim | ok",
+                    ),
+                    _job(70, title="Data Engineer"),
+                )
+            ]
+        )
+
+        rendered = render_operations_next_actions(actions)
+
+        self.assertIn("Proximas acoes operacionais: 1", rendered)
+        self.assertIn("application_id=7", rendered)
+        self.assertIn("vaga=Data Engineer", rendered)
+        self.assertIn("motivo=pronto_para_envio", rendered)
+        self.assertIn("python main.py applications preflight --id 7 --dry-run", rendered)


### PR DESCRIPTION
## Summary

- Add `python main.py operations next-actions` as a read-only local command.
- Suggest conservative next commands for operational application states without executing them.
- Prioritize `error_submit`, `authorized_submit`, `confirmed`, `ready_for_review`, and `draft` deterministically.
- Add focused helper and dispatch tests.
- Reference the command from README.

Closes #98.

## Testing

- CI should run `pytest`.
- Docker workflow should validate compose/image/worker command.