### PR TITLE
feat: add human review decision contract

### DIFF
--- a/job_hunter_agent/application/human_review.py
+++ b/job_hunter_agent/application/human_review.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Literal
+
+HumanReviewState = Literal[
+    "pending_review",
+    "approved",
+    "rejected",
+    "blocked",
+    "authorized_for_external_action",
+]
+HumanReviewAction = Literal["approve", "reject", "block", "authorize_external_action"]
+
+PENDING_REVIEW: HumanReviewState = "pending_review"
+APPROVED: HumanReviewState = "approved"
+REJECTED: HumanReviewState = "rejected"
+BLOCKED: HumanReviewState = "blocked"
+AUTHORIZED_FOR_EXTERNAL_ACTION: HumanReviewState = "authorized_for_external_action"
+
+_TERMINAL_STATES: set[HumanReviewState] = {
+    REJECTED,
+    BLOCKED,
+    AUTHORIZED_FOR_EXTERNAL_ACTION,
+}
+
+
+def utc_now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+@dataclass(frozen=True)
+class HumanReviewDecision:
+    application_id: int
+    from_state: HumanReviewState
+    to_state: HumanReviewState
+    action: HumanReviewAction
+    decided_by: str
+    reason: str
+    decided_at_utc: str = field(default_factory=utc_now_iso)
+
+    @property
+    def allows_external_action(self) -> bool:
+        return self.to_state == AUTHORIZED_FOR_EXTERNAL_ACTION
+
+
+def require_explicit_human_actor(decided_by: str) -> str:
+    actor = decided_by.strip()
+    if not actor:
+        raise ValueError("decided_by must identify the human reviewer")
+    if actor.lower() in {"system", "automation", "auto", "bot"}:
+        raise ValueError("decided_by must be a human reviewer, not automation")
+    return actor
+
+
+def require_reason(reason: str, *, action: HumanReviewAction) -> str:
+    clean_reason = reason.strip()
+    if not clean_reason:
+        raise ValueError(f"reason is required to {action}")
+    return clean_reason
+
+
+def resolve_human_review_decision(
+    *,
+    application_id: int,
+    current_state: HumanReviewState,
+    action: HumanReviewAction,
+    decided_by: str,
+    reason: str,
+    decided_at_utc: str | None = None,
+) -> HumanReviewDecision:
+    if application_id <= 0:
+        raise ValueError("application_id must be positive")
+
+    actor = require_explicit_human_actor(decided_by)
+    clean_reason = require_reason(reason, action=action)
+
+    if current_state in _TERMINAL_STATES:
+        raise ValueError(f"human review already finalized: {current_state}")
+
+    if action == "approve":
+        to_state: HumanReviewState = APPROVED
+    elif action == "reject":
+        to_state = REJECTED
+    elif action == "block":
+        to_state = BLOCKED
+    elif action == "authorize_external_action":
+        if current_state != APPROVED:
+            raise ValueError("external action can only be authorized after approval")
+        to_state = AUTHORIZED_FOR_EXTERNAL_ACTION
+    else:
+        raise ValueError(f"unsupported human review action: {action}")
+
+    return HumanReviewDecision(
+        application_id=application_id,
+        from_state=current_state,
+        to_state=to_state,
+        action=action,
+        decided_by=actor,
+        reason=clean_reason,
+        decided_at_utc=decided_at_utc or utc_now_iso(),
+    )
+
+
+def is_external_action_authorized(state: HumanReviewState) -> bool:
+    return state == AUTHORIZED_FOR_EXTERNAL_ACTION

--- a/tests/test_human_review.py
+++ b/tests/test_human_review.py
@@ -1,0 +1,116 @@
+import unittest
+
+from job_hunter_agent.application.human_review import (
+    APPROVED,
+    AUTHORIZED_FOR_EXTERNAL_ACTION,
+    BLOCKED,
+    PENDING_REVIEW,
+    REJECTED,
+    is_external_action_authorized,
+    resolve_human_review_decision,
+)
+
+
+class HumanReviewDecisionTests(unittest.TestCase):
+    def test_approve_records_human_actor_reason_and_timestamp(self) -> None:
+        decision = resolve_human_review_decision(
+            application_id=42,
+            current_state=PENDING_REVIEW,
+            action="approve",
+            decided_by="vinicius",
+            reason="vaga aderente ao perfil",
+            decided_at_utc="2026-05-07T12:00:00+00:00",
+        )
+
+        self.assertEqual(decision.application_id, 42)
+        self.assertEqual(decision.from_state, PENDING_REVIEW)
+        self.assertEqual(decision.to_state, APPROVED)
+        self.assertEqual(decision.decided_by, "vinicius")
+        self.assertEqual(decision.reason, "vaga aderente ao perfil")
+        self.assertEqual(decision.decided_at_utc, "2026-05-07T12:00:00+00:00")
+        self.assertFalse(decision.allows_external_action)
+
+    def test_reject_requires_audit_reason(self) -> None:
+        decision = resolve_human_review_decision(
+            application_id=42,
+            current_state=PENDING_REVIEW,
+            action="reject",
+            decided_by="vinicius",
+            reason="senioridade fora do alvo",
+        )
+
+        self.assertEqual(decision.to_state, REJECTED)
+        self.assertEqual(decision.reason, "senioridade fora do alvo")
+        self.assertFalse(decision.allows_external_action)
+
+    def test_block_records_safety_decision(self) -> None:
+        decision = resolve_human_review_decision(
+            application_id=42,
+            current_state=PENDING_REVIEW,
+            action="block",
+            decided_by="vinicius",
+            reason="exige envio de dados sensíveis fora do fluxo",
+        )
+
+        self.assertEqual(decision.to_state, BLOCKED)
+        self.assertFalse(decision.allows_external_action)
+
+    def test_external_action_requires_prior_approval(self) -> None:
+        with self.assertRaisesRegex(
+            ValueError,
+            "external action can only be authorized after approval",
+        ):
+            resolve_human_review_decision(
+                application_id=42,
+                current_state=PENDING_REVIEW,
+                action="authorize_external_action",
+                decided_by="vinicius",
+                reason="pode submeter",
+            )
+
+    def test_authorize_external_action_after_approval(self) -> None:
+        decision = resolve_human_review_decision(
+            application_id=42,
+            current_state=APPROVED,
+            action="authorize_external_action",
+            decided_by="vinicius",
+            reason="revisado e autorizado para envio",
+        )
+
+        self.assertEqual(decision.to_state, AUTHORIZED_FOR_EXTERNAL_ACTION)
+        self.assertTrue(decision.allows_external_action)
+        self.assertTrue(is_external_action_authorized(decision.to_state))
+
+    def test_automation_cannot_decide_human_review(self) -> None:
+        with self.assertRaisesRegex(ValueError, "human reviewer, not automation"):
+            resolve_human_review_decision(
+                application_id=42,
+                current_state=PENDING_REVIEW,
+                action="approve",
+                decided_by="bot",
+                reason="auto approve",
+            )
+
+    def test_reason_is_required_for_auditability(self) -> None:
+        with self.assertRaisesRegex(ValueError, "reason is required"):
+            resolve_human_review_decision(
+                application_id=42,
+                current_state=PENDING_REVIEW,
+                action="reject",
+                decided_by="vinicius",
+                reason=" ",
+            )
+
+    def test_terminal_states_cannot_be_changed(self) -> None:
+        with self.assertRaisesRegex(ValueError, "already finalized"):
+            resolve_human_review_decision(
+                application_id=42,
+                current_state=REJECTED,
+                action="approve",
+                decided_by="vinicius",
+                reason="reabrir",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Add a dedicated human review decision contract for application review gates.
- Model explicit states: `pending_review`, `approved`, `rejected`, `blocked`, and `authorized_for_external_action`.
- Require a human reviewer identity, audit reason, and UTC timestamp for decisions.
- Enforce that external actions can only be authorized after prior approval.
- Add tests for approval, rejection, blocking, external authorization, automation rejection, audit reason, and terminal states.

## Scope note
This is the first incremental foundation for #121. It does not close #121 yet because persistence and integration with the current application workflow still remain.

## Safety
- No Playwright changes.
- No Telegram changes.
- No real submission/login/form automation added.
- No schema changes.
- No existing application statuses changed.

## Tests
Not run in this environment.

Expected command:

```bash
pytest tests/test_human_review.py
```

Refs #121