### PR TITLE
feat: record human review decisions as history payloads

### DIFF
--- a/job_hunter_agent/application/human_review.py
+++ b/job_hunter_agent/application/human_review.py
@@ -44,6 +44,21 @@ class HumanReviewDecision:
     def allows_external_action(self) -> bool:
         return self.to_state == AUTHORIZED_FOR_EXTERNAL_ACTION
 
+    @property
+    def event_type(self) -> str:
+        return f"human_review_{self.action}"
+
+    def to_event_payload(self) -> dict[str, str | bool]:
+        return {
+            "from_state": self.from_state,
+            "to_state": self.to_state,
+            "action": self.action,
+            "decided_by": self.decided_by,
+            "reason": self.reason,
+            "decided_at_utc": self.decided_at_utc,
+            "allows_external_action": self.allows_external_action,
+        }
+
 
 def require_explicit_human_actor(decided_by: str) -> str:
     actor = decided_by.strip()

--- a/tests/test_human_review.py
+++ b/tests/test_human_review.py
@@ -1,3 +1,4 @@
+import sqlite3
 import unittest
 
 from job_hunter_agent.application.human_review import (
@@ -9,6 +10,11 @@ from job_hunter_agent.application.human_review import (
     is_external_action_authorized,
     resolve_human_review_decision,
 )
+from job_hunter_agent.infrastructure.application_history import (
+    list_application_events,
+    record_application_event,
+)
+from job_hunter_agent.infrastructure.schema_migrations import ensure_current_schema_version
 
 
 class HumanReviewDecisionTests(unittest.TestCase):
@@ -80,6 +86,60 @@ class HumanReviewDecisionTests(unittest.TestCase):
         self.assertEqual(decision.to_state, AUTHORIZED_FOR_EXTERNAL_ACTION)
         self.assertTrue(decision.allows_external_action)
         self.assertTrue(is_external_action_authorized(decision.to_state))
+
+    def test_decision_exposes_auditable_event_payload(self) -> None:
+        decision = resolve_human_review_decision(
+            application_id=42,
+            current_state=APPROVED,
+            action="authorize_external_action",
+            decided_by="vinicius",
+            reason="revisado e autorizado para envio",
+            decided_at_utc="2026-05-07T12:30:00+00:00",
+        )
+
+        self.assertEqual(decision.event_type, "human_review_authorize_external_action")
+        self.assertEqual(
+            decision.to_event_payload(),
+            {
+                "from_state": APPROVED,
+                "to_state": AUTHORIZED_FOR_EXTERNAL_ACTION,
+                "action": "authorize_external_action",
+                "decided_by": "vinicius",
+                "reason": "revisado e autorizado para envio",
+                "decided_at_utc": "2026-05-07T12:30:00+00:00",
+                "allows_external_action": True,
+            },
+        )
+
+    def test_decision_payload_can_be_recorded_in_application_history(self) -> None:
+        connection = sqlite3.connect(":memory:")
+        connection.execute("CREATE TABLE job_applications (id INTEGER PRIMARY KEY)")
+        connection.execute("INSERT INTO job_applications (id) VALUES (42)")
+        ensure_current_schema_version(connection)
+        decision = resolve_human_review_decision(
+            application_id=42,
+            current_state=PENDING_REVIEW,
+            action="reject",
+            decided_by="vinicius",
+            reason="fora do alvo atual",
+            decided_at_utc="2026-05-07T12:45:00+00:00",
+        )
+
+        record_application_event(
+            connection,
+            application_id=decision.application_id,
+            event_type=decision.event_type,
+            payload=decision.to_event_payload(),
+            occurred_at_utc=decision.decided_at_utc,
+        )
+
+        events = list_application_events(connection, 42)
+        self.assertEqual(len(events), 1)
+        self.assertEqual(events[0].event_type, "human_review_reject")
+        self.assertEqual(events[0].occurred_at_utc, "2026-05-07T12:45:00+00:00")
+        self.assertEqual(events[0].payload["to_state"], REJECTED)
+        self.assertEqual(events[0].payload["reason"], "fora do alvo atual")
+        self.assertFalse(events[0].payload["allows_external_action"])
 
     def test_automation_cannot_decide_human_review(self) -> None:
         with self.assertRaisesRegex(ValueError, "human reviewer, not automation"):


### PR DESCRIPTION
## Summary
- Add auditable event serialization to `HumanReviewDecision`.
- Expose `event_type` and `to_event_payload()` for recording decisions in application operational history.
- Cover persistence via `record_application_event` / `list_application_events` using the existing SQLite history schema.

## Scope note
This is an incremental continuation of #121. It does not close #121 yet because wiring the current application workflow/CLI to emit these decisions remains.

## Safety
- No schema changes.
- No Playwright changes.
- No Telegram changes.
- No real external actions.
- No current application status transitions changed.

## Tests
Not run in this environment.

Expected command:

```bash
pytest tests/test_human_review.py
```

Refs #121