### PR TITLE
feat: add Playwright safety policy

### DIFF
--- a/job_hunter_agent/application/playwright_safety_policy.py
+++ b/job_hunter_agent/application/playwright_safety_policy.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+
+BrowserActionCategory = Literal[
+    "read",
+    "navigate",
+    "inspect",
+    "authenticate",
+    "fill_form",
+    "upload_document",
+    "submit",
+    "send_message",
+    "external_contact",
+]
+
+BrowserPolicyDecision = Literal["allowed", "dry_run_only", "human_gate_required", "blocked"]
+
+ALLOWED: BrowserPolicyDecision = "allowed"
+DRY_RUN_ONLY: BrowserPolicyDecision = "dry_run_only"
+HUMAN_GATE_REQUIRED: BrowserPolicyDecision = "human_gate_required"
+BLOCKED: BrowserPolicyDecision = "blocked"
+
+SENSITIVE_ACTIONS: set[BrowserActionCategory] = {
+    "authenticate",
+    "fill_form",
+    "upload_document",
+    "submit",
+    "send_message",
+    "external_contact",
+}
+SAFE_READ_ACTIONS: set[BrowserActionCategory] = {"read", "navigate", "inspect"}
+SAFE_STOP_REASONS = {
+    "captcha",
+    "paywall",
+    "blocked",
+    "consent_screen",
+    "unexpected_prompt",
+    "unexpected_login",
+    "credential_prompt",
+}
+
+
+@dataclass(frozen=True)
+class BrowserActionPolicy:
+    category: BrowserActionCategory
+    decision: BrowserPolicyDecision
+    reason: str
+    minimum_delay_seconds: float = 1.0
+
+    @property
+    def allows_playwright_execution(self) -> bool:
+        return self.decision == ALLOWED
+
+    @property
+    def requires_human_gate(self) -> bool:
+        return self.decision == HUMAN_GATE_REQUIRED
+
+    @property
+    def blocks_external_action(self) -> bool:
+        return self.category in SENSITIVE_ACTIONS and self.decision != ALLOWED
+
+
+def resolve_playwright_policy(
+    category: BrowserActionCategory,
+    *,
+    human_gate_approved: bool = False,
+    dry_run: bool = False,
+    safe_stop_reason: str | None = None,
+    minimum_delay_seconds: float = 1.0,
+) -> BrowserActionPolicy:
+    if minimum_delay_seconds < 0.5:
+        raise ValueError("minimum_delay_seconds must be at least 0.5 to avoid aggressive automation")
+
+    if safe_stop_reason is not None:
+        clean_reason = safe_stop_reason.strip().lower()
+        if clean_reason in SAFE_STOP_REASONS:
+            return BrowserActionPolicy(
+                category=category,
+                decision=BLOCKED,
+                reason=f"safe stop required: {clean_reason}",
+                minimum_delay_seconds=minimum_delay_seconds,
+            )
+
+    if category in SAFE_READ_ACTIONS:
+        return BrowserActionPolicy(
+            category=category,
+            decision=ALLOWED,
+            reason="read-only browser action",
+            minimum_delay_seconds=minimum_delay_seconds,
+        )
+
+    if dry_run:
+        return BrowserActionPolicy(
+            category=category,
+            decision=DRY_RUN_ONLY,
+            reason="sensitive browser action limited to dry-run",
+            minimum_delay_seconds=minimum_delay_seconds,
+        )
+
+    if category in SENSITIVE_ACTIONS:
+        if human_gate_approved:
+            return BrowserActionPolicy(
+                category=category,
+                decision=HUMAN_GATE_REQUIRED,
+                reason="sensitive browser action requires human gate; approval recorded",
+                minimum_delay_seconds=minimum_delay_seconds,
+            )
+        return BrowserActionPolicy(
+            category=category,
+            decision=BLOCKED,
+            reason="sensitive browser action blocked without human gate",
+            minimum_delay_seconds=minimum_delay_seconds,
+        )
+
+    return BrowserActionPolicy(
+        category=category,
+        decision=BLOCKED,
+        reason="out-of-policy browser action",
+        minimum_delay_seconds=minimum_delay_seconds,
+    )
+
+
+def ensure_playwright_action_allowed(policy: BrowserActionPolicy) -> None:
+    if not policy.allows_playwright_execution:
+        raise PermissionError(policy.reason)

--- a/tests/test_playwright_safety_policy.py
+++ b/tests/test_playwright_safety_policy.py
@@ -1,0 +1,71 @@
+import unittest
+
+from job_hunter_agent.application.playwright_safety_policy import (
+    ALLOWED,
+    BLOCKED,
+    DRY_RUN_ONLY,
+    HUMAN_GATE_REQUIRED,
+    ensure_playwright_action_allowed,
+    resolve_playwright_policy,
+)
+
+
+class PlaywrightSafetyPolicyTests(unittest.TestCase):
+    def test_read_only_actions_are_allowed(self) -> None:
+        for category in ("read", "navigate", "inspect"):
+            with self.subTest(category=category):
+                policy = resolve_playwright_policy(category)
+
+                self.assertEqual(policy.decision, ALLOWED)
+                self.assertTrue(policy.allows_playwright_execution)
+                self.assertFalse(policy.requires_human_gate)
+
+    def test_sensitive_actions_are_blocked_without_human_gate(self) -> None:
+        for category in (
+            "authenticate",
+            "fill_form",
+            "upload_document",
+            "submit",
+            "send_message",
+            "external_contact",
+        ):
+            with self.subTest(category=category):
+                policy = resolve_playwright_policy(category)
+
+                self.assertEqual(policy.decision, BLOCKED)
+                self.assertTrue(policy.blocks_external_action)
+
+    def test_sensitive_actions_are_dry_run_only_when_dry_run(self) -> None:
+        policy = resolve_playwright_policy("submit", dry_run=True)
+
+        self.assertEqual(policy.decision, DRY_RUN_ONLY)
+        self.assertFalse(policy.allows_playwright_execution)
+
+    def test_sensitive_actions_record_human_gate_requirement_when_approved(self) -> None:
+        policy = resolve_playwright_policy("submit", human_gate_approved=True)
+
+        self.assertEqual(policy.decision, HUMAN_GATE_REQUIRED)
+        self.assertTrue(policy.requires_human_gate)
+        self.assertTrue(policy.blocks_external_action)
+
+    def test_safe_stop_reasons_block_even_read_actions(self) -> None:
+        for reason in ("captcha", "paywall", "unexpected_prompt", "credential_prompt"):
+            with self.subTest(reason=reason):
+                policy = resolve_playwright_policy("read", safe_stop_reason=reason)
+
+                self.assertEqual(policy.decision, BLOCKED)
+                self.assertIn(reason, policy.reason)
+
+    def test_aggressive_delay_is_rejected(self) -> None:
+        with self.assertRaisesRegex(ValueError, "avoid aggressive automation"):
+            resolve_playwright_policy("read", minimum_delay_seconds=0.1)
+
+    def test_ensure_allowed_raises_for_blocked_policy(self) -> None:
+        policy = resolve_playwright_policy("submit")
+
+        with self.assertRaisesRegex(PermissionError, "blocked without human gate"):
+            ensure_playwright_action_allowed(policy)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Add a pure Playwright safety policy module.
- Classify browser actions as read-only, sensitive, dry-run-only, human-gated, or blocked.
- Block sensitive actions such as authentication, form filling, upload, submit, messages, and external contact without human gate.
- Add safe-stop handling for captcha, paywall, unexpected prompts, credential prompts, and similar browser states.
- Require a minimum delay to avoid aggressive automation.
- Add unit tests for allowed, blocked, dry-run, human-gate, safe-stop, and delay behavior.

## Scope note
This is the first incremental foundation for #132. It does not wire the policy into Playwright execution yet.

## Safety
- No Playwright runtime execution added.
- No login automation.
- No submit/upload/message automation.
- No Telegram changes.
- No schema changes.
- No external actions.

## Tests
Not run in this environment.

Expected command:

```bash
pytest tests/test_playwright_safety_policy.py
```

Refs #132