### PR TITLE
feat: add in-memory event bus

### DIFF
--- a/job_hunter_agent/core/event_bus.py
+++ b/job_hunter_agent/core/event_bus.py
@@ -27,6 +27,47 @@ class EventBusPort(Protocol):
         raise NotImplementedError
 
 
+class InMemoryEventBus:
+    def __init__(self, events: tuple[DomainEvent, ...] | None = None) -> None:
+        self._events: list[DomainEvent] = list(events or ())
+
+    def publish(self, event: DomainEvent) -> None:
+        self._events.append(event)
+
+    def read_all(self) -> tuple[DomainEvent, ...]:
+        return tuple(self._events)
+
+    def clear(self) -> None:
+        self._events.clear()
+
+    def read_job_collected(self) -> tuple[JobCollectedV1, ...]:
+        return tuple(event for event in self._events if isinstance(event, JobCollectedV1))
+
+    def read_job_scored(self) -> tuple[JobScoredV1, ...]:
+        return tuple(event for event in self._events if isinstance(event, JobScoredV1))
+
+    def read_job_review_requested(self) -> tuple[JobReviewRequestedV1, ...]:
+        return tuple(event for event in self._events if isinstance(event, JobReviewRequestedV1))
+
+    def read_job_reviewed(self) -> tuple[JobReviewedV1, ...]:
+        return tuple(event for event in self._events if isinstance(event, JobReviewedV1))
+
+    def read_application_authorized(self) -> tuple[ApplicationAuthorizedV1, ...]:
+        return tuple(event for event in self._events if isinstance(event, ApplicationAuthorizedV1))
+
+    def read_application_draft_created(self) -> tuple[ApplicationDraftCreatedV1, ...]:
+        return tuple(event for event in self._events if isinstance(event, ApplicationDraftCreatedV1))
+
+    def read_application_preflight_completed(self) -> tuple[ApplicationPreflightCompletedV1, ...]:
+        return tuple(event for event in self._events if isinstance(event, ApplicationPreflightCompletedV1))
+
+    def read_application_submitted(self) -> tuple[ApplicationSubmittedV1, ...]:
+        return tuple(event for event in self._events if isinstance(event, ApplicationSubmittedV1))
+
+    def read_application_blocked(self) -> tuple[ApplicationBlockedV1, ...]:
+        return tuple(event for event in self._events if isinstance(event, ApplicationBlockedV1))
+
+
 class LocalNdjsonEventBus:
     def __init__(self, path: Path) -> None:
         self.path = Path(path)

--- a/tests/test_event_bus.py
+++ b/tests/test_event_bus.py
@@ -4,7 +4,7 @@ import shutil
 from unittest import TestCase
 
 from job_hunter_agent.core.domain import JobPosting
-from job_hunter_agent.core.event_bus import LocalNdjsonEventBus
+from job_hunter_agent.core.event_bus import InMemoryEventBus, LocalNdjsonEventBus
 from job_hunter_agent.core.events import (
     ApplicationAuthorizedV1,
     ApplicationBlockedV1,
@@ -31,6 +31,51 @@ def _job() -> JobPosting:
         rationale="fit",
         external_key="job-key-123",
     )
+
+
+class InMemoryEventBusTests(TestCase):
+    def test_publish_and_read_all_preserves_event_order(self) -> None:
+        bus = InMemoryEventBus()
+        collected = JobCollectedV1(
+            run_id=1,
+            jobs=(_job(),),
+            jobs_seen=1,
+            jobs_saved=1,
+            errors=0,
+            event_id="evt-collected",
+            occurred_at="2026-04-24T12:00:00+00:00",
+        )
+        scored = JobScoredV1(
+            run_id=1,
+            external_key="job-key-123",
+            accepted=True,
+            relevance=9,
+            event_id="evt-scored",
+            occurred_at="2026-04-24T12:01:00+00:00",
+        )
+
+        bus.publish(collected)
+        bus.publish(scored)
+
+        self.assertEqual(bus.read_all(), (collected, scored))
+        self.assertEqual(bus.read_job_collected(), (collected,))
+        self.assertEqual(bus.read_job_scored(), (scored,))
+
+    def test_can_be_seeded_and_cleared(self) -> None:
+        collected = JobCollectedV1(
+            run_id=1,
+            jobs=(_job(),),
+            jobs_seen=1,
+            jobs_saved=1,
+            errors=0,
+        )
+        bus = InMemoryEventBus((collected,))
+
+        self.assertEqual(bus.read_job_collected(), (collected,))
+
+        bus.clear()
+
+        self.assertEqual(bus.read_all(), ())
 
 
 class LocalNdjsonEventBusTests(TestCase):


### PR DESCRIPTION
## Summary
- Add `InMemoryEventBus` implementing the existing `EventBusPort` shape.
- Preserve event order in memory for orchestrator/unit-test use cases.
- Add read helpers matching the existing `LocalNdjsonEventBus` typed filters.
- Add tests for publish/read order, typed filtering, seeding, and clearing.

## Scope note
This is an incremental foundation for #110. It does not close #110 yet because worker rewiring, DLQ standardization, CLI replay/inspect, and Docker profile work remain.

## Safety
- No schema changes.
- No external actions.
- No worker runtime behavior changed.
- Existing NDJSON event bus remains unchanged.

## Tests
Not run in this environment.

Expected command:

```bash
pytest tests/test_event_bus.py
```

Refs #110