### PR TITLE
feat: record human review for application actions

### DIFF
--- a/job_hunter_agent/application/application_flow.py
+++ b/job_hunter_agent/application/application_flow.py
@@ -3,6 +3,12 @@ from __future__ import annotations
 from dataclasses import dataclass
 from datetime import datetime
 
+from job_hunter_agent.application.human_review import (
+    APPROVED,
+    PENDING_REVIEW,
+    HumanReviewDecision,
+    resolve_human_review_decision,
+)
 from job_hunter_agent.core.domain import JobApplication, JobPosting
 from job_hunter_agent.infrastructure.repository import JobRepository
 
@@ -96,6 +102,52 @@ class ApplicationFlowCoordinator:
             from_status=from_status,
             to_status=to_status,
         )
+
+    def record_human_review_decision(self, decision: HumanReviewDecision) -> None:
+        self.repository.record_application_event(
+            decision.application_id,
+            event_type=decision.event_type,
+            detail=decision.reason,
+            from_status=decision.from_state,
+            to_status=decision.to_state,
+        )
+        history_recorder = getattr(self.repository, "record_application_history_event", None)
+        if history_recorder:
+            history_recorder(
+                decision.application_id,
+                event_type=decision.event_type,
+                payload=decision.to_event_payload(),
+                occurred_at_utc=decision.decided_at_utc,
+            )
+
+    def resolve_and_record_human_review_action(
+        self,
+        context: ApplicationExecutionContext,
+        *,
+        action: str,
+        decided_by: str,
+        reason: str,
+        decided_at_utc: str | None = None,
+    ) -> HumanReviewDecision:
+        if action == "app_confirm":
+            current_state = PENDING_REVIEW
+            review_action = "approve"
+        elif action == "app_authorize":
+            current_state = APPROVED
+            review_action = "authorize_external_action"
+        else:
+            raise ValueError(f"unsupported human review application action: {action}")
+
+        decision = resolve_human_review_decision(
+            application_id=context.application.id,
+            current_state=current_state,
+            action=review_action,
+            decided_by=decided_by,
+            reason=reason,
+            decided_at_utc=decided_at_utc,
+        )
+        self.record_human_review_decision(decision)
+        return decision
 
     @staticmethod
     def resolve_submitted_at(submitted_at: str | None) -> str:

--- a/tests/test_application_flow.py
+++ b/tests/test_application_flow.py
@@ -184,6 +184,100 @@ class ApplicationFlowTests(unittest.TestCase):
             ],
         )
 
+    def test_resolve_and_record_human_review_confirm_action(self) -> None:
+        application = JobApplication(id=7, job_id=10, status="ready_for_review")
+        context = ApplicationExecutionContext(application=application, job=_sample_job(job_id=10))
+
+        class _Repository:
+            def __init__(self) -> None:
+                self.event_calls = []
+                self.history_calls = []
+
+            def record_application_event(self, application_id: int, **kwargs):
+                self.event_calls.append((application_id, kwargs))
+
+            def record_application_history_event(self, application_id: int, **kwargs):
+                self.history_calls.append((application_id, kwargs))
+
+        repository = _Repository()
+        flow = ApplicationFlowCoordinator(repository)
+
+        decision = flow.resolve_and_record_human_review_action(
+            context,
+            action="app_confirm",
+            decided_by="vinicius",
+            reason="curriculo revisado e vaga aderente",
+            decided_at_utc="2026-05-08T12:00:00+00:00",
+        )
+
+        self.assertEqual(decision.action, "approve")
+        self.assertEqual(decision.to_state, "approved")
+        self.assertEqual(
+            repository.event_calls,
+            [
+                (
+                    7,
+                    {
+                        "event_type": "human_review_approve",
+                        "detail": "curriculo revisado e vaga aderente",
+                        "from_status": "pending_review",
+                        "to_status": "approved",
+                    },
+                )
+            ],
+        )
+        self.assertEqual(repository.history_calls[0][0], 7)
+        self.assertEqual(repository.history_calls[0][1]["event_type"], "human_review_approve")
+        self.assertEqual(repository.history_calls[0][1]["occurred_at_utc"], "2026-05-08T12:00:00+00:00")
+        self.assertEqual(repository.history_calls[0][1]["payload"]["decided_by"], "vinicius")
+        self.assertFalse(repository.history_calls[0][1]["payload"]["allows_external_action"])
+
+    def test_resolve_and_record_human_review_authorize_action(self) -> None:
+        application = JobApplication(id=8, job_id=11, status="confirmed")
+        context = ApplicationExecutionContext(application=application, job=_sample_job(job_id=11))
+
+        class _Repository:
+            def __init__(self) -> None:
+                self.event_calls = []
+
+            def record_application_event(self, application_id: int, **kwargs):
+                self.event_calls.append((application_id, kwargs))
+
+        repository = _Repository()
+        flow = ApplicationFlowCoordinator(repository)
+
+        decision = flow.resolve_and_record_human_review_action(
+            context,
+            action="app_authorize",
+            decided_by="vinicius",
+            reason="autorizado para acao externa",
+        )
+
+        self.assertEqual(decision.action, "authorize_external_action")
+        self.assertEqual(decision.to_state, "authorized_for_external_action")
+        self.assertTrue(decision.allows_external_action)
+        self.assertEqual(repository.event_calls[0][1]["event_type"], "human_review_authorize_external_action")
+        self.assertEqual(repository.event_calls[0][1]["from_status"], "approved")
+        self.assertEqual(repository.event_calls[0][1]["to_status"], "authorized_for_external_action")
+
+    def test_resolve_and_record_human_review_rejects_unknown_action(self) -> None:
+        application = JobApplication(id=7, job_id=10, status="ready_for_review")
+        context = ApplicationExecutionContext(application=application, job=_sample_job(job_id=10))
+
+        class _Repository:
+            def record_application_event(self, application_id: int, **kwargs):
+                raise AssertionError("should not record unknown actions")
+
+        flow = ApplicationFlowCoordinator(_Repository())
+
+        with self.assertRaisesRegex(ValueError, "unsupported human review application action"):
+            flow.resolve_and_record_human_review_action(
+                context,
+                action="app_prepare",
+                decided_by="vinicius",
+                reason="not a human review decision",
+            )
+
     def test_resolve_submitted_at_uses_current_timestamp_when_missing(self) -> None:
         resolved = ApplicationFlowCoordinator.resolve_submitted_at(None)
 


### PR DESCRIPTION
## Summary
- Add `ApplicationFlowCoordinator.resolve_and_record_human_review_action()`.
- Map existing application actions to explicit human-review decisions:
  - `app_confirm` -> `approve`
  - `app_authorize` -> `authorize_external_action`
- Record the decision in the existing application event stream.
- Optionally record the auditable payload in operational history when the repository exposes `record_application_history_event`.
- Add unit tests for confirm, authorize, and unknown-action rejection.

## Scope note
This is an incremental continuation of #121. It still does not close #121 because CLI/repository wiring remains.

## Safety
- No schema changes.
- No Playwright changes.
- No Telegram changes.
- No real external actions.
- No existing application status transitions changed.

## Tests
Not run in this environment.

Expected command:

```bash
pytest tests/test_application_flow.py tests/test_human_review.py
```

Refs #121