### PR TITLE
feat: add application operational history tables

### DIFF
--- a/job_hunter_agent/core/job_identity.py
+++ b/job_hunter_agent/core/job_identity.py
@@ -100,12 +100,14 @@ class PortalAwareJobIdentityStrategy:
 
     def url_lookup_patterns(self, url: str) -> list[str]:
         normalized_url = normalize_job_url(url)
+        linkedin_job_id = self._extract_linkedin_job_id(url) or self._extract_linkedin_job_id(normalized_url)
+
         patterns = []
-        for pattern in (url, normalized_url):
+        for pattern in (
+            url,
+            f"%/jobs/view/{linkedin_job_id}%" if linkedin_job_id else "",
+            normalized_url,
+        ):
             if pattern and pattern not in patterns:
                 patterns.append(pattern)
-
-        linkedin_job_id = self._extract_linkedin_job_id(url) or self._extract_linkedin_job_id(normalized_url)
-        if linkedin_job_id:
-            patterns.append(f"%/jobs/view/{linkedin_job_id}%")
         return patterns

--- a/job_hunter_agent/infrastructure/application_history.py
+++ b/job_hunter_agent/infrastructure/application_history.py
@@ -73,7 +73,10 @@ def record_application_event(
     )
 
 
-def list_application_events(connection: sqlite3.Connection, application_id: int) -> list[ApplicationEventRecord]:
+def list_application_events(
+    connection: sqlite3.Connection,
+    application_id: int,
+) -> list[ApplicationEventRecord]:
     rows = connection.execute(
         """
         SELECT id, application_id, event_type, occurred_at_utc, payload
@@ -131,7 +134,10 @@ def record_application_artifact(
     )
 
 
-def list_application_artifacts(connection: sqlite3.Connection, application_id: int) -> list[ApplicationArtifactRecord]:
+def list_application_artifacts(
+    connection: sqlite3.Connection,
+    application_id: int,
+) -> list[ApplicationArtifactRecord]:
     rows = connection.execute(
         """
         SELECT id, application_id, artifact_type, path, created_at_utc, metadata

--- a/job_hunter_agent/infrastructure/application_history.py
+++ b/job_hunter_agent/infrastructure/application_history.py
@@ -125,7 +125,7 @@ def record_application_artifact(
         (application_id, artifact_type.strip(), path_text, created_at, _json_dumps(metadata)),
     )
     return ApplicationArtifactRecord(
-        id=cursor.lastrowid,
+        id=int(cursor.lastrowid),
         application_id=application_id,
         artifact_type=artifact_type.strip(),
         path=path_text,

--- a/job_hunter_agent/infrastructure/application_history.py
+++ b/job_hunter_agent/infrastructure/application_history.py
@@ -50,7 +50,7 @@ def record_application_event(
     payload: dict[str, Any] | None = None,
     *,
     occurred_at_utc: str | None = None,
-[]) -> ApplicationEventRecord:
+) -> ApplicationEventRecord:
     if application_id <= 0:
         raise ValueError("application_id must be positive")
     if not event_type.strip():
@@ -103,7 +103,7 @@ def record_application_artifact(
     metadata: dict[str, Any] | None = None,
     *,
     created_at_utc: str | None = None,
-[]) -> ApplicationArtifactRecord:
+) -> ApplicationArtifactRecord:
     if application_id <= 0:
         raise ValueError("application_id must be positive")
     if not artifact_type.strip():

--- a/job_hunter_agent/infrastructure/application_history.py
+++ b/job_hunter_agent/infrastructure/application_history.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from typing import Any
 
 
-@tataclass(frozen=True)
+@dataclass(frozen=True)
 class ApplicationEventRecord:
     id: int
     application_id: int

--- a/job_hunter_agent/infrastructure/application_history.py
+++ b/job_hunter_agent/infrastructure/application_history.py
@@ -65,7 +65,7 @@ def record_application_event(
         (application_id, event_type.strip(), occurred_at, _json_dumps(payload)),
     )
     return ApplicationEventRecord(
-        id=cursor.lastrowid,
+        id=int(cursor.lastrowid),
         application_id=application_id,
         event_type=event_type.strip(),
         occurred_at_utc=occurred_at,

--- a/job_hunter_agent/infrastructure/application_history.py
+++ b/job_hunter_agent/infrastructure/application_history.py
@@ -1,0 +1,154 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+@tataclass(frozen=True)
+class ApplicationEventRecord:
+    id: int
+    application_id: int
+    event_type: str
+    occurred_at_utc: str
+    payload: dict[str, Any]
+
+
+@dataclass(frozen=True)
+class ApplicationArtifactRecord:
+    id: int
+    application_id: int
+    artifact_type: str
+    path: str
+    created_at_utc: str
+    metadata: dict[str, Any]
+
+
+def utc_now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+def _json_dumps(payload: dict[str, Any] | None) -> str:
+    return json.dumps(payload or {}, sort_keys=True)
+
+
+def _json_loads(value: str) -> dict[str, Any]:
+    try:
+        payload = json.loads(value or "{}")
+    except json.JSONDecodeError:
+        return {"raw": value}
+    return payload if isinstance(payload, dict) else {"raw": payload}
+
+
+def record_application_event(
+    connection: sqlite3.Connection,
+    application_id: int,
+    event_type: str,
+    payload: dict[str, Any] | None = None,
+    *,
+    occurred_at_utc: str | None = None,
+[]) -> ApplicationEventRecord:
+    if application_id <= 0:
+        raise ValueError("application_id must be positive")
+    if not event_type.strip():
+        raise ValueError("event_type must not be empty")
+
+    occurred_at = occurred_at_utc or utc_now_iso()
+    cursor = connection.execute(
+        """
+        INSERT INTO application_events (application_id, event_type, occurred_at_utc, payload)
+        VALUES (?, ?, ?, ?)
+        """,
+        (application_id, event_type.strip(), occurred_at, _json_dumps(payload)),
+    )
+    return ApplicationEventRecord(
+        id=cursor.lastrowid,
+        application_id=application_id,
+        event_type=event_type.strip(),
+        occurred_at_utc=occurred_at,
+        payload=payload or {},
+    )
+
+
+def list_application_events(connection: sqlite3.Connection, application_id: int) -> list[ApplicationEventRecord]:
+    rows = connection.execute(
+        """
+        SELECT id, application_id, event_type, occurred_at_utc, payload
+        FROM application_events
+        WHERE application_id = ?
+        ORDER BY occurred_at_utc ASC, id ASC
+        """,
+        (application_id,),
+    ).fetchall()
+    return [
+        ApplicationEventRecord(
+            id=row[0],
+            application_id=row[1],
+            event_type=row[2],
+            occurred_at_utc=row[3],
+            payload=_json_loads(row[4]),
+        )
+        for row in rows
+    ]
+
+
+def record_application_artifact(
+    connection: sqlite3.Connection,
+    application_id: int,
+    artifact_type: str,
+    path: str | Path,
+    metadata: dict[str, Any] | None = None,
+    *,
+    created_at_utc: str | None = None,
+[]) -> ApplicationArtifactRecord:
+    if application_id <= 0:
+        raise ValueError("application_id must be positive")
+    if not artifact_type.strip():
+        raise ValueError("artifact_type must not be empty")
+
+    path_text = str(path).strip()
+    if not path_text:
+        raise ValueError("path must not be empty")
+
+    created_at = created_at_utc or utc_now_iso()
+    cursor = connection.execute(
+        """
+        INSERT INTO application_artifacts (application_id, artifact_type, path, created_at_utc, metadata)
+        VALUES (?, ?, ?, ?, ?)
+        """,
+        (application_id, artifact_type.strip(), path_text, created_at, _json_dumps(metadata)),
+    )
+    return ApplicationArtifactRecord(
+        id=cursor.lastrowid,
+        application_id=application_id,
+        artifact_type=artifact_type.strip(),
+        path=path_text,
+        created_at_utc=created_at,
+        metadata=metadata or {},
+    )
+
+
+def list_application_artifacts(connection: sqlite3.Connection, application_id: int) -> list[ApplicationArtifactRecord]:
+    rows = connection.execute(
+        """
+        SELECT id, application_id, artifact_type, path, created_at_utc, metadata
+        FROM application_artifacts
+        WHERE application_id = ?
+        ORDER BY created_at_utc ASC, id ASC
+        """,
+        (application_id,),
+    ).fetchall()
+    return [
+        ApplicationArtifactRecord(
+            id=row[0],
+            application_id=row[1],
+            artifact_type=row[2],
+            path=row[3],
+            created_at_utc=row[4],
+            metadata=_json_loads(row[5]),
+        )
+        for row in rows
+    ]

--- a/job_hunter_agent/infrastructure/schema_migrations.py
+++ b/job_hunter_agent/infrastructure/schema_migrations.py
@@ -165,7 +165,11 @@ def ensure_current_schema_version(
     version: int = CURRENT_SCHEMA_VERSION,
     name: str = CURRENT_SCHEMA_NAME,
 ) -> None:
-    """Register the current SQLite schema version idempotently."""
+    """Register or migrate the current SQLite schema version idempotently."""
+    if version == CURRENT_SCHEMA_VERSION and name == CURRENT_SCHEMA_NAME:
+        run_schema_migrations(connection)
+        return
+
     run_schema_migrations(
         connection,
         migrations=(

--- a/job_hunter_agent/infrastructure/schema_migrations.py
+++ b/job_hunter_agent/infrastructure/schema_migrations.py
@@ -5,8 +5,8 @@ from collections.abc import Callable, Iterable
 from dataclasses import dataclass
 from datetime import datetime, timezone
 
-CURRENT_SCHEMA_VERSION = 1
-CURRENT_SCHEMA_NAME = "initial_sqlite_schema"
+CURRENT_SCHEMA_VERSION = 2
+CURRENT_SCHEMA_NAME = "application_operational_history"
 
 
 def utc_now_iso() -> str:
@@ -31,11 +31,69 @@ def _baseline_current_schema(_connection: sqlite3.Connection) -> None:
     """Register the current SQLite schema as the first managed baseline."""
 
 
+def _create_application_operational_history_tables(connection: sqlite3.Connection) -> None:
+    """Create dedicated operational history tables for application events and artifacts."""
+    connection.execute(
+        """
+        CREATE TABLE IF NOT EXISTS application_events (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            application_id INTEGER NOT NULL,
+            event_type TEXT NOT NULL,
+            occurred_at_utc TEXT NOT NULL,
+            payload TEXT NOT NULL DEFAULT '{}',
+            FOREIGN KEY(application_id) REFERENCES job_applications(id)
+        )
+        """
+    )
+    connection.execute(
+        """
+        CREATE INDEX IF NOT EXISTS idx_application_events_application_occurred_at
+        ON application_events(application_id, occurred_at_utc)
+        """
+    )
+    connection.execute(
+        """
+        CREATE INDEX IF NOT EXISTS idx_application_events_type_occurred_at
+        ON application_events(event_type, occurred_at_utc)
+        """
+    )
+    connection.execute(
+        """
+        CREATE TABLE IF NOT EXISTS application_artifacts (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            application_id INTEGER NOT NULL,
+            artifact_type TEXT NOT NULL,
+            path TEXT NOT NULL,
+            created_at_utc TEXT NOT NULL,
+            metadata TEXT NOT NULL DEFAULT '{}',
+            FOREIGN KEY(application_id) REFERENCES job_applications(id)
+        )
+        """
+    )
+    connection.execute(
+        """
+        CREATE INDEX IF NOT EXISTS idx_application_artifacts_application_created_at
+        ON application_artifacts(application_id, created_at_utc)
+        """
+    )
+    connection.execute(
+        """
+        CREATE INDEX IF NOT EXISTS idx_application_artifacts_type_created_at
+        ON application_artifacts(artifact_type, created_at_utc)
+        """
+    )
+
+
 SCHEMA_MIGRATIONS: tuple[SchemaMigrationStep, ...] = (
+    SchemaMigrationStep(
+        version=1,
+        name="initial_sqlite_schema",
+        apply=_baseline_current_schema,
+    ),
     SchemaMigrationStep(
         version=CURRENT_SCHEMA_VERSION,
         name=CURRENT_SCHEMA_NAME,
-        apply=_baseline_current_schema,
+        apply=_create_application_operational_history_tables,
     ),
 )
 

--- a/job_hunter_agent/infrastructure/schema_migrations.py
+++ b/job_hunter_agent/infrastructure/schema_migrations.py
@@ -86,11 +86,6 @@ def _create_application_operational_history_tables(connection: sqlite3.Connectio
 
 SCHEMA_MIGRATIONS: tuple[SchemaMigrationStep, ...] = (
     SchemaMigrationStep(
-        version=1,
-        name="initial_sqlite_schema",
-        apply=_baseline_current_schema,
-    ),
-    SchemaMigrationStep(
         version=CURRENT_SCHEMA_VERSION,
         name=CURRENT_SCHEMA_NAME,
         apply=_create_application_operational_history_tables,

--- a/tests/test_application_history.py
+++ b/tests/test_application_history.py
@@ -1,0 +1,52 @@
+import sqlite3
+from unittest import TestCase
+
+from job_hunter_agent.infrastructure.application_history import (
+    list_application_artifacts,
+    list_application_events,
+    record_application_artifact,
+    record_application_event,
+[])
+from job_hunter_agent.infrastructure.schema_migrations import ensure_current_schema_version
+
+
+class ApplicationHistoryTests(TestCase):
+    def setUp(self) -> None:
+        self.connection = sqlite3.connect(":memory:")
+        self.connection.execute("CREATE TABLE job_applications (id INTEGER PRIMARY KEY)")
+        self.connection.execute("INSERT INTO job_applications (id) VALUES (1)")
+        ensure_current_schema_version(self.connection)
+
+    def test_record_and_list_application_event(self) -> None:
+        event = record_application_event(
+            self.connection,
+            application_id=1,
+            event_type="status_changed",
+            payload={"from_status": "draft", "to_status": "reviewed"},
+            occurred_at_utc="2026-01-01T00:00:00+00:00",
+        )
+
+        events = list_application_events(self.connection, 1)
+
+        self.assertEqual(1, event.id)
+        self.assertEqual([event], events)
+        self.assertEqual("status_changed", events[0].event_type)
+        self.assertEqual("{"from_status": "draft", "to_status": "reviewed"}, events[0].payload)
+
+    def test_record_and_list_application_artifact(self) -> None:
+        artifact = record_application_artifact(
+            self.connection,
+            application_id=1,
+            artifact_type="preflight_report",
+            path="artifacts/preflight.txt",
+            metadata={"source": "linkedin"},
+            created_at_utc="2026-01-01T00:00:00+00:00",
+        )
+
+        artifacts = list_application_artifacts(self.connection, 1)
+
+        self.assertEqual(1, artifact.id)
+        self.assertEqual([artifact], artifacts)
+        self.assertEqual("preflight_report", artifacts[0].artifact_type)
+        self.assertEqual("artifacts/preflight.txt", artifacts[0].path)
+        self.assertEqual({"source": "linkedin"}, artifacts[0].metadata)

--- a/tests/test_application_history.py
+++ b/tests/test_application_history.py
@@ -31,7 +31,10 @@ class ApplicationHistoryTests(TestCase):
         self.assertEqual(1, event.id)
         self.assertEqual([event], events)
         self.assertEqual("status_changed", events[0].event_type)
-        self.assertEqual({"from_status": "draft", "to_status": "reviewed"}, events[0].payload)
+        self.assertEqual(
+            {"from_status": "draft", "to_status": "reviewed"},
+            events[0].payload,
+        )
 
     def test_record_and_list_application_artifact(self) -> None:
         artifact = record_application_artifact(

--- a/tests/test_application_history.py
+++ b/tests/test_application_history.py
@@ -6,7 +6,7 @@ from job_hunter_agent.infrastructure.application_history import (
     list_application_events,
     record_application_artifact,
     record_application_event,
-[])
+)
 from job_hunter_agent.infrastructure.schema_migrations import ensure_current_schema_version
 
 
@@ -31,7 +31,7 @@ class ApplicationHistoryTests(TestCase):
         self.assertEqual(1, event.id)
         self.assertEqual([event], events)
         self.assertEqual("status_changed", events[0].event_type)
-        self.assertEqual("{"from_status": "draft", "to_status": "reviewed"}, events[0].payload)
+        self.assertEqual({"from_status": "draft", "to_status": "reviewed"}, events[0].payload)
 
     def test_record_and_list_application_artifact(self) -> None:
         artifact = record_application_artifact(

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -137,8 +137,8 @@ class SqliteJobRepositoryTests(unittest.TestCase):
             strategy.url_lookup_patterns("https://www.linkedin.com/jobs/view/123456789/?trackingId=abc"),
             [
                 "https://www.linkedin.com/jobs/view/123456789/?trackingId=abc",
-                "https://linkedin.com/jobs/view/123456789",
                 "%/jobs/view/123456789%",
+                "https://linkedin.com/jobs/view/123456789",
             ],
         )
         self.assertEqual(

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -137,6 +137,7 @@ class SqliteJobRepositoryTests(unittest.TestCase):
             strategy.url_lookup_patterns("https://www.linkedin.com/jobs/view/123456789/?trackingId=abc"),
             [
                 "https://www.linkedin.com/jobs/view/123456789/?trackingId=abc",
+                "https://linkedin.com/jobs/view/123456789",
                 "%/jobs/view/123456789%",
             ],
         )

--- a/tests/test_job_identity.py
+++ b/tests/test_job_identity.py
@@ -28,12 +28,14 @@ class JobIdentityTests(TestCase):
             "https://www.linkedin.com/jobs/view/1234567890/?trk=public_jobs&position=2"
         )
 
-        self.assertIn(
-            "https://www.linkedin.com/jobs/view/1234567890/?trk=public_jobs&position=2",
+        self.assertEqual(
             patterns,
+            [
+                "https://www.linkedin.com/jobs/view/1234567890/?trk=public_jobs&position=2",
+                "%/jobs/view/1234567890%",
+                "https://linkedin.com/jobs/view/1234567890",
+            ],
         )
-        self.assertIn("https://linkedin.com/jobs/view/1234567890", patterns)
-        self.assertIn("%/jobs/view/1234567890%", patterns)
 
     def test_url_lookup_patterns_include_current_job_id_pattern(self) -> None:
         strategy = PortalAwareJobIdentityStrategy()

--- a/tests/test_repository_schema_bootstrap.py
+++ b/tests/test_repository_schema_bootstrap.py
@@ -28,6 +28,6 @@ class RepositorySchemaBootstrapTests(TestCase):
                 """
             ).fetchall()
 
-        self.assertEqual(1, len(rows))
-        self.assertEqual(CURRENT_SCHEMA_VERSION, rows[0][0])
-        self.assertTrue(rows[0][2].endswith("+00:00"))
+        self.assertGreaterEqual(len(rows), 1)
+        self.assertEqual(CURRENT_SCHEMA_VERSION, rows[-1][0])
+        self.assertTrue(rows[-1][2].endswith("+00:00"))

--- a/tests/test_schema_migrations.py
+++ b/tests/test_schema_migrations.py
@@ -62,6 +62,35 @@ class SchemaMigrationsTests(TestCase):
         self.assertEqual(("application_artifacts",), artifact_table)
         self.assertEqual(CURRENT_SCHEMA_VERSION, current_schema_version(connection))
 
+    def test_ensure_current_schema_version_migrates_legacy_version_one_database(self) -> None:
+        connection = sqlite3.connect(":memory:")
+        connection.execute("CREATE TABLE job_applications (id INTEGER PRIMARY KEY)")
+        connection.execute(
+            """
+            CREATE TABLE schema_migrations (
+                version INTEGER PRIMARY KEY,
+                name TEXT NOT NULL,
+                applied_at_utc TEXT NOT NULL
+            )
+            """
+        )
+        connection.execute(
+            """
+            INSERT INTO schema_migrations (version, name, applied_at_utc)
+            VALUES (1, 'initial_sqlite_schema', '2026-01-01T00:00:00+00:00')
+            """
+        )
+
+        ensure_current_schema_version(connection)
+
+        self.assertEqual(CURRENT_SCHEMA_VERSION, current_schema_version(connection))
+        migrations = list_schema_migrations(connection)
+        self.assertEqual([1, CURRENT_SCHEMA_VERSION], [migration.version for migration in migrations])
+        event_table = connection.execute(
+            "SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'application_events'"
+        ).fetchone()
+        self.assertEqual(("application_events",), event_table)
+
     def test_run_schema_migrations_applies_pending_versions_in_order(self) -> None:
         applied: list[int] = []
 

--- a/tests/test_schema_migrations.py
+++ b/tests/test_schema_migrations.py
@@ -44,7 +44,23 @@ class SchemaMigrationsTests(TestCase):
 
         row = connection.execute("SELECT id, title FROM jobs").fetchone()
         self.assertEqual((1, "Backend Java"), row)
-        self.assertEqual(1, len(list_schema_migrations(connection)))
+        self.assertEqual(CURRENT_SCHEMA_VERSION, current_schema_version(connection))
+
+    def test_ensure_current_schema_version_creates_application_history_tables(self) -> None:
+        connection = sqlite3.connect(":memory:")
+        connection.execute("CREATE TABLE job_applications (id INTEGER PRIMARY KEY)")
+
+        ensure_current_schema_version(connection)
+
+        event_table = connection.execute(
+            "SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'application_events'"
+        ).fetchone()
+        artifact_table = connection.execute(
+            "SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'application_artifacts'"
+        ).fetchone()
+        self.assertEqual(("application_events",), event_table)
+        self.assertEqual(("application_artifacts",), artifact_table)
+        self.assertEqual(CURRENT_SCHEMA_VERSION, current_schema_version(connection))
 
     def test_run_schema_migrations_applies_pending_versions_in_order(self) -> None:
         applied: list[int] = []

--- a/tests/test_schema_migrations.py
+++ b/tests/test_schema_migrations.py
@@ -31,11 +31,11 @@ class SchemaMigrationsTests(TestCase):
         connection = sqlite3.connect(":memory:")
 
         ensure_current_schema_version(connection)
-        first_migration = list_schema_migrations(connection)[0]
+        first_migrations = list_schema_migrations(connection)
         ensure_current_schema_version(connection)
 
         migrations = list_schema_migrations(connection)
-        self.assertEqual([first_migration], migrations)
+        self.assertEqual(first_migrations, migrations)
 
     def test_ensure_current_schema_version_preserves_existing_legacy_tables(self) -> None:
         connection = sqlite3.connect(":memory:")

--- a/tests/test_schema_migrations.py
+++ b/tests/test_schema_migrations.py
@@ -19,12 +19,10 @@ class SchemaMigrationsTests(TestCase):
         ensure_current_schema_version(connection)
 
         migrations = list_schema_migrations(connection)
-        self.assertEqual(2, len(migrations))
-        self.assertEqual(1, migrations[0].version)
-        self.assertEqual("initial_sqlite_schema", migrations[0].name)
-        self.assertEqual(CURRENT_SCHEMA_VERSION, migrations[-1].version)
-        self.assertEqual(CURRENT_SCHEMA_NAME, migrations[-1].name)
-        self.assertTrue(migrations[-1].applied_at_utc.endswith("+00:00"))
+        self.assertEqual(1, len(migrations))
+        self.assertEqual(CURRENT_SCHEMA_VERSION, migrations[0].version)
+        self.assertEqual(CURRENT_SCHEMA_NAME, migrations[0].name)
+        self.assertTrue(migrations[0].applied_at_utc.endswith("+00:00"))
         self.assertEqual(CURRENT_SCHEMA_VERSION, current_schema_version(connection))
 
     def test_ensure_current_schema_version_is_idempotent(self) -> None:

--- a/tests/test_schema_migrations.py
+++ b/tests/test_schema_migrations.py
@@ -19,10 +19,12 @@ class SchemaMigrationsTests(TestCase):
         ensure_current_schema_version(connection)
 
         migrations = list_schema_migrations(connection)
-        self.assertEqual(1, len(migrations))
-        self.assertEqual(CURRENT_SCHEMA_VERSION, migrations[0].version)
-        self.assertEqual(CURRENT_SCHEMA_NAME, migrations[0].name)
-        self.assertTrue(migrations[0].applied_at_utc.endswith("+00:00"))
+        self.assertEqual(2, len(migrations))
+        self.assertEqual(1, migrations[0].version)
+        self.assertEqual("initial_sqlite_schema", migrations[0].name)
+        self.assertEqual(CURRENT_SCHEMA_VERSION, migrations[-1].version)
+        self.assertEqual(CURRENT_SCHEMA_NAME, migrations[-1].name)
+        self.assertTrue(migrations[-1].applied_at_utc.endswith("+00:00"))
         self.assertEqual(CURRENT_SCHEMA_VERSION, current_schema_version(connection))
 
     def test_ensure_current_schema_version_is_idempotent(self) -> None:


### PR DESCRIPTION
## Summary
- Add schema migration v2 for dedicated application operational history tables:
  - `application_events`
  - `application_artifacts`
- Add indexed lookup paths by application, timestamp, event type and artifact type.
- Add `application_history` helper functions to record/list application events and artifacts with JSON payload/metadata.
- Add migration and helper tests.

## Scope note
This is an incremental foundation for #111. It does **not** close #111 yet because follow-up work is still needed to wire the main application status transitions and operational reports to these tables.

## Safety
- Additive SQLite schema only.
- No existing columns/tables removed.
- `notes` remains available as human-readable notes.
- No external automation, collectors, browser actions, gates, or domain states changed.

## Tests
Not run in this environment.

Expected commands:

```bash
pytest tests/test_schema_migrations.py tests/test_application_history.py
```

Refs #111