### PR TITLE
feat: add limit to operations next actions

### DIFF
--- a/docs/OPERATIONS_REPORT.md
+++ b/docs/OPERATIONS_REPORT.md
@@ -73,9 +73,12 @@ A data informada e interpretada como inicio do dia em UTC.
 
 ```bash
 python main.py operations next-actions
+python main.py operations next-actions --limit 10
 ```
 
 Use este comando quando quiser uma lista curta de candidaturas que podem exigir atencao humana ou proxima acao operacional.
+
+Sem `--limit`, o comando exibe ate 20 proximas acoes. Use `--limit N` para reduzir ou ampliar a quantidade maxima exibida.
 
 O comando apenas sugere comandos conservadores. Ele nao executa nenhum dos comandos sugeridos.
 
@@ -205,7 +208,7 @@ Use essa secao para identificar rapidamente falhas de portal, problemas de naveg
 
 A saida e textual e ordenada por prioridade conservadora.
 
-Quando houver itens, a primeira linha informa a quantidade total:
+Quando houver itens, a primeira linha informa a quantidade total exibida:
 
 ```text
 Proximas acoes operacionais: 3
@@ -249,6 +252,8 @@ A ordem e deterministica e conservadora:
 5. `draft`: preparar candidatura para revisao humana.
 
 Candidaturas ja `submitted` ou `cancelled` nao aparecem como proximas acoes.
+
+O limite de saida e aplicado depois dessa ordenacao. Assim, `--limit 5` mostra os cinco itens mais prioritarios no momento da execucao.
 
 ## Interpretacao Operacional
 
@@ -318,6 +323,7 @@ Use `health` para sanidade operacional e `operations report` para historico rece
 
 ```bash
 python main.py operations next-actions
+python main.py operations next-actions --limit 10
 ```
 
 Mostra a fila operacional sugerida no momento atual.
@@ -350,6 +356,7 @@ Use `operations report` para visao agregada, `operations next-actions` para prio
 - O resumo da janela depende de timestamps gravados nos eventos.
 - O `next-actions` depende dos status atuais persistidos das candidaturas.
 - O `next-actions` nao executa os comandos recomendados.
+- O limite do `next-actions` corta a lista depois da ordenacao por prioridade.
 - Os comandos nao corrigem dados inconsistentes; eles apenas os mostram.
 
 ## Fluxo Recomendado
@@ -358,14 +365,14 @@ Para uma revisao diaria simples:
 
 ```bash
 python main.py operations report
-python main.py operations next-actions
+python main.py operations next-actions --limit 10
 ```
 
 Para uma revisao semanal:
 
 ```bash
 python main.py operations report --days 7
-python main.py operations next-actions
+python main.py operations next-actions --limit 20
 ```
 
 Quando houver erro ou bloqueio relevante:

--- a/job_hunter_agent/application/application_cli.py
+++ b/job_hunter_agent/application/application_cli.py
@@ -66,9 +66,15 @@ def parse_args() -> argparse.Namespace:
         default=None,
         help="Data inicial da janela no formato YYYY-MM-DD.",
     )
-    operations_subparsers.add_parser(
+    operations_next_actions_parser = operations_subparsers.add_parser(
         "next-actions",
         help="Lista proximas acoes operacionais sugeridas sem executar nenhuma acao.",
+    )
+    operations_next_actions_parser.add_argument(
+        "--limit",
+        type=int,
+        default=20,
+        help="Quantidade maxima de proximas acoes exibidas.",
     )
 
     jobs_parser = subparsers.add_parser("jobs", help="Operacoes de revisao de vagas.")

--- a/job_hunter_agent/application/application_cli_dispatch.py
+++ b/job_hunter_agent/application/application_cli_dispatch.py
@@ -80,7 +80,8 @@ def _run_operations_command(args: Namespace) -> None:
         if repository is None:
             print("Nenhuma proxima acao operacional encontrada.")
             return
-        print(render_operations_next_actions(build_operations_next_actions_from_repository(repository)))
+        actions = build_operations_next_actions_from_repository(repository)
+        print(render_operations_next_actions(actions[: args.limit]))
 
 
 def _extract_report_since(report: str) -> str:

--- a/tests/test_application_cli_dispatch.py
+++ b/tests/test_application_cli_dispatch.py
@@ -60,7 +60,7 @@ class ApplicationCliDispatchTests(TestCase):
         app_factory.assert_called_once_with()
         print_mock.assert_called_once_with("operations=7|date=2026-05-01")
 
-    def test_execute_cli_command_dispatches_operations_next_actions(self) -> None:
+    def test_execute_cli_command_dispatches_operations_next_actions_with_limit(self) -> None:
         fake_repository = object()
         fake_app = type(
             "FakeApp",
@@ -69,11 +69,13 @@ class ApplicationCliDispatchTests(TestCase):
                 "repository": fake_repository,
             },
         )()
+        actions = ["a1", "a2", "a3"]
 
         args = Namespace(
             bootstrap_linkedin_session=False,
             command="operations",
             operations_command="next-actions",
+            limit=2,
             sem_telegram=True,
         )
 
@@ -82,14 +84,18 @@ class ApplicationCliDispatchTests(TestCase):
             return_value=fake_app,
         ) as app_factory, patch(
             "job_hunter_agent.application.application_cli_dispatch.build_operations_next_actions_from_repository",
-            return_value=[],
-        ) as build_actions, patch("builtins.print") as print_mock:
+            return_value=actions,
+        ) as build_actions, patch(
+            "job_hunter_agent.application.application_cli_dispatch.render_operations_next_actions",
+            return_value="rendered",
+        ) as render_actions, patch("builtins.print") as print_mock:
             handled = execute_cli_command(args)
 
         self.assertTrue(handled)
         app_factory.assert_called_once_with()
         build_actions.assert_called_once_with(fake_repository)
-        print_mock.assert_called_once_with("Nenhuma proxima acao operacional encontrada.")
+        render_actions.assert_called_once_with(actions[:2])
+        print_mock.assert_called_once_with("rendered")
 
     def test_execute_cli_command_dispatches_application_list_alias(self) -> None:
         fake_app = type(


### PR DESCRIPTION
## Summary

- Add `--limit` to `python main.py operations next-actions`.
- Default the command to 20 displayed actions.
- Apply the limit after deterministic priority ordering.
- Update dispatch test coverage and operations report documentation.

Closes #106.

## Testing

- CI should run `pytest`.
- Docker workflow should validate compose/image/worker command.