### PR TITLE
docs: define Admin API preflight submit limits

### DIFF
--- a/docs/ADMIN_API.md
+++ b/docs/ADMIN_API.md
@@ -174,6 +174,23 @@ Ela não:
 
 Mesmo em futuras expansões, qualquer ação de alto impacto deve preservar os gates humanos documentados no projeto. Submit real continua dependendo de autorização explícita e estado compatível, nunca apenas de uma chamada do frontend.
 
+## Decisão sobre preflight real e submit real
+
+Preflight real e submit real ficam fora do MVP inicial da Admin API.
+
+A API não deve expor rotas HTTP para acionar preflight real ou submit real enquanto não houver política dedicada, revisão humana explícita e proteções próprias no backend. Isso significa que o cockpit local não deve renderizar botão de submit real nem tentar chamar serviços internos diretamente para contornar a API.
+
+Qualquer endpoint futuro que execute submit real deve exigir, no mínimo:
+
+- candidatura no estado `authorized_submit`;
+- confirmação humana explícita no momento da ação;
+- readiness check antes da execução;
+- auditoria persistida da decisão e do resultado;
+- bloqueio seguro para captcha, login inesperado, prompts de credencial, paywall, consent screen ou qualquer prompt inesperado;
+- modo dry-run ou preview quando aplicável.
+
+Até que esses critérios sejam implementados e aprovados, tentativas de `POST` para rotas como `/api/applications/{application_id}/preflight` ou `/api/applications/{application_id}/submit` devem permanecer inexistentes e retornar 404.
+
 ## Exposição de rede
 
 Execute a API como serviço local/admin.

--- a/tests/test_admin_api.py
+++ b/tests/test_admin_api.py
@@ -94,3 +94,20 @@ def test_applications_list_detail_events_and_next_actions(tmp_path):
     assert actions_response.status_code == 200
     assert actions_response.json()[0]["application_id"] == application.id
     assert missing_response.status_code == 404
+
+
+def test_admin_api_does_not_expose_real_preflight_or_submit_routes(tmp_path):
+    repository = SqliteJobRepository(tmp_path / "jobs.db")
+    settings = Settings(database_path=tmp_path / "jobs.db", resume_path=tmp_path / "cv.pdf")
+    client = _make_client(repository, settings)
+    try:
+        openapi_paths = set(client.get("/openapi.json").json()["paths"])
+        preflight_response = client.post("/api/applications/1/preflight")
+        submit_response = client.post("/api/applications/1/submit")
+    finally:
+        _clear_overrides()
+
+    assert not any("preflight" in path for path in openapi_paths)
+    assert not any("submit" in path for path in openapi_paths)
+    assert preflight_response.status_code == 404
+    assert submit_response.status_code == 404


### PR DESCRIPTION
## Resumo

- Documenta que preflight real e submit real ficam fora do MVP inicial da Admin API.
- Explicita que o cockpit local não deve renderizar botão de submit real nem chamar serviços internos para contornar a API.
- Adiciona teste de contrato garantindo que rotas reais de preflight/submit não aparecem no OpenAPI e retornam 404.

## Segurança

- Não implementa endpoint de preflight real.
- Não implementa endpoint de submit real.
- Não altera gates humanos, estados de candidatura, CLI, Telegram, Playwright, MCP ou Browser Use.
- Mantém ações sensíveis bloqueadas fora da Admin API inicial.

## Validação

- Slice validado como baixo risco: 2 arquivos, +34/-0.
- Teste adicionado em `tests/test_admin_api.py`.
- Aguardar CI e Docker antes de merge.

Refs #129