### PR TITLE
feat: wire CLI application transitions to human review audit

### DIFF
--- a/job_hunter_agent/application/application_commands.py
+++ b/job_hunter_agent/application/application_commands.py
@@ -116,5 +116,18 @@ class ApplicationTransitionCommandService:
             )
         return detail
 
+    def _record_human_review_if_applicable(self, application: JobApplication, action: str, detail: str) -> None:
+        if action not in {"app_confirm", "app_authorize"}:
+            return
+        job = self.repository.get_job(application.job_id)
+        if job is None:
+            return
+        self.application_flow.resolve_and_record_human_review_action(
+            ApplicationExecutionContext(application=application, job=job),
+            action=action,
+            decided_by="command",
+            reason=detail,
+        )
+
     def authorize_application(self, application_id: int) -> str:
         return self.transition_application(application_id, "app_authorize")

--- a/job_hunter_agent/application/application_commands.py
+++ b/job_hunter_agent/application/application_commands.py
@@ -102,6 +102,7 @@ class ApplicationTransitionCommandService:
         if next_status is None:
             return detail
         self.repository.mark_application_status(application_id, status=next_status, event_detail=detail)
+        self._record_human_review_if_applicable(application, action, detail)
         if self.event_bus is not None and next_status == "authorized_submit":
             self.event_bus.publish(
                 ApplicationAuthorizedV1(

--- a/job_hunter_agent/application/application_commands.py
+++ b/job_hunter_agent/application/application_commands.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from job_hunter_agent.application.application_flow import ApplicationExecutionContext, ApplicationFlowCoordinator
 from job_hunter_agent.application.application_messages import (
     format_created_application_draft,
     format_existing_application_for_job,

--- a/job_hunter_agent/application/application_commands.py
+++ b/job_hunter_agent/application/application_commands.py
@@ -119,7 +119,10 @@ class ApplicationTransitionCommandService:
     def _record_human_review_if_applicable(self, application: JobApplication, action: str, detail: str) -> None:
         if action not in {"app_confirm", "app_authorize"}:
             return
-        job = self.repository.get_job(application.job_id)
+        get_job = getattr(self.repository, "get_job", None)
+        if get_job is None:
+            return
+        job = get_job(application.job_id)
         if job is None:
             return
         self.application_flow.resolve_and_record_human_review_action(

--- a/job_hunter_agent/application/application_commands.py
+++ b/job_hunter_agent/application/application_commands.py
@@ -92,6 +92,7 @@ class ApplicationTransitionCommandService:
     def __init__(self, repository: JobRepository, event_bus: EventBusPort | None = None) -> None:
         self.repository = repository
         self.event_bus = event_bus
+        self.application_flow = ApplicationFlowCoordinator(repository)
 
     def transition_application(self, application_id: int, action: str) -> str:
         application = self.repository.get_application(application_id)

--- a/job_hunter_agent/infrastructure/repository.py
+++ b/job_hunter_agent/infrastructure/repository.py
@@ -4,7 +4,7 @@ import sqlite3
 from dataclasses import replace
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Optional, Protocol
+from typing import Any, Optional, Protocol
 
 from job_hunter_agent.core.domain import (
     CollectionRun,
@@ -17,6 +17,7 @@ from job_hunter_agent.core.domain import (
     VALID_STATUSES,
 )
 from job_hunter_agent.core.job_identity import JobIdentityStrategy, PortalAwareJobIdentityStrategy
+from job_hunter_agent.infrastructure.application_history import record_application_event as record_operational_application_event
 
 
 class JobRepository(Protocol):

--- a/job_hunter_agent/infrastructure/repository.py
+++ b/job_hunter_agent/infrastructure/repository.py
@@ -845,6 +845,24 @@ class SqliteJobRepository:
             rows = connection.execute(query, params).fetchall()
         return [self._row_to_application_event(row) for row in rows]
 
+    def record_application_history_event(
+        self,
+        application_id: int,
+        *,
+        event_type: str,
+        payload: dict[str, Any] | None = None,
+        occurred_at_utc: str | None = None,
+    ) -> None:
+        with self._connect() as connection:
+            record_operational_application_event(
+                connection,
+                application_id,
+                event_type,
+                payload,
+                occurred_at_utc=occurred_at_utc,
+            )
+            connection.commit()
+
     def list_recent_application_events_since(self, since: str) -> list[JobApplicationEvent]:
         with self._connect() as connection:
             rows = connection.execute(

--- a/job_hunter_agent/infrastructure/repository.py
+++ b/job_hunter_agent/infrastructure/repository.py
@@ -138,6 +138,16 @@ class JobRepository(Protocol):
     ) -> list[JobApplicationEvent]:
         raise NotImplementedError
 
+    def record_application_history_event(
+        self,
+        application_id: int,
+        *,
+        event_type: str,
+        payload: dict[str, Any] | None = None,
+        occurred_at_utc: str | None = None,
+    ) -> None:
+        raise NotImplementedError
+
     def list_recent_application_events_since(self, since: str) -> list[JobApplicationEvent]:
         raise NotImplementedError
 

--- a/tests/test_application_commands.py
+++ b/tests/test_application_commands.py
@@ -75,12 +75,23 @@ class ApplicationTransitionCommandServiceTests(unittest.TestCase):
         class _Repository:
             def __init__(self) -> None:
                 self.marked: list[tuple[int, str, str]] = []
+                self.events: list[tuple[int, dict]] = []
+                self.history_events: list[tuple[int, dict]] = []
 
             def get_application(self, application_id: int):
                 return JobApplication(id=application_id, job_id=5, status="confirmed")
 
+            def get_job(self, job_id: int):
+                return _sample_job(job_id=job_id, status="approved")
+
             def mark_application_status(self, application_id: int, *, status: str, event_detail: str = "", **kwargs):
                 self.marked.append((application_id, status, event_detail))
+
+            def record_application_event(self, application_id: int, **kwargs):
+                self.events.append((application_id, kwargs))
+
+            def record_application_history_event(self, application_id: int, **kwargs):
+                self.history_events.append((application_id, kwargs))
 
         repository = _Repository()
         service = ApplicationTransitionCommandService(repository)
@@ -92,3 +103,6 @@ class ApplicationTransitionCommandServiceTests(unittest.TestCase):
             repository.marked,
             [(9, "authorized_submit", "Candidatura autorizada para envio: id=9")],
         )
+        self.assertEqual(repository.events[0][1]["event_type"], "human_review_authorize_external_action")
+        self.assertEqual(repository.history_events[0][1]["event_type"], "human_review_authorize_external_action")
+        self.assertTrue(repository.history_events[0][1]["payload"]["allows_external_action"])


### PR DESCRIPTION
## Summary
- Wire `ApplicationTransitionCommandService` to record human-review audit events for existing CLI application transitions.
- Keep existing status transitions unchanged.
- Add `JobRepository.record_application_history_event(...)` to expose operational-history payload recording.
- Implement the writer in `SqliteJobRepository` using the existing `application_events` operational history schema.
- Extend command tests to assert audit events are recorded for authorization.

## Scope note
This is an incremental continuation of #121. It still does not add external automation or real submission behavior.

## Safety
- No schema changes.
- No Playwright changes.
- No Telegram changes.
- No real external actions.
- Existing status transition behavior remains unchanged.

## Tests
Not run in this environment.

Expected command:

```bash
pytest tests/test_application_commands.py tests/test_application_flow.py tests/test_human_review.py tests/test_application_history.py
```

Refs #121