### PR TITLE
docs: document operations next actions

### DIFF
--- a/docs/OPERATIONS_REPORT.md
+++ b/docs/OPERATIONS_REPORT.md
@@ -13,11 +13,13 @@ Use este relatorio para entender rapidamente:
 - logs de coleta por fonte e nivel;
 - warnings e erros recentes de coleta.
 
+O comando `python main.py operations next-actions` complementa o relatorio com uma lista curta de proximas acoes sugeridas, tambem read-only.
+
 ## Principios De Seguranca
 
-O relatorio operacional e somente leitura.
+Os comandos operacionais descritos neste guia sao somente leitura.
 
-Ele nao deve:
+Eles nao devem:
 
 - alterar status de vagas;
 - alterar status de candidaturas;
@@ -29,7 +31,7 @@ Ele nao deve:
 - autorizar candidatura;
 - substituir revisao humana.
 
-Ele existe para observabilidade local e auditoria leve.
+Eles existem para observabilidade local, auditoria leve e apoio a decisao humana.
 
 ## Comandos
 
@@ -67,7 +69,17 @@ Use `--date YYYY-MM-DD` para iniciar a janela em uma data especifica.
 
 A data informada e interpretada como inicio do dia em UTC.
 
-## Estrutura Da Saida
+### Proximas Acoes Operacionais
+
+```bash
+python main.py operations next-actions
+```
+
+Use este comando quando quiser uma lista curta de candidaturas que podem exigir atencao humana ou proxima acao operacional.
+
+O comando apenas sugere comandos conservadores. Ele nao executa nenhum dos comandos sugeridos.
+
+## Estrutura Da Saida Do `operations report`
 
 A saida e textual, pensada para terminal e logs locais.
 
@@ -189,6 +201,55 @@ Lista warnings e erros recentes de coleta dentro da janela.
 
 Use essa secao para identificar rapidamente falhas de portal, problemas de navegacao ou coleta parcial.
 
+## Estrutura Da Saida Do `operations next-actions`
+
+A saida e textual e ordenada por prioridade conservadora.
+
+Quando houver itens, a primeira linha informa a quantidade total:
+
+```text
+Proximas acoes operacionais: 3
+```
+
+Cada item mostra:
+
+- `application_id`;
+- `job_id`;
+- `status` atual;
+- titulo da vaga;
+- empresa;
+- motivo operacional resumido;
+- acao sugerida;
+- comando recomendado.
+
+Exemplo ilustrativo:
+
+```text
+- application_id=42 | job_id=101 | status=confirmed
+  vaga=Backend Java | empresa=ACME
+  motivo=pronto_para_envio
+  acao=avaliar autorizacao humana explicita apos preflight
+  comando=python main.py applications preflight --id 42 --dry-run
+```
+
+Se nao houver candidaturas em estados acompanhados, o comando retorna:
+
+```text
+Nenhuma proxima acao operacional encontrada.
+```
+
+## Ordem De Prioridade Do `next-actions`
+
+A ordem e deterministica e conservadora:
+
+1. `error_submit`: investigar erro antes de nova tentativa;
+2. `authorized_submit`: validar dry-run antes de submit real;
+3. `confirmed`: rodar preflight em dry-run antes de qualquer acao;
+4. `ready_for_review`: revisar manualmente antes de confirmar;
+5. `draft`: preparar candidatura para revisao humana.
+
+Candidaturas ja `submitted` ou `cancelled` nao aparecem como proximas acoes.
+
 ## Interpretacao Operacional
 
 ### Quando `jobs_seen` E Alto Mas `jobs_saved` E Baixo
@@ -225,6 +286,12 @@ python main.py applications diagnose --id <application_id>
 
 O relatorio operacional mostra o agregado. O diagnostico por candidatura explica o caso individual.
 
+### Quando `next-actions` Sugere Um Comando
+
+Leia a sugestao como uma proxima verificacao, nao como autorizacao automatica.
+
+Por exemplo, uma sugestao de `submit --dry-run` nao significa que o submit real deve ser executado. Ela apenas indica que a candidatura esta em um estado onde uma validacao controlada pode ser o proximo passo.
+
 ## Relacao Com Outros Comandos
 
 ### `status`
@@ -247,13 +314,23 @@ Mostra checks locais de configuracao e ambiente.
 
 Use `health` para sanidade operacional e `operations report` para historico recente.
 
+### `operations next-actions`
+
+```bash
+python main.py operations next-actions
+```
+
+Mostra a fila operacional sugerida no momento atual.
+
+Use depois de `operations report` quando quiser transformar o diagnostico agregado em uma lista curta de candidaturas para revisar.
+
 ### `applications diagnose`
 
 ```bash
 python main.py applications diagnose --id <application_id>
 ```
 
-Use para aprofundar uma candidatura especifica que apareceu no relatorio operacional.
+Use para aprofundar uma candidatura especifica que apareceu no relatorio operacional ou no `next-actions`.
 
 ### `applications report`
 
@@ -263,7 +340,7 @@ python main.py applications report --id <application_id>
 
 Gera relatorio A-F por candidatura.
 
-Use `operations report` para visao agregada e `applications report` para uma candidatura individual.
+Use `operations report` para visao agregada, `operations next-actions` para priorizacao operacional e `applications report` para uma candidatura individual.
 
 ## Limites Conhecidos
 
@@ -271,7 +348,9 @@ Use `operations report` para visao agregada e `applications report` para uma can
 - Se nao houver `collection_runs` ou `collection_logs`, a secao de coleta pode aparecer vazia ou zerada.
 - O snapshot atual representa o estado no momento da execucao, nao necessariamente apenas a janela.
 - O resumo da janela depende de timestamps gravados nos eventos.
-- O comando nao corrige dados inconsistentes; ele apenas os mostra.
+- O `next-actions` depende dos status atuais persistidos das candidaturas.
+- O `next-actions` nao executa os comandos recomendados.
+- Os comandos nao corrigem dados inconsistentes; eles apenas os mostram.
 
 ## Fluxo Recomendado
 
@@ -279,12 +358,14 @@ Para uma revisao diaria simples:
 
 ```bash
 python main.py operations report
+python main.py operations next-actions
 ```
 
 Para uma revisao semanal:
 
 ```bash
 python main.py operations report --days 7
+python main.py operations next-actions
 ```
 
 Quando houver erro ou bloqueio relevante:
@@ -312,4 +393,5 @@ Antes de tratar o relatorio como suficiente para uma revisao local, deve ser pos
 - quantas vagas foram vistas e salvas;
 - quais fontes geraram logs;
 - se houve warnings ou erros recentes de coleta;
-- qual candidatura precisa de diagnostico individual.
+- qual candidatura precisa de diagnostico individual;
+- qual proxima acao sugerida deve ser revisada primeiro.


### PR DESCRIPTION
## Summary

- Document `python main.py operations next-actions` in `docs/OPERATIONS_REPORT.md`.
- Explain the conservative priority order and read-only safety boundaries.
- Clarify how `next-actions` relates to `operations report` and `applications diagnose`.

Closes #100.

## Testing

- Documentation-only change; CI and Docker should still run.