### PR TITLE
feat: enrich failure artifact listing

### DIFF
--- a/job_hunter_agent/application/application_cli_rendering.py
+++ b/job_hunter_agent/application/application_cli_rendering.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
+import json
 from datetime import datetime
 from pathlib import Path
+from typing import Any
 
 from job_hunter_agent.core.application_insights import (
     classify_application_operational_insight,
@@ -246,7 +248,7 @@ def render_failure_artifacts(*, artifacts_dir: Path, files: list[Path], limit: i
     lines = [f"Artefatos recentes: {min(len(files), limit)}"]
     for path in files[:limit]:
         timestamp = datetime.fromtimestamp(path.stat().st_mtime).isoformat(timespec="seconds")
-        lines.append(f"{timestamp} | {path.name}")
+        lines.append(_render_failure_artifact_line(path=path, timestamp=timestamp))
     return "\n".join(lines)
 
 
@@ -336,6 +338,38 @@ def _render_event_lines(events: list[object]) -> list[str]:
         f"{event.detail or '-'}"
         for event in events
     ]
+
+
+def _render_failure_artifact_line(*, path: Path, timestamp: str) -> str:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+        return f"{timestamp} | {path.name} | metadata=invalido"
+    if not isinstance(payload, dict):
+        return f"{timestamp} | {path.name} | metadata=invalido"
+    metadata = _extract_failure_artifact_metadata(payload)
+    if not metadata:
+        return f"{timestamp} | {path.name}"
+    return f"{timestamp} | {path.name} | {' | '.join(metadata)}"
+
+
+def _extract_failure_artifact_metadata(payload: dict[str, Any]) -> list[str]:
+    fields = {
+        "application_id": _first_present(payload, "application_id", "applicationId"),
+        "job_id": _first_present(payload, "job_id", "jobId"),
+        "portal": _first_present(payload, "portal", "source", "source_site"),
+        "reason": _first_present(payload, "reason", "reason_code", "readiness"),
+        "url": _first_present(payload, "url", "page_url", "current_url"),
+    }
+    return [f"{key}={value}" for key, value in fields.items() if value not in {None, ""}]
+
+
+def _first_present(payload: dict[str, Any], *keys: str) -> object | None:
+    for key in keys:
+        value = payload.get(key)
+        if value not in {None, ""}:
+            return value
+    return None
 
 
 def _render_domain_event_lines(events: tuple[DomainEvent, ...]) -> list[str]:

--- a/tests/test_application_cli_rendering.py
+++ b/tests/test_application_cli_rendering.py
@@ -14,6 +14,7 @@ from job_hunter_agent.application.application_cli_rendering import (
     summarize_operational_counts,
 )
 from job_hunter_agent.core.domain import JobApplication, JobApplicationEvent, JobPosting
+from tests.tmp_workspace import prepare_workspace_tmp_dir
 
 
 def _sample_job(*, job_id: int, status: str) -> JobPosting:
@@ -187,6 +188,35 @@ class ApplicationCliRenderingTests(unittest.TestCase):
         )
 
         self.assertEqual(rendered, "Nenhum diretorio de artefatos encontrado: diretorio-inexistente")
+
+    def test_render_failure_artifacts_includes_metadata_when_available(self) -> None:
+        temp_dir = prepare_workspace_tmp_dir("failure-artifacts-valid")
+        artifact = temp_dir / "20260501_meta.json"
+        artifact.write_text(
+            '{"application_id": 42, "job_id": 101, "portal": "LinkedIn", "reason_code": "no_apply_cta", "page_url": "https://example.com/job"}',
+            encoding="utf-8",
+        )
+
+        rendered = render_failure_artifacts(artifacts_dir=temp_dir, files=[artifact], limit=5)
+
+        self.assertIn("Artefatos recentes: 1", rendered)
+        self.assertIn("20260501_meta.json", rendered)
+        self.assertIn("application_id=42", rendered)
+        self.assertIn("job_id=101", rendered)
+        self.assertIn("portal=LinkedIn", rendered)
+        self.assertIn("reason=no_apply_cta", rendered)
+        self.assertIn("url=https://example.com/job", rendered)
+
+    def test_render_failure_artifacts_tolerates_invalid_json(self) -> None:
+        temp_dir = prepare_workspace_tmp_dir("failure-artifacts-invalid")
+        artifact = temp_dir / "broken_meta.json"
+        artifact.write_text("{invalid", encoding="utf-8")
+
+        rendered = render_failure_artifacts(artifacts_dir=temp_dir, files=[artifact], limit=5)
+
+        self.assertIn("Artefatos recentes: 1", rendered)
+        self.assertIn("broken_meta.json", rendered)
+        self.assertIn("metadata=invalido", rendered)
 
     def test_render_execution_summary_groups_block_types(self) -> None:
         events = [


### PR DESCRIPTION
## Summary

- Enrich `python main.py applications artifacts --limit N` output with metadata from valid `_meta.json` files.
- Render application/job ids, portal/source, reason and URL when available.
- Tolerate invalid JSON without breaking the whole listing.
- Keep fallback behavior for missing directories, empty directories and sparse metadata.
- Add renderer tests for valid and invalid metadata files.

Closes #102.

## Testing

- CI should run `pytest`.
- Docker workflow should validate compose/image/worker command.