### PR TITLE
feat: adiciona Admin API read-only

### DIFF
--- a/job_hunter_agent/api/__init__.py
+++ b/job_hunter_agent/api/__init__.py
@@ -1,0 +1,1 @@
+"""Admin API for the local Job Hunter cockpit."""

--- a/job_hunter_agent/api/dependencies.py
+++ b/job_hunter_agent/api/dependencies.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from fastapi import Depends
+
+from job_hunter_agent.application.composition import create_domain_event_bus, create_repository
+from job_hunter_agent.core.event_bus import EventBusPort
+from job_hunter_agent.core.settings import Settings, load_settings
+from job_hunter_agent.infrastructure.repository import JobRepository
+
+
+def get_settings() -> Settings:
+    return load_settings()
+
+
+def get_repository(settings: Settings = Depends(get_settings)) -> JobRepository:
+    return create_repository(settings)
+
+
+def get_domain_event_bus(settings: Settings = Depends(get_settings)) -> EventBusPort | None:
+    return create_domain_event_bus(settings)

--- a/job_hunter_agent/api/main.py
+++ b/job_hunter_agent/api/main.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from fastapi import FastAPI
+
+from job_hunter_agent.api.routes import applications, health, jobs, operations, status
+
+app = FastAPI(
+    title="Job Hunter Agent Admin API",
+    description="Local read-only admin API for the Job Hunter Agent cockpit.",
+    version="0.1.0",
+)
+
+app.include_router(health.router, prefix="/api")
+app.include_router(status.router, prefix="/api")
+app.include_router(jobs.router, prefix="/api")
+app.include_router(applications.router, prefix="/api")
+app.include_router(operations.router, prefix="/api")

--- a/job_hunter_agent/api/routes/__init__.py
+++ b/job_hunter_agent/api/routes/__init__.py
@@ -1,0 +1,1 @@
+"""Admin API routes."""

--- a/job_hunter_agent/api/routes/applications.py
+++ b/job_hunter_agent/api/routes/applications.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+
+from job_hunter_agent.api.dependencies import get_repository
+from job_hunter_agent.api.schemas import (
+    ApplicationDetailResponse,
+    ApplicationEventResponse,
+    ApplicationResponse,
+    application_event_to_response,
+    application_to_response,
+)
+from job_hunter_agent.core.domain import VALID_APPLICATION_STATUSES
+from job_hunter_agent.infrastructure.repository import JobRepository
+
+router = APIRouter(prefix="/applications", tags=["applications"])
+
+APPLICATION_STATUS_ORDER = (
+    "draft",
+    "ready_for_review",
+    "confirmed",
+    "authorized_submit",
+    "submitted",
+    "error_submit",
+    "cancelled",
+)
+
+
+@router.get("", response_model=list[ApplicationResponse])
+def list_applications(
+    status: str | None = Query(default=None),
+    repository: JobRepository = Depends(get_repository),
+) -> list[ApplicationResponse]:
+    statuses = _resolve_application_statuses(status)
+    applications: list[ApplicationResponse] = []
+    for current_status in statuses:
+        list_with_jobs = getattr(repository, "list_applications_with_jobs_by_status", None)
+        if list_with_jobs is None:
+            for application in repository.list_applications_by_status(current_status):
+                applications.append(application_to_response(application, repository.get_job(application.job_id)))
+            continue
+        applications.extend(
+            application_to_response(application, job)
+            for application, job in list_with_jobs(current_status)
+        )
+    return applications
+
+
+@router.get("/{application_id}", response_model=ApplicationDetailResponse)
+def get_application(
+    application_id: int,
+    repository: JobRepository = Depends(get_repository),
+) -> ApplicationDetailResponse:
+    application = repository.get_application(application_id)
+    if application is None:
+        raise HTTPException(status_code=404, detail=f"Candidatura nao encontrada: id={application_id}")
+    job = repository.get_job(application.job_id)
+    events = repository.list_application_events(application_id, limit=20)
+    base = application_to_response(application, job)
+    return ApplicationDetailResponse(
+        **base.model_dump(),
+        events=[application_event_to_response(event) for event in events],
+    )
+
+
+@router.get("/{application_id}/events", response_model=list[ApplicationEventResponse])
+def list_application_events(
+    application_id: int,
+    limit: int = Query(default=20, ge=1, le=100),
+    repository: JobRepository = Depends(get_repository),
+) -> list[ApplicationEventResponse]:
+    application = repository.get_application(application_id)
+    if application is None:
+        raise HTTPException(status_code=404, detail=f"Candidatura nao encontrada: id={application_id}")
+    events = repository.list_application_events(application_id, limit=limit)
+    return [application_event_to_response(event) for event in events]
+
+
+def _resolve_application_statuses(status: str | None) -> tuple[str, ...]:
+    if status is None or status == "all":
+        return tuple(current for current in APPLICATION_STATUS_ORDER if current in VALID_APPLICATION_STATUSES)
+    if status not in VALID_APPLICATION_STATUSES:
+        raise HTTPException(status_code=400, detail=f"Status de candidatura invalido: {status}")
+    return (status,)

--- a/job_hunter_agent/api/routes/health.py
+++ b/job_hunter_agent/api/routes/health.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends
+
+from job_hunter_agent.api.dependencies import get_settings
+from job_hunter_agent.api.schemas import HealthCheckItemResponse, HealthReportResponse
+from job_hunter_agent.application.application_health import build_application_health_report
+from job_hunter_agent.core.settings import Settings
+
+router = APIRouter(tags=["health"])
+
+
+@router.get("/health", response_model=HealthReportResponse)
+def get_health(settings: Settings = Depends(get_settings)) -> HealthReportResponse:
+    report = build_application_health_report(settings)
+    return HealthReportResponse(
+        ok=report.ok,
+        items=[
+            HealthCheckItemResponse(name=item.name, status=item.status, detail=item.detail)
+            for item in report.items
+        ],
+    )

--- a/job_hunter_agent/api/routes/jobs.py
+++ b/job_hunter_agent/api/routes/jobs.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+
+from job_hunter_agent.api.dependencies import get_repository
+from job_hunter_agent.api.schemas import (
+    JobDetailResponse,
+    JobResponse,
+    application_to_response,
+    job_event_to_response,
+    job_to_response,
+)
+from job_hunter_agent.core.domain import VALID_STATUSES
+from job_hunter_agent.infrastructure.repository import JobRepository
+
+router = APIRouter(prefix="/jobs", tags=["jobs"])
+
+JOB_STATUS_ORDER = ("collected", "approved", "rejected", "error_collect")
+
+
+@router.get("", response_model=list[JobResponse])
+def list_jobs(
+    status: str | None = Query(default=None),
+    repository: JobRepository = Depends(get_repository),
+) -> list[JobResponse]:
+    statuses = _resolve_job_statuses(status)
+    jobs: list[object] = []
+    for current_status in statuses:
+        jobs.extend(repository.list_jobs_by_status(current_status))
+    return [job_to_response(job) for job in jobs]
+
+
+@router.get("/{job_id}", response_model=JobDetailResponse)
+def get_job(job_id: int, repository: JobRepository = Depends(get_repository)) -> JobDetailResponse:
+    job = repository.get_job(job_id)
+    if job is None:
+        raise HTTPException(status_code=404, detail=f"Vaga nao encontrada: id={job_id}")
+    application = repository.get_application_by_job(job_id)
+    events = repository.list_job_events(job_id, limit=20)
+    base = job_to_response(job)
+    return JobDetailResponse(
+        **base.model_dump(),
+        application=application_to_response(application) if application is not None else None,
+        events=[job_event_to_response(event) for event in events],
+    )
+
+
+def _resolve_job_statuses(status: str | None) -> tuple[str, ...]:
+    if status is None or status == "all":
+        return tuple(current for current in JOB_STATUS_ORDER if current in VALID_STATUSES)
+    if status not in VALID_STATUSES:
+        raise HTTPException(status_code=400, detail=f"Status de vaga invalido: {status}")
+    return (status,)

--- a/job_hunter_agent/api/routes/operations.py
+++ b/job_hunter_agent/api/routes/operations.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+from fastapi import APIRouter, Depends, Query
+
+from job_hunter_agent.api.dependencies import get_repository
+from job_hunter_agent.api.schemas import (
+    CollectionLogSummaryResponse,
+    CollectionOperationsReportResponse,
+    CollectionRunSummaryResponse,
+    OperationNextActionResponse,
+    OperationsReportResponse,
+)
+from job_hunter_agent.application.collection_operations_report import build_collection_operations_report
+from job_hunter_agent.application.operations_next_actions import build_operations_next_actions_from_repository
+from job_hunter_agent.infrastructure.repository import JobRepository
+
+router = APIRouter(prefix="/operations", tags=["operations"])
+
+
+@router.get("/next-actions", response_model=list[OperationNextActionResponse])
+def list_next_actions(
+    limit: int = Query(default=20, ge=1, le=100),
+    repository: JobRepository = Depends(get_repository),
+) -> list[OperationNextActionResponse]:
+    actions = build_operations_next_actions_from_repository(repository)
+    return [OperationNextActionResponse(**action.__dict__) for action in actions[:limit]]
+
+
+@router.get("/report", response_model=OperationsReportResponse)
+def get_operations_report(
+    days: int = Query(default=1, ge=1, le=365),
+    repository: JobRepository = Depends(get_repository),
+) -> OperationsReportResponse:
+    since = (datetime.now(timezone.utc) - timedelta(days=days)).isoformat(timespec="seconds")
+    report = build_collection_operations_report(repository, since=since)
+    return OperationsReportResponse(
+        collection=CollectionOperationsReportResponse(
+            run_summary=CollectionRunSummaryResponse(**report.run_summary.__dict__),
+            log_summary=CollectionLogSummaryResponse(
+                by_source=report.log_summary.by_source,
+                by_level=report.log_summary.by_level,
+                recent_warnings_or_errors=list(report.log_summary.recent_warnings_or_errors),
+            ),
+        )
+    )

--- a/job_hunter_agent/api/routes/status.py
+++ b/job_hunter_agent/api/routes/status.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends
+
+from job_hunter_agent.api.dependencies import get_repository
+from job_hunter_agent.api.schemas import StatusOverviewResponse
+from job_hunter_agent.infrastructure.repository import JobRepository
+
+router = APIRouter(tags=["status"])
+
+
+@router.get("/status", response_model=StatusOverviewResponse)
+def get_status(repository: JobRepository = Depends(get_repository)) -> StatusOverviewResponse:
+    return StatusOverviewResponse(
+        jobs=repository.summary(),
+        applications=repository.application_summary(),
+    )

--- a/job_hunter_agent/api/schemas.py
+++ b/job_hunter_agent/api/schemas.py
@@ -1,0 +1,186 @@
+from __future__ import annotations
+
+from typing import Optional
+
+from pydantic import BaseModel
+
+
+class ApiError(BaseModel):
+    detail: str
+
+
+class JobEventResponse(BaseModel):
+    id: Optional[int] = None
+    job_id: int
+    event_type: str
+    detail: str = ""
+    from_status: Optional[str] = None
+    to_status: Optional[str] = None
+    created_at: Optional[str] = None
+
+
+class JobResponse(BaseModel):
+    id: Optional[int] = None
+    title: str
+    company: str
+    location: str
+    work_mode: str
+    salary_text: str
+    url: str
+    source_site: str
+    summary: str
+    relevance: int
+    rationale: str
+    external_key: str
+    status: str
+    created_at: Optional[str] = None
+
+
+class ApplicationEventResponse(BaseModel):
+    id: Optional[int] = None
+    application_id: int
+    event_type: str
+    detail: str = ""
+    from_status: Optional[str] = None
+    to_status: Optional[str] = None
+    created_at: Optional[str] = None
+
+
+class ApplicationResponse(BaseModel):
+    id: Optional[int] = None
+    job_id: int
+    status: str
+    support_level: str
+    support_rationale: str = ""
+    notes: str = ""
+    last_preflight_detail: str = ""
+    last_submit_detail: str = ""
+    last_error: str = ""
+    created_at: Optional[str] = None
+    updated_at: Optional[str] = None
+    submitted_at: Optional[str] = None
+    job: Optional[JobResponse] = None
+
+
+class JobDetailResponse(JobResponse):
+    application: Optional[ApplicationResponse] = None
+    events: list[JobEventResponse] = []
+
+
+class ApplicationDetailResponse(ApplicationResponse):
+    events: list[ApplicationEventResponse] = []
+
+
+class StatusOverviewResponse(BaseModel):
+    jobs: dict[str, int]
+    applications: dict[str, int]
+
+
+class HealthCheckItemResponse(BaseModel):
+    name: str
+    status: str
+    detail: str
+
+
+class HealthReportResponse(BaseModel):
+    ok: bool
+    items: list[HealthCheckItemResponse]
+
+
+class OperationNextActionResponse(BaseModel):
+    priority: int
+    application_id: int
+    job_id: int
+    status: str
+    title: str
+    company: str
+    reason_code: str
+    command: str
+    note: str
+
+
+class CollectionRunSummaryResponse(BaseModel):
+    total_runs: int = 0
+    success_runs: int = 0
+    error_runs: int = 0
+    interrupted_runs: int = 0
+    running_runs: int = 0
+    jobs_seen: int = 0
+    jobs_saved: int = 0
+    errors: int = 0
+
+
+class CollectionLogSummaryResponse(BaseModel):
+    by_source: dict[str, int]
+    by_level: dict[str, int]
+    recent_warnings_or_errors: list[dict[str, str]]
+
+
+class CollectionOperationsReportResponse(BaseModel):
+    run_summary: CollectionRunSummaryResponse
+    log_summary: CollectionLogSummaryResponse
+
+
+class OperationsReportResponse(BaseModel):
+    collection: CollectionOperationsReportResponse
+
+
+def job_to_response(job: object) -> JobResponse:
+    return JobResponse(
+        id=getattr(job, "id", None),
+        title=str(getattr(job, "title", "")),
+        company=str(getattr(job, "company", "")),
+        location=str(getattr(job, "location", "")),
+        work_mode=str(getattr(job, "work_mode", "")),
+        salary_text=str(getattr(job, "salary_text", "")),
+        url=str(getattr(job, "url", "")),
+        source_site=str(getattr(job, "source_site", "")),
+        summary=str(getattr(job, "summary", "")),
+        relevance=int(getattr(job, "relevance", 0)),
+        rationale=str(getattr(job, "rationale", "")),
+        external_key=str(getattr(job, "external_key", "")),
+        status=str(getattr(job, "status", "")),
+        created_at=getattr(job, "created_at", None),
+    )
+
+
+def job_event_to_response(event: object) -> JobEventResponse:
+    return JobEventResponse(
+        id=getattr(event, "id", None),
+        job_id=int(getattr(event, "job_id")),
+        event_type=str(getattr(event, "event_type", "")),
+        detail=str(getattr(event, "detail", "")),
+        from_status=getattr(event, "from_status", None),
+        to_status=getattr(event, "to_status", None),
+        created_at=getattr(event, "created_at", None),
+    )
+
+
+def application_to_response(application: object, job: object | None = None) -> ApplicationResponse:
+    return ApplicationResponse(
+        id=getattr(application, "id", None),
+        job_id=int(getattr(application, "job_id")),
+        status=str(getattr(application, "status", "")),
+        support_level=str(getattr(application, "support_level", "")),
+        support_rationale=str(getattr(application, "support_rationale", "")),
+        notes=str(getattr(application, "notes", "")),
+        last_preflight_detail=str(getattr(application, "last_preflight_detail", "")),
+        last_submit_detail=str(getattr(application, "last_submit_detail", "")),
+        last_error=str(getattr(application, "last_error", "")),
+        created_at=getattr(application, "created_at", None),
+        updated_at=getattr(application, "updated_at", None),
+        submitted_at=getattr(application, "submitted_at", None),
+        job=job_to_response(job) if job is not None else None,
+    )
+
+
+def application_event_to_response(event: object) -> ApplicationEventResponse:
+    return ApplicationEventResponse(
+        id=getattr(event, "id", None),
+        application_id=int(getattr(event, "application_id")),
+        event_type=str(getattr(event, "event_type", "")),
+        detail=str(getattr(event, "detail", "")),
+        from_status=getattr(event, "from_status", None),
+        to_status=getattr(event, "to_status", None),
+        created_at=getattr(event, "created_at", None),
+    )

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,6 @@
 browser-use>=0.1.0
+fastapi>=0.115.0
+httpx>=0.27.0
 langchain>=0.2.0
 langchain-ollama>=0.1.0
 playwright>=1.58.0
@@ -8,3 +10,4 @@ pydantic-settings>=2.4.0
 pypdf>=5.0.0
 pytest>=8.3.0
 python-telegram-bot>=21.0
+uvicorn>=0.30.0

--- a/tests/test_admin_api.py
+++ b/tests/test_admin_api.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from job_hunter_agent.api.dependencies import get_repository, get_settings
+from job_hunter_agent.api.main import app
+from job_hunter_agent.core.domain import JobPosting
+from job_hunter_agent.core.settings import Settings
+from job_hunter_agent.infrastructure.repository import SqliteJobRepository
+
+
+def _make_client(repository: SqliteJobRepository, settings: Settings) -> TestClient:
+    app.dependency_overrides[get_repository] = lambda: repository
+    app.dependency_overrides[get_settings] = lambda: settings
+    return TestClient(app)
+
+
+def _clear_overrides() -> None:
+    app.dependency_overrides.clear()
+
+
+def _sample_job() -> JobPosting:
+    return JobPosting(
+        title="Backend Developer",
+        company="Acme",
+        location="Remoto",
+        work_mode="remoto",
+        salary_text="",
+        url="https://example.com/jobs/1",
+        source_site="LinkedIn",
+        summary="Vaga backend Java.",
+        relevance=8,
+        rationale="Boa aderencia ao perfil.",
+        external_key="linkedin:1",
+    )
+
+
+def test_status_endpoint_uses_isolated_repository(tmp_path):
+    repository = SqliteJobRepository(tmp_path / "jobs.db")
+    settings = Settings(database_path=tmp_path / "jobs.db", resume_path=tmp_path / "cv.pdf")
+    client = _make_client(repository, settings)
+    try:
+        response = client.get("/api/status")
+    finally:
+        _clear_overrides()
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["jobs"]["total"] == 0
+    assert payload["applications"]["total"] == 0
+
+
+def test_jobs_list_and_detail(tmp_path):
+    repository = SqliteJobRepository(tmp_path / "jobs.db")
+    settings = Settings(database_path=tmp_path / "jobs.db", resume_path=tmp_path / "cv.pdf")
+    saved = repository.save_new_jobs([_sample_job()])
+    job_id = saved[0].id
+    client = _make_client(repository, settings)
+    try:
+        list_response = client.get("/api/jobs")
+        detail_response = client.get(f"/api/jobs/{job_id}")
+        missing_response = client.get("/api/jobs/999")
+    finally:
+        _clear_overrides()
+    assert list_response.status_code == 200
+    assert list_response.json()[0]["title"] == "Backend Developer"
+    assert detail_response.status_code == 200
+    detail = detail_response.json()
+    assert detail["id"] == job_id
+    assert detail["events"][0]["event_type"] == "job_collected"
+    assert missing_response.status_code == 404
+
+
+def test_applications_list_detail_events_and_next_actions(tmp_path):
+    repository = SqliteJobRepository(tmp_path / "jobs.db")
+    settings = Settings(database_path=tmp_path / "jobs.db", resume_path=tmp_path / "cv.pdf")
+    job = repository.save_new_jobs([_sample_job()])[0]
+    repository.mark_status(job.id, "approved", detail="aprovada no teste")
+    application = repository.create_application_draft(job.id, notes="teste")
+    client = _make_client(repository, settings)
+    try:
+        list_response = client.get("/api/applications")
+        detail_response = client.get(f"/api/applications/{application.id}")
+        events_response = client.get(f"/api/applications/{application.id}/events")
+        actions_response = client.get("/api/operations/next-actions")
+        missing_response = client.get("/api/applications/999")
+    finally:
+        _clear_overrides()
+    assert list_response.status_code == 200
+    assert list_response.json()[0]["job"]["title"] == "Backend Developer"
+    assert detail_response.status_code == 200
+    assert detail_response.json()["events"][0]["event_type"] == "draft_created"
+    assert events_response.status_code == 200
+    assert events_response.json()[0]["application_id"] == application.id
+    assert actions_response.status_code == 200
+    assert actions_response.json()[0]["application_id"] == application.id
+    assert missing_response.status_code == 404


### PR DESCRIPTION
## Contexto

Implementa a primeira fatia da Admin API local para o futuro cockpit/frontend do Job Hunter Agent.

## O que foi feito

- Cria pacote `job_hunter_agent/api/` com app FastAPI.
- Adiciona dependências injetáveis para `Settings` e `JobRepository`.
- Expõe endpoints read-only:
  - `GET /api/health`
  - `GET /api/status`
  - `GET /api/jobs`
  - `GET /api/jobs/{job_id}`
  - `GET /api/applications`
  - `GET /api/applications/{application_id}`
  - `GET /api/applications/{application_id}/events`
  - `GET /api/operations/next-actions`
  - `GET /api/operations/report`
- Adiciona schemas Pydantic para respostas JSON.
- Adiciona dependências `fastapi`, `uvicorn` e `httpx`.
- Adiciona testes com SQLite isolado via `tmp_path`.

## Segurança / limites

- Não executa Playwright.
- Não executa preflight real.
- Não executa submit real.
- Não altera estados.
- Não chama Telegram, LinkedIn ou Ollama.
- Não usa banco real nos testes.

## Validação esperada

```bash
pytest
uvicorn job_hunter_agent.api.main:app --reload
```

Refs #124
Refs #125
Refs #127